### PR TITLE
feat: wire all cognitive subsystems into MenteDb

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,11 +322,88 @@ All cognitive features are enabled by default. Toggle individually:
 use mentedb::{MenteDb, CognitiveConfig};
 
 let config = CognitiveConfig {
-    write_inference: true,   // auto-edges, contradiction detection
-    decay_on_recall: true,   // time-based salience decay
+    write_inference: true,        // auto-edges, contradiction detection
+    decay_on_recall: true,        // time-based salience decay
+    pain_tracking: true,          // recurring failure warnings
+    interference_detection: true, // confusable memory detection
+    phantom_tracking: true,       // missing knowledge gap detection
+    speculative_cache: true,      // predictive context pre-assembly
+    archival_evaluation: true,    // memory lifecycle management
     ..Default::default()
 };
 let db = MenteDb::open_with_config("./memory", config)?;
+```
+
+### Pain Registry
+
+Track recurring failures and surface warnings when similar contexts arise:
+
+```rust
+db.record_pain(PainSignal { trigger_keywords: vec!["deploy".into()], .. });
+let warnings = db.get_pain_warnings(&["deploy".into(), "production".into()]);
+```
+
+### Interference Detection
+
+Find confusable memories and generate disambiguation hints:
+
+```rust
+let pairs = db.detect_interference(&retrieved_memories);
+for pair in &pairs {
+    println!("Confusable: {} ({})", pair.disambiguation, pair.similarity);
+}
+```
+
+### Phantom Tracking
+
+Detect referenced-but-missing knowledge gaps:
+
+```rust
+db.register_entities(&["PostgreSQL", "Redis"]);
+let phantoms = db.detect_phantoms("Deploy to Kubernetes", &known, turn_id);
+```
+
+### Speculative Cache
+
+Pre-fetch context for predicted topics:
+
+```rust
+let predictions = db.predict_next_topics();
+db.pre_assemble_speculative(predictions, |topic| { /* build context */ });
+let hit = db.try_speculative_hit("database design", Some(&query_embedding));
+```
+
+### Entity Resolution
+
+Resolve aliases to canonical names:
+
+```rust
+db.add_entity_alias("JS", "JavaScript", 0.95);
+let resolved = db.resolve_entity("JS"); // → "javascript"
+```
+
+### Memory Compression
+
+Compress verbose memories for token efficiency:
+
+```rust
+let compressed = db.compress_memory(&memory);
+println!("Ratio: {:.0}%", compressed.compression_ratio * 100.0);
+```
+
+### Archival Evaluation
+
+Evaluate memory lifecycle decisions (keep, archive, delete):
+
+```rust
+let decisions = db.evaluate_archival_global()?;
+for (id, decision) in decisions {
+    match decision {
+        ArchivalDecision::Archive => { /* move to cold storage */ },
+        ArchivalDecision::Delete => { db.forget(id)?; },
+        _ => {}
+    }
+}
 ```
 
 ## Crates
@@ -335,7 +412,7 @@ MenteDB is organized as a Cargo workspace with 13 crates:
 
 | Crate | Description |
 |-------|-------------|
-| `mentedb` | Facade crate with integrated cognitive engine (write inference, decay, consolidation) |
+| `mentedb` | Facade crate with full cognitive engine (12 subsystems wired in) |
 | `mentedb-core` | Types (MemoryNode, MemoryEdge), newtype IDs, errors, config |
 | `mentedb-storage` | Page based storage engine with crash safe WAL, buffer pool, LZ4 |
 | `mentedb-index` | HNSW vector index (bounded, concurrent), roaring bitmaps, temporal index |

--- a/crates/mentedb/src/lib.rs
+++ b/crates/mentedb/src/lib.rs
@@ -40,9 +40,18 @@
 
 use std::path::{Path, PathBuf};
 
+use mentedb_cognitive::EntityResolver;
+use mentedb_cognitive::interference::{InterferenceDetector, InterferencePair};
+use mentedb_cognitive::pain::{PainRegistry, PainSignal};
+use mentedb_cognitive::phantom::{PhantomConfig, PhantomMemory, PhantomTracker};
+use mentedb_cognitive::speculative::{CacheEntry, CacheStats, SpeculativeCache};
+use mentedb_cognitive::stream::{CognitionStream, StreamAlert, StreamConfig};
+use mentedb_cognitive::trajectory::{TrajectoryNode, TrajectoryTracker};
 use mentedb_cognitive::write_inference::{
     InferredAction, WriteInferenceConfig, WriteInferenceEngine,
 };
+use mentedb_consolidation::archival::{ArchivalConfig, ArchivalDecision, ArchivalPipeline};
+use mentedb_consolidation::compression::{CompressedMemory, MemoryCompressor};
 use mentedb_consolidation::consolidation::{ConsolidationCandidate, ConsolidationEngine};
 use mentedb_consolidation::decay::{DecayConfig, DecayEngine};
 use mentedb_context::{AssemblyConfig, ContextAssembler, ContextWindow, ScoredMemory};
@@ -102,10 +111,34 @@ pub struct CognitiveConfig {
     pub write_inference: bool,
     /// Whether salience decay is applied during retrieval.
     pub decay_on_recall: bool,
+    /// Whether pain tracking is enabled.
+    pub pain_tracking: bool,
+    /// Whether interference detection is available.
+    pub interference_detection: bool,
+    /// Whether phantom tracking is enabled.
+    pub phantom_tracking: bool,
+    /// Whether speculative caching is enabled.
+    pub speculative_cache: bool,
+    /// Whether archival evaluation is available.
+    pub archival_evaluation: bool,
     /// Configuration for the write inference engine.
     pub inference_config: WriteInferenceConfig,
     /// Configuration for the decay engine.
     pub decay_config: DecayConfig,
+    /// Configuration for phantom tracking.
+    pub phantom_config: PhantomConfig,
+    /// Configuration for the archival pipeline.
+    pub archival_config: ArchivalConfig,
+    /// Configuration for the cognition stream.
+    pub stream_config: StreamConfig,
+    /// Similarity threshold for interference detection.
+    pub interference_threshold: f32,
+    /// Maximum trajectory turns to track.
+    pub trajectory_max_turns: usize,
+    /// Maximum speculative cache entries.
+    pub speculative_cache_size: usize,
+    /// Maximum pain signals to retain.
+    pub pain_max_warnings: usize,
 }
 
 impl Default for CognitiveConfig {
@@ -113,8 +146,20 @@ impl Default for CognitiveConfig {
         Self {
             write_inference: true,
             decay_on_recall: true,
+            pain_tracking: true,
+            interference_detection: true,
+            phantom_tracking: true,
+            speculative_cache: true,
+            archival_evaluation: true,
             inference_config: WriteInferenceConfig::default(),
             decay_config: DecayConfig::default(),
+            phantom_config: PhantomConfig::default(),
+            archival_config: ArchivalConfig::default(),
+            stream_config: StreamConfig::default(),
+            interference_threshold: 0.8,
+            trajectory_max_turns: 100,
+            speculative_cache_size: 10,
+            pain_max_warnings: 5,
         }
     }
 }
@@ -147,6 +192,24 @@ pub struct MenteDb {
     decay: DecayEngine,
     /// Consolidation engine for memory merging.
     consolidation: ConsolidationEngine,
+    /// Pain registry for tracking recurring failures.
+    pain: RwLock<PainRegistry>,
+    /// Trajectory tracker for conversation patterns.
+    trajectory: RwLock<TrajectoryTracker>,
+    /// Cognition stream for token-level monitoring.
+    stream: CognitionStream,
+    /// Phantom tracker for detecting referenced-but-missing knowledge.
+    phantom: RwLock<PhantomTracker>,
+    /// Speculative cache for pre-fetching likely-needed memories.
+    speculative: RwLock<SpeculativeCache>,
+    /// Interference detector for finding confusable memories.
+    interference: InterferenceDetector,
+    /// Entity resolver for canonical name resolution.
+    entity_resolver: RwLock<EntityResolver>,
+    /// Memory compressor for content summarization.
+    compressor: MemoryCompressor,
+    /// Archival pipeline for lifecycle evaluation.
+    archival: ArchivalPipeline,
 }
 
 impl MenteDb {
@@ -191,6 +254,36 @@ impl MenteDb {
             WriteInferenceEngine::with_config(cognitive_config.inference_config.clone());
         let decay = DecayEngine::new(cognitive_config.decay_config.clone());
         let consolidation = ConsolidationEngine::new();
+        let pain = RwLock::new(PainRegistry::new(cognitive_config.pain_max_warnings));
+        let trajectory = RwLock::new(TrajectoryTracker::new(
+            cognitive_config.trajectory_max_turns,
+        ));
+        let stream = CognitionStream::with_config(cognitive_config.stream_config.clone());
+        let phantom = RwLock::new(PhantomTracker::new(cognitive_config.phantom_config.clone()));
+        let speculative = RwLock::new(SpeculativeCache::new(
+            cognitive_config.speculative_cache_size,
+            0.5,
+            0.4,
+        ));
+        let interference = InterferenceDetector::new(cognitive_config.interference_threshold);
+        let entity_resolver = RwLock::new(EntityResolver::new());
+        let compressor = MemoryCompressor::new();
+        let archival = ArchivalPipeline::new(cognitive_config.archival_config.clone());
+
+        // Load persisted state for subsystems that support it.
+        let cognitive_dir = path.join("cognitive");
+        if cognitive_dir.exists() {
+            let _ = trajectory
+                .write()
+                .transitions
+                .load(&cognitive_dir.join("transitions.json"));
+            let _ = speculative
+                .write()
+                .load(&cognitive_dir.join("speculative.json"));
+            let _ = entity_resolver
+                .write()
+                .load(&cognitive_dir.join("entities.json"));
+        }
 
         Ok(Self {
             storage,
@@ -204,6 +297,15 @@ impl MenteDb {
             write_inference,
             decay,
             consolidation,
+            pain,
+            trajectory,
+            stream,
+            phantom,
+            speculative,
+            interference,
+            entity_resolver,
+            compressor,
+            archival,
         })
     }
 
@@ -932,6 +1034,24 @@ impl MenteDb {
         self.index.save(&self.path.join("indexes"))?;
         self.graph.save(&self.path.join("graph"))?;
         self.storage.checkpoint()?;
+
+        // Persist cognitive subsystem state.
+        let cognitive_dir = self.path.join("cognitive");
+        if std::fs::create_dir_all(&cognitive_dir).is_ok() {
+            let _ = self
+                .trajectory
+                .read()
+                .transitions
+                .save(&cognitive_dir.join("transitions.json"), 1);
+            let _ = self
+                .speculative
+                .read()
+                .save(&cognitive_dir.join("speculative.json"), 0);
+            let _ = self
+                .entity_resolver
+                .read()
+                .save(&cognitive_dir.join("entities.json"));
+        }
         Ok(())
     }
 
@@ -1038,5 +1158,346 @@ impl MenteDb {
             });
         }
         Ok(scored)
+    }
+
+    // -----------------------------------------------------------------------
+    // Cognitive Engine: Pain Registry
+    // -----------------------------------------------------------------------
+
+    /// Record a pain signal — a recurring failure or frustration pattern.
+    ///
+    /// Pain signals are tracked by keywords and surfaced as warnings when
+    /// similar contexts arise in future queries.
+    pub fn record_pain(&self, signal: PainSignal) {
+        if self.cognitive_config.pain_tracking {
+            self.pain.write().record_pain(signal);
+        }
+    }
+
+    /// Get pain warnings relevant to the given context keywords.
+    ///
+    /// Returns formatted warning text if any pain signals match the keywords.
+    /// Use this before answering to warn about past failures.
+    pub fn get_pain_warnings(&self, context_keywords: &[String]) -> Vec<PainSignal> {
+        if !self.cognitive_config.pain_tracking {
+            return vec![];
+        }
+        let registry = self.pain.read();
+        registry
+            .get_pain_for_context(context_keywords)
+            .into_iter()
+            .cloned()
+            .collect()
+    }
+
+    /// Format pain warnings as a human-readable string.
+    pub fn format_pain_warnings(&self, signals: &[&PainSignal]) -> String {
+        self.pain.read().format_pain_warnings(signals)
+    }
+
+    /// Decay all pain signals to reduce intensity over time.
+    pub fn decay_pain(&self) {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_micros() as u64;
+        self.pain.write().decay_all(now);
+    }
+
+    /// Get all recorded pain signals.
+    pub fn all_pain_signals(&self) -> Vec<PainSignal> {
+        self.pain.read().all_signals().to_vec()
+    }
+
+    // -----------------------------------------------------------------------
+    // Cognitive Engine: Trajectory Tracking
+    // -----------------------------------------------------------------------
+
+    /// Record a conversation turn in the trajectory tracker.
+    ///
+    /// Tracks the evolution of topics, decisions, and open questions across
+    /// a conversation. Used for resume context and topic prediction.
+    pub fn record_trajectory_turn(&self, turn: TrajectoryNode) {
+        self.trajectory.write().record_turn(turn);
+    }
+
+    /// Get a resume context string summarizing the conversation so far.
+    ///
+    /// Returns None if no trajectory has been recorded.
+    pub fn get_resume_context(&self) -> Option<String> {
+        self.trajectory.read().get_resume_context()
+    }
+
+    /// Predict the next likely topics based on conversation trajectory.
+    ///
+    /// Returns up to 3 predicted topic strings based on transition patterns.
+    pub fn predict_next_topics(&self) -> Vec<String> {
+        self.trajectory.read().predict_next_topics()
+    }
+
+    /// Get the full trajectory of recorded turns.
+    pub fn get_trajectory(&self) -> Vec<TrajectoryNode> {
+        self.trajectory.read().get_trajectory().to_vec()
+    }
+
+    /// Reinforce a transition that led to a speculative cache hit.
+    pub fn reinforce_transition(&self, hit_topic: &str) {
+        self.trajectory.write().reinforce_transition(hit_topic);
+    }
+
+    // -----------------------------------------------------------------------
+    // Cognitive Engine: Cognition Stream
+    // -----------------------------------------------------------------------
+
+    /// Feed a token to the cognition stream for real-time monitoring.
+    ///
+    /// Tokens are buffered and analyzed for contradictions with known facts
+    /// when `check_stream_alerts()` is called.
+    pub fn feed_stream_token(&self, token: &str) {
+        self.stream.feed_token(token);
+    }
+
+    /// Check for stream alerts against known facts.
+    ///
+    /// Compares the buffered token stream against the provided known facts
+    /// to detect contradictions, corrections, and reinforcements.
+    pub fn check_stream_alerts(&self, known_facts: &[(MemoryId, String)]) -> Vec<StreamAlert> {
+        self.stream.check_alerts(known_facts)
+    }
+
+    /// Drain the token buffer, returning accumulated text.
+    pub fn drain_stream_buffer(&self) -> String {
+        self.stream.drain_buffer()
+    }
+
+    // -----------------------------------------------------------------------
+    // Cognitive Engine: Phantom Tracking
+    // -----------------------------------------------------------------------
+
+    /// Detect phantom memories — entities referenced in content but not stored.
+    ///
+    /// Scans content for entity mentions that don't exist in the known entities
+    /// list, flagging them as knowledge gaps that should be filled.
+    pub fn detect_phantoms(
+        &self,
+        content: &str,
+        known_entities: &[String],
+        turn_id: u64,
+    ) -> Vec<PhantomMemory> {
+        if !self.cognitive_config.phantom_tracking {
+            return vec![];
+        }
+        self.phantom
+            .write()
+            .detect_gaps(content, known_entities, turn_id)
+    }
+
+    /// Resolve a phantom memory (mark it as no longer a gap).
+    pub fn resolve_phantom(&self, phantom_id: MemoryId) {
+        self.phantom.write().resolve(phantom_id.into());
+    }
+
+    /// Get all active (unresolved) phantom memories, sorted by priority.
+    pub fn get_active_phantoms(&self) -> Vec<PhantomMemory> {
+        self.phantom
+            .read()
+            .get_active_phantoms()
+            .into_iter()
+            .cloned()
+            .collect()
+    }
+
+    /// Format phantom warnings as a human-readable string.
+    pub fn format_phantom_warnings(&self) -> String {
+        self.phantom.read().format_phantom_warnings()
+    }
+
+    /// Register an entity so the phantom tracker knows it exists.
+    pub fn register_entity(&self, entity: &str) {
+        self.phantom.write().register_entity(entity);
+    }
+
+    /// Register multiple entities at once.
+    pub fn register_entities(&self, entities: &[&str]) {
+        self.phantom.write().register_entities(entities);
+    }
+
+    // -----------------------------------------------------------------------
+    // Cognitive Engine: Speculative Cache
+    // -----------------------------------------------------------------------
+
+    /// Try to hit the speculative cache for a query.
+    ///
+    /// If a previous prediction matches the current query (by keyword overlap
+    /// or embedding similarity), returns the pre-assembled context.
+    pub fn try_speculative_hit(
+        &self,
+        query: &str,
+        query_embedding: Option<&[f32]>,
+    ) -> Option<CacheEntry> {
+        if !self.cognitive_config.speculative_cache {
+            return None;
+        }
+        self.speculative.write().try_hit(query, query_embedding)
+    }
+
+    /// Pre-assemble speculative cache entries for predicted topics.
+    ///
+    /// The builder function should return `(context_text, memory_ids, optional_embedding)`
+    /// for each topic prediction.
+    pub fn pre_assemble_speculative<F>(&self, predictions: Vec<String>, builder: F)
+    where
+        F: Fn(&str) -> Option<(String, Vec<MemoryId>, Option<Vec<f32>>)>,
+    {
+        if self.cognitive_config.speculative_cache {
+            self.speculative.write().pre_assemble(predictions, builder);
+        }
+    }
+
+    /// Evict stale entries from the speculative cache.
+    pub fn evict_stale_speculative(&self, max_age_us: u64) {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_micros() as u64;
+        self.speculative.write().evict_stale(max_age_us, now);
+    }
+
+    /// Get speculative cache statistics.
+    pub fn speculative_cache_stats(&self) -> CacheStats {
+        self.speculative.read().stats()
+    }
+
+    // -----------------------------------------------------------------------
+    // Cognitive Engine: Interference Detection
+    // -----------------------------------------------------------------------
+
+    /// Detect interference between a set of memories.
+    ///
+    /// Returns pairs of memories that are similar enough to cause confusion,
+    /// along with disambiguation hints. Use this during context assembly to
+    /// add disambiguation notes or separate confusable memories.
+    pub fn detect_interference(&self, memories: &[MemoryNode]) -> Vec<InterferencePair> {
+        if !self.cognitive_config.interference_detection {
+            return vec![];
+        }
+        self.interference.detect_interference(memories)
+    }
+
+    /// Generate a disambiguation hint for two confusable memories.
+    pub fn generate_disambiguation(&self, a: &MemoryNode, b: &MemoryNode) -> String {
+        self.interference.generate_disambiguation(a, b)
+    }
+
+    /// Arrange memory IDs to maximize separation between interfering pairs.
+    pub fn arrange_with_separation(
+        memories: Vec<MemoryId>,
+        pairs: &[InterferencePair],
+    ) -> Vec<MemoryId> {
+        InterferenceDetector::arrange_with_separation(memories, pairs)
+    }
+
+    // -----------------------------------------------------------------------
+    // Cognitive Engine: Entity Resolution
+    // -----------------------------------------------------------------------
+
+    /// Resolve an entity name to its canonical form.
+    ///
+    /// Uses cached aliases and rule-based matching (no LLM).
+    pub fn resolve_entity(&self, name: &str) -> mentedb_cognitive::ResolvedEntity {
+        self.entity_resolver.read().resolve(name)
+    }
+
+    /// Add an alias mapping for entity resolution.
+    pub fn add_entity_alias(&self, alias: &str, canonical: &str, confidence: f32) {
+        self.entity_resolver
+            .write()
+            .add_alias(alias, canonical, confidence);
+    }
+
+    /// Get the canonical name for an entity, if known.
+    pub fn get_canonical_entity(&self, name: &str) -> Option<String> {
+        self.entity_resolver.read().get_canonical(name).cloned()
+    }
+
+    /// List all known entities in the resolver.
+    pub fn known_entities(&self) -> Vec<String> {
+        self.entity_resolver.read().known_entities()
+    }
+
+    // -----------------------------------------------------------------------
+    // Cognitive Engine: Memory Compression
+    // -----------------------------------------------------------------------
+
+    /// Compress a memory's content, extracting key facts and removing filler.
+    ///
+    /// Returns a compressed representation with the original ID, compressed text,
+    /// compression ratio, and extracted key facts.
+    pub fn compress_memory(&self, memory: &MemoryNode) -> CompressedMemory {
+        self.compressor.compress(memory)
+    }
+
+    /// Compress a batch of memories.
+    pub fn compress_memories(&self, memories: &[MemoryNode]) -> Vec<CompressedMemory> {
+        self.compressor.compress_batch(memories)
+    }
+
+    /// Estimate token count for a text string.
+    pub fn estimate_tokens(text: &str) -> usize {
+        MemoryCompressor::estimate_tokens(text)
+    }
+
+    // -----------------------------------------------------------------------
+    // Cognitive Engine: Archival Evaluation
+    // -----------------------------------------------------------------------
+
+    /// Evaluate whether a memory should be kept, archived, or deleted.
+    ///
+    /// Uses age, salience, and access patterns to make lifecycle decisions.
+    pub fn evaluate_archival(&self, memory: &MemoryNode) -> ArchivalDecision {
+        if !self.cognitive_config.archival_evaluation {
+            return ArchivalDecision::Keep;
+        }
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_micros() as u64;
+        self.archival.evaluate(memory, now)
+    }
+
+    /// Evaluate archival decisions for a batch of memories.
+    pub fn evaluate_archival_batch(
+        &self,
+        memories: &[MemoryNode],
+    ) -> Vec<(MemoryId, ArchivalDecision)> {
+        if !self.cognitive_config.archival_evaluation {
+            return memories
+                .iter()
+                .map(|m| (m.id, ArchivalDecision::Keep))
+                .collect();
+        }
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_micros() as u64;
+        self.archival.evaluate_batch(memories, now)
+    }
+
+    /// Run archival evaluation on all memories in the database.
+    ///
+    /// Returns decisions for each memory. Does NOT apply them — call
+    /// `invalidate_memory` or `forget` to act on the decisions.
+    pub fn evaluate_archival_global(&self) -> MenteResult<Vec<(MemoryId, ArchivalDecision)>> {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_micros() as u64;
+        let pm = self.page_map.read();
+        let memories: Vec<MemoryNode> = pm
+            .values()
+            .filter_map(|pid| self.storage.load_memory(*pid).ok())
+            .collect();
+        drop(pm);
+        Ok(self.archival.evaluate_batch(&memories, now))
     }
 }

--- a/crates/mentedb/tests/integration.rs
+++ b/crates/mentedb/tests/integration.rs
@@ -637,4 +637,510 @@ fn test_cognitive_config_default_enables_all() {
         "Write inference should be enabled by default"
     );
     assert!(config.decay_on_recall, "Decay should be enabled by default");
+    assert!(
+        config.pain_tracking,
+        "Pain tracking should be enabled by default"
+    );
+    assert!(
+        config.interference_detection,
+        "Interference detection should be enabled by default"
+    );
+    assert!(
+        config.phantom_tracking,
+        "Phantom tracking should be enabled by default"
+    );
+    assert!(
+        config.speculative_cache,
+        "Speculative cache should be enabled by default"
+    );
+    assert!(
+        config.archival_evaluation,
+        "Archival evaluation should be enabled by default"
+    );
+}
+
+// -----------------------------------------------------------------------
+// Pain Registry Tests
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_pain_record_and_retrieve() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = MenteDb::open(dir.path()).unwrap();
+
+    let signal = mentedb_cognitive::PainSignal {
+        id: MemoryId::new(),
+        memory_id: MemoryId::new(),
+        intensity: 0.8,
+        trigger_keywords: vec!["deploy".into(), "production".into()],
+        description: "Deployment to production failed twice last week".into(),
+        created_at: std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_micros() as u64,
+        decay_rate: 0.1,
+    };
+    db.record_pain(signal);
+
+    let warnings = db.get_pain_warnings(&["deploy".into(), "staging".into()]);
+    assert_eq!(
+        warnings.len(),
+        1,
+        "Should find pain signal matching 'deploy'"
+    );
+    assert!(
+        warnings[0].description.contains("production"),
+        "Should return the correct pain signal"
+    );
+}
+
+#[test]
+fn test_pain_disabled_returns_empty() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = mentedb::CognitiveConfig {
+        pain_tracking: false,
+        ..Default::default()
+    };
+    let db = MenteDb::open_with_config(dir.path(), config).unwrap();
+
+    let signal = mentedb_cognitive::PainSignal {
+        id: MemoryId::new(),
+        memory_id: MemoryId::new(),
+        intensity: 0.9,
+        trigger_keywords: vec!["deploy".into()],
+        description: "test".into(),
+        created_at: 0,
+        decay_rate: 0.1,
+    };
+    db.record_pain(signal);
+
+    let warnings = db.get_pain_warnings(&["deploy".into()]);
+    assert!(
+        warnings.is_empty(),
+        "Disabled pain should return no warnings"
+    );
+}
+
+#[test]
+fn test_pain_decay_reduces_signals() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = MenteDb::open(dir.path()).unwrap();
+
+    let signal = mentedb_cognitive::PainSignal {
+        id: MemoryId::new(),
+        memory_id: MemoryId::new(),
+        intensity: 0.8,
+        trigger_keywords: vec!["test".into()],
+        description: "test pain".into(),
+        created_at: 1_000_000, // very old
+        decay_rate: 0.9,
+    };
+    db.record_pain(signal);
+    db.decay_pain();
+
+    let all = db.all_pain_signals();
+    assert_eq!(all.len(), 1);
+}
+
+// -----------------------------------------------------------------------
+// Trajectory Tracking Tests
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_trajectory_record_and_resume() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = MenteDb::open(dir.path()).unwrap();
+
+    let turn = mentedb_cognitive::trajectory::TrajectoryNode {
+        turn_id: 1,
+        topic_embedding: vec![1.0, 0.0, 0.0],
+        topic_summary: "Discussing database schema design".into(),
+        decision_state: mentedb_cognitive::trajectory::DecisionState::Investigating,
+        open_questions: vec!["Which DB to use?".into()],
+        timestamp: std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_micros() as u64,
+    };
+    db.record_trajectory_turn(turn);
+
+    let resume = db.get_resume_context();
+    assert!(
+        resume.is_some(),
+        "Should have resume context after recording a turn"
+    );
+
+    let trajectory = db.get_trajectory();
+    assert_eq!(trajectory.len(), 1);
+    assert_eq!(
+        trajectory[0].topic_summary,
+        "Discussing database schema design"
+    );
+}
+
+#[test]
+fn test_trajectory_predict_topics() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = MenteDb::open(dir.path()).unwrap();
+
+    // Record multiple turns to build transition patterns
+    for i in 0u64..5 {
+        let turn = mentedb_cognitive::trajectory::TrajectoryNode {
+            turn_id: i,
+            topic_embedding: vec![i as f32, 0.0, 0.0],
+            topic_summary: format!("Topic {}", i),
+            decision_state: mentedb_cognitive::trajectory::DecisionState::Investigating,
+            open_questions: vec![],
+            timestamp: i * 1_000_000,
+        };
+        db.record_trajectory_turn(turn);
+    }
+
+    let predictions = db.predict_next_topics();
+    // Predictions may or may not be empty depending on transition patterns
+    assert!(
+        predictions.len() <= 3,
+        "Should return at most 3 predictions"
+    );
+}
+
+// -----------------------------------------------------------------------
+// Cognition Stream Tests
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_stream_feed_and_check() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = MenteDb::open(dir.path()).unwrap();
+
+    db.feed_stream_token("The");
+    db.feed_stream_token(" user");
+    db.feed_stream_token(" prefers");
+    db.feed_stream_token(" PostgreSQL");
+
+    let known_facts = vec![(
+        MemoryId::new(),
+        "The user uses MySQL for their database".into(),
+    )];
+    let alerts = db.check_stream_alerts(&known_facts);
+    // Stream may or may not detect contradiction depending on keyword overlap
+    // The important thing is it doesn't panic
+    let _ = alerts;
+
+    let buffer = db.drain_stream_buffer();
+    assert!(
+        buffer.contains("PostgreSQL"),
+        "Buffer should contain fed tokens"
+    );
+}
+
+// -----------------------------------------------------------------------
+// Phantom Tracking Tests
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_phantom_detect_and_resolve() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = MenteDb::open(dir.path()).unwrap();
+
+    // Register some known entities
+    db.register_entities(&["PostgreSQL", "Redis", "Docker"]);
+
+    // Detect phantoms — mention "Kubernetes" which is NOT registered
+    let phantoms = db.detect_phantoms(
+        "We should deploy to Kubernetes using our Docker setup",
+        &["PostgreSQL".into(), "Redis".into(), "Docker".into()],
+        1,
+    );
+    // Phantom detection is heuristic — may or may not find gaps
+    // The API should work without panicking regardless
+    let _ = phantoms;
+
+    let active = db.get_active_phantoms();
+    for p in &active {
+        db.resolve_phantom(p.id);
+    }
+    let after_resolve = db.get_active_phantoms();
+    assert!(
+        after_resolve.len() <= active.len(),
+        "Resolving should not increase active phantoms"
+    );
+}
+
+#[test]
+fn test_phantom_disabled_returns_empty() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = mentedb::CognitiveConfig {
+        phantom_tracking: false,
+        ..Default::default()
+    };
+    let db = MenteDb::open_with_config(dir.path(), config).unwrap();
+
+    let phantoms = db.detect_phantoms("mention of Unknown Entity", &[], 1);
+    assert!(
+        phantoms.is_empty(),
+        "Disabled phantom tracking returns empty"
+    );
+}
+
+// -----------------------------------------------------------------------
+// Speculative Cache Tests
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_speculative_cache_hit_and_miss() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = MenteDb::open(dir.path()).unwrap();
+
+    // Pre-assemble cache for a predicted topic
+    db.pre_assemble_speculative(vec!["database design".into()], |topic| {
+        Some((
+            format!("Context about {}", topic),
+            vec![MemoryId::new()],
+            None,
+        ))
+    });
+
+    // Try a hit with matching keywords
+    let hit = db.try_speculative_hit("database design patterns", None);
+    // Whether this hits depends on keyword overlap threshold
+    let _ = hit;
+
+    // Try a miss with completely different topic
+    let miss = db.try_speculative_hit("cooking recipes", None);
+    assert!(miss.is_none(), "Unrelated query should miss the cache");
+
+    let stats = db.speculative_cache_stats();
+    assert!(
+        stats.cache_size > 0,
+        "Cache should have entries after pre-assembly"
+    );
+}
+
+#[test]
+fn test_speculative_cache_disabled() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = mentedb::CognitiveConfig {
+        speculative_cache: false,
+        ..Default::default()
+    };
+    let db = MenteDb::open_with_config(dir.path(), config).unwrap();
+
+    let hit = db.try_speculative_hit("anything", None);
+    assert!(hit.is_none(), "Disabled cache always misses");
+}
+
+// -----------------------------------------------------------------------
+// Interference Detection Tests
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_interference_detects_similar_memories() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = MenteDb::open(dir.path()).unwrap();
+
+    let m1 = make_memory("Deploy to staging environment", vec![0.9, 0.1, 0.0, 0.0]);
+    let m2 = make_memory(
+        "Deploy to production environment",
+        vec![0.88, 0.12, 0.0, 0.0],
+    );
+    let m3 = make_memory("Cook pasta for dinner", vec![0.0, 0.0, 1.0, 0.0]);
+
+    let pairs = db.detect_interference(&[m1.clone(), m2.clone(), m3]);
+    // m1 and m2 have very similar embeddings, m3 is different
+    // Whether interference is detected depends on threshold (0.8 default)
+    for pair in &pairs {
+        assert!(
+            pair.similarity >= 0.8,
+            "Interference pairs should be above threshold"
+        );
+        assert!(
+            !pair.disambiguation.is_empty(),
+            "Disambiguation should not be empty"
+        );
+    }
+}
+
+#[test]
+fn test_interference_disabled_returns_empty() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = mentedb::CognitiveConfig {
+        interference_detection: false,
+        ..Default::default()
+    };
+    let db = MenteDb::open_with_config(dir.path(), config).unwrap();
+
+    let m1 = make_memory("test A", vec![1.0, 0.0, 0.0, 0.0]);
+    let m2 = make_memory("test B", vec![1.0, 0.0, 0.0, 0.0]);
+    let pairs = db.detect_interference(&[m1, m2]);
+    assert!(pairs.is_empty(), "Disabled interference returns empty");
+}
+
+// -----------------------------------------------------------------------
+// Entity Resolution Tests
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_entity_resolve_with_alias() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = MenteDb::open(dir.path()).unwrap();
+
+    db.add_entity_alias("JS", "JavaScript", 0.95);
+    db.add_entity_alias("TS", "TypeScript", 0.9);
+
+    let resolved = db.resolve_entity("JS");
+    assert_eq!(resolved.canonical, "javascript");
+    assert!(resolved.confidence >= 0.9);
+
+    let canonical = db.get_canonical_entity("TS");
+    assert_eq!(canonical, Some("typescript".into()));
+
+    let unknown = db.get_canonical_entity("Rust");
+    assert!(unknown.is_none(), "Unknown entity returns None");
+
+    let entities = db.known_entities();
+    assert!(entities.len() >= 2, "Should know at least 2 entities");
+}
+
+// -----------------------------------------------------------------------
+// Memory Compression Tests
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_compress_memory() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = MenteDb::open(dir.path()).unwrap();
+
+    let memory = make_memory(
+        "The user mentioned that they really prefer using PostgreSQL for their database needs \
+         because it has great support for JSON and is very reliable in production environments. \
+         They also said they like the extension ecosystem.",
+        vec![1.0, 0.0, 0.0, 0.0],
+    );
+
+    let compressed = db.compress_memory(&memory);
+    assert_eq!(compressed.original_id, memory.id);
+    assert!(
+        !compressed.compressed_content.is_empty(),
+        "Compressed content should not be empty"
+    );
+    assert!(
+        compressed.compression_ratio <= 1.0,
+        "Compression ratio should be <= 1.0"
+    );
+}
+
+#[test]
+fn test_compress_batch() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = MenteDb::open(dir.path()).unwrap();
+
+    let memories = vec![
+        make_memory("First memory with some content", vec![1.0, 0.0, 0.0, 0.0]),
+        make_memory(
+            "Second memory about something else",
+            vec![0.0, 1.0, 0.0, 0.0],
+        ),
+    ];
+
+    let compressed = db.compress_memories(&memories);
+    assert_eq!(compressed.len(), 2);
+}
+
+#[test]
+fn test_estimate_tokens() {
+    let tokens = MenteDb::estimate_tokens("Hello world, this is a test sentence.");
+    assert!(tokens > 0, "Token estimate should be positive");
+}
+
+// -----------------------------------------------------------------------
+// Archival Evaluation Tests
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_archival_fresh_memory_kept() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = MenteDb::open(dir.path()).unwrap();
+
+    let memory = make_memory("A fresh new memory", vec![1.0, 0.0, 0.0, 0.0]);
+    let decision = db.evaluate_archival(&memory);
+    assert!(
+        matches!(
+            decision,
+            mentedb_consolidation::archival::ArchivalDecision::Keep
+        ),
+        "Fresh memory should be kept, got {:?}",
+        decision
+    );
+}
+
+#[test]
+fn test_archival_disabled_always_keeps() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = mentedb::CognitiveConfig {
+        archival_evaluation: false,
+        ..Default::default()
+    };
+    let db = MenteDb::open_with_config(dir.path(), config).unwrap();
+
+    let mut memory = make_memory("Old memory", vec![1.0, 0.0, 0.0, 0.0]);
+    memory.salience = 0.01;
+    memory.created_at = 1_000_000; // very old
+
+    let decision = db.evaluate_archival(&memory);
+    assert!(
+        matches!(
+            decision,
+            mentedb_consolidation::archival::ArchivalDecision::Keep
+        ),
+        "Disabled archival should always Keep"
+    );
+}
+
+#[test]
+fn test_archival_batch_evaluation() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = MenteDb::open(dir.path()).unwrap();
+
+    let memories = vec![
+        make_memory("Fresh memory A", vec![1.0, 0.0, 0.0, 0.0]),
+        make_memory("Fresh memory B", vec![0.0, 1.0, 0.0, 0.0]),
+    ];
+
+    let decisions = db.evaluate_archival_batch(&memories);
+    assert_eq!(decisions.len(), 2);
+    // Fresh memories should be kept
+    for (_, decision) in &decisions {
+        assert!(
+            matches!(
+                decision,
+                mentedb_consolidation::archival::ArchivalDecision::Keep
+            ),
+            "Fresh memories should be kept"
+        );
+    }
+}
+
+// -----------------------------------------------------------------------
+// Persistence Tests: Cognitive State Survives Flush
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_entity_resolver_persists_across_flush() {
+    let dir = tempfile::tempdir().unwrap();
+    {
+        let db = MenteDb::open(dir.path()).unwrap();
+        db.add_entity_alias("pg", "PostgreSQL", 0.95);
+        db.flush().unwrap();
+        db.close().unwrap();
+    }
+    {
+        let db = MenteDb::open(dir.path()).unwrap();
+        let canonical = db.get_canonical_entity("pg");
+        assert_eq!(
+            canonical,
+            Some("postgresql".into()),
+            "Entity alias should persist across flush/reopen"
+        );
+    }
 }


### PR DESCRIPTION
Wire all 9 remaining cognitive subsystems into the MenteDb facade:

**New subsystems wired:**
- **PainRegistry** — track recurring failures, surface warnings on similar contexts
- **TrajectoryTracker** — conversation pattern tracking, topic prediction, resume context
- **CognitionStream** — real-time token-level monitoring for contradictions
- **PhantomTracker** — detect referenced-but-missing knowledge gaps
- **SpeculativeCache** — pre-fetch context for predicted topics
- **InterferenceDetector** — find confusable memories, generate disambiguation hints
- **EntityResolver** — canonical name resolution with alias persistence
- **MemoryCompressor** — content compression for token efficiency
- **ArchivalPipeline** — lifecycle evaluation (keep/archive/delete)

**Infrastructure:**
- Expanded CognitiveConfig with per-subsystem toggles (all enabled by default)
- RwLock wrappers for mutable subsystems (MenteDb methods take `&self`)
- Persists EntityResolver, SpeculativeCache, TransitionMap to `cognitive/` dir
- Loads persisted state on open, saves on flush

**Tests:** 20 new integration tests (39 total), all passing
**Clippy:** Clean with `-D warnings` on all tests
**README:** Updated with all cognitive engine APIs and examples