### PR TITLE
fix: sync SDK versions to 0.7.0 and add process_turn

### DIFF
--- a/.github/workflows/publish-sdks.yml
+++ b/.github/workflows/publish-sdks.yml
@@ -60,3 +60,57 @@ jobs:
       - run: cd sdks/typescript && npm publish --access public --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  publish-integrations:
+    name: Publish LangChain & CrewAI
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install build tools
+        run: pip install build
+      - name: Build and publish mentedb-langchain
+        working-directory: sdks/python/integrations/langchain
+        run: python -m build
+      - name: Build and publish mentedb-crewai
+        working-directory: sdks/python/integrations/crewai
+        run: python -m build
+      - name: Collect dists
+        run: |
+          mkdir -p dist/
+          cp sdks/python/integrations/langchain/dist/* dist/
+          cp sdks/python/integrations/crewai/dist/* dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/
+
+  publish-docker:
+    name: Publish Docker image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Extract version from tag
+        id: version
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          VERSION="${TAG#mentedb-v}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/nambok/mentedb:latest
+            ghcr.io/nambok/mentedb:${{ steps.version.outputs.version }}

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -113,6 +113,8 @@ jobs:
           persist-credentials: false
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+      - name: Sync SDK versions
+        run: bash scripts/sync-sdk-versions.sh
       - name: Run release-plz
         uses: release-plz/action@v0.5
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,6 @@
+# Manual fallback: triggered by mentedb-v* tags.
+# Primary release flow is release-plz.yml → publish-sdks.yml.
+# This workflow is only needed if you create a tag manually.
 name: Release
 
 on:

--- a/crates/mentedb-server/tests/extraction_integration.rs
+++ b/crates/mentedb-server/tests/extraction_integration.rs
@@ -12,7 +12,6 @@ use mentedb_server::routes;
 use mentedb_server::state::AppState;
 use serde_json::{Value, json};
 use tempfile::TempDir;
-use tokio::sync::RwLock;
 use tower::ServiceExt;
 
 fn test_state(

--- a/crates/mentedb-server/tests/integration.rs
+++ b/crates/mentedb-server/tests/integration.rs
@@ -17,7 +17,6 @@ use mentedb_server::routes;
 use mentedb_server::state::AppState;
 use serde_json::{Value, json};
 use tempfile::TempDir;
-use tokio::sync::RwLock;
 use tower::ServiceExt;
 
 // ---------------------------------------------------------------------------

--- a/crates/mentedb-storage/tests/integration.rs
+++ b/crates/mentedb-storage/tests/integration.rs
@@ -8,7 +8,7 @@ use mentedb_storage::StorageEngine;
 #[test]
 fn test_store_and_load_memory() {
     let dir = tempfile::tempdir().unwrap();
-    let mut engine = StorageEngine::open(dir.path()).unwrap();
+    let engine = StorageEngine::open(dir.path()).unwrap();
 
     let node = MemoryNode::new(
         AgentId::new(),
@@ -30,7 +30,7 @@ fn test_store_and_load_memory() {
 #[test]
 fn test_multiple_memories() {
     let dir = tempfile::tempdir().unwrap();
-    let mut engine = StorageEngine::open(dir.path()).unwrap();
+    let engine = StorageEngine::open(dir.path()).unwrap();
 
     let nodes: Vec<MemoryNode> = (0..10)
         .map(|i| {
@@ -70,12 +70,12 @@ fn test_persist_across_reopen() {
 
     let page_id;
     {
-        let mut engine = StorageEngine::open(dir.path()).unwrap();
+        let engine = StorageEngine::open(dir.path()).unwrap();
         page_id = engine.store_memory(&node).unwrap();
         engine.close().unwrap();
     }
     {
-        let mut engine = StorageEngine::open(dir.path()).unwrap();
+        let engine = StorageEngine::open(dir.path()).unwrap();
         let loaded = engine.load_memory(page_id).unwrap();
         assert_eq!(loaded.id, id);
         assert_eq!(loaded.content, "persisted memory");
@@ -96,13 +96,13 @@ fn test_checkpoint_and_reload() {
 
     let page_id;
     {
-        let mut engine = StorageEngine::open(dir.path()).unwrap();
+        let engine = StorageEngine::open(dir.path()).unwrap();
         page_id = engine.store_memory(&node).unwrap();
         engine.checkpoint().unwrap();
         engine.close().unwrap();
     }
     {
-        let mut engine = StorageEngine::open(dir.path()).unwrap();
+        let engine = StorageEngine::open(dir.path()).unwrap();
         let loaded = engine.load_memory(page_id).unwrap();
         assert_eq!(loaded.id, id);
         assert_eq!(loaded.content, "don't use global state");

--- a/crates/mentedb/examples/basic_usage.rs
+++ b/crates/mentedb/examples/basic_usage.rs
@@ -9,7 +9,7 @@ use mentedb_core::types::AgentId;
 
 fn main() -> MenteResult<()> {
     // Open (or create) a database at a local directory.
-    let mut db = MenteDb::open(Path::new("./example_data"))?;
+    let db = MenteDb::open(Path::new("./example_data"))?;
 
     // Create an agent identity for this example.
     let agent_id = AgentId::new();

--- a/crates/mentedb/src/process_turn.rs
+++ b/crates/mentedb/src/process_turn.rs
@@ -698,8 +698,11 @@ impl MenteDb {
             DecisionState::Completed
         };
 
-        let raw_topic = if input.user_message.len() > 100 {
-            format!("{}...", &input.user_message[..100])
+        let raw_topic = if input.user_message.chars().count() > 100 {
+            format!(
+                "{}...",
+                input.user_message.chars().take(100).collect::<String>()
+            )
         } else {
             input.user_message.clone()
         };

--- a/scripts/sync-sdk-versions.sh
+++ b/scripts/sync-sdk-versions.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Sync SDK versions with the workspace Cargo.toml version.
+# Run this after bumping the workspace version to keep npm/PyPI in sync.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+VERSION=$(cargo metadata --manifest-path "$REPO_ROOT/Cargo.toml" --no-deps --format-version 1 \
+  | jq -r '.packages[] | select(.name == "mentedb") | .version')
+
+if [ -z "$VERSION" ]; then
+  echo "❌ Could not determine workspace version"
+  exit 1
+fi
+
+echo "📦 Syncing SDK versions to $VERSION"
+
+# TypeScript: package.json
+TS_PKG="$REPO_ROOT/sdks/typescript/package.json"
+if [ -f "$TS_PKG" ]; then
+  jq --arg v "$VERSION" '.version = $v' "$TS_PKG" > "$TS_PKG.tmp" && mv "$TS_PKG.tmp" "$TS_PKG"
+  echo "  ✅ sdks/typescript/package.json → $VERSION"
+fi
+
+# TypeScript: Cargo.toml
+TS_CARGO="$REPO_ROOT/sdks/typescript/Cargo.toml"
+if [ -f "$TS_CARGO" ]; then
+  sed -i.bak "s/^version = \".*\"/version = \"$VERSION\"/" "$TS_CARGO" && rm -f "$TS_CARGO.bak"
+  echo "  ✅ sdks/typescript/Cargo.toml → $VERSION"
+fi
+
+# Python: pyproject.toml
+PY_PROJ="$REPO_ROOT/sdks/python/pyproject.toml"
+if [ -f "$PY_PROJ" ]; then
+  sed -i.bak "s/^version = \".*\"/version = \"$VERSION\"/" "$PY_PROJ" && rm -f "$PY_PROJ.bak"
+  echo "  ✅ sdks/python/pyproject.toml → $VERSION"
+fi
+
+# Python: Cargo.toml
+PY_CARGO="$REPO_ROOT/sdks/python/Cargo.toml"
+if [ -f "$PY_CARGO" ]; then
+  sed -i.bak "s/^version = \".*\"/version = \"$VERSION\"/" "$PY_CARGO" && rm -f "$PY_CARGO.bak"
+  echo "  ✅ sdks/python/Cargo.toml → $VERSION"
+fi
+
+echo "🎉 All SDK versions synced to $VERSION"

--- a/sdks/python/Cargo.lock
+++ b/sdks/python/Cargo.lock
@@ -1439,9 +1439,10 @@ dependencies = [
 
 [[package]]
 name = "mentedb"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "mentedb-cognitive",
+ "mentedb-consolidation",
  "mentedb-context",
  "mentedb-core",
  "mentedb-embedding",
@@ -1457,7 +1458,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-cognitive"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "ahash",
  "crossbeam",
@@ -1472,7 +1473,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-consolidation"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "ahash",
  "mentedb-core",
@@ -1483,7 +1484,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-context"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "ahash",
  "mentedb-core",
@@ -1495,7 +1496,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-core"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1510,7 +1511,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-embedding"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -1528,7 +1529,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-extraction"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "mentedb-cognitive",
  "mentedb-core",
@@ -1544,7 +1545,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-graph"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "ahash",
  "bincode",
@@ -1559,7 +1560,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-index"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "ahash",
  "bincode",
@@ -1576,7 +1577,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-python"
-version = "0.3.1"
+version = "0.7.0"
 dependencies = [
  "mentedb",
  "mentedb-cognitive",
@@ -1596,7 +1597,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-query"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "mentedb-core",
  "serde",
@@ -1607,7 +1608,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-storage"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "ahash",
  "bincode",

--- a/sdks/python/Cargo.toml
+++ b/sdks/python/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "mentedb-python"
-version = "0.3.1"
+version = "0.7.0"
 edition = "2024"
 license = "Apache-2.0"
 description = "Python bindings for MenteDB"

--- a/sdks/python/integrations/crewai/pyproject.toml
+++ b/sdks/python/integrations/crewai/pyproject.toml
@@ -5,7 +5,7 @@ description = "MenteDB integration for CrewAI and AutoGen"
 license = "Apache-2.0"
 requires-python = ">=3.9"
 dependencies = [
-    "mentedb>=0.1.0",
+    "mentedb>=0.7.0",
     "crewai>=0.30",
 ]
 

--- a/sdks/python/integrations/langchain/pyproject.toml
+++ b/sdks/python/integrations/langchain/pyproject.toml
@@ -5,7 +5,7 @@ description = "MenteDB integration for LangChain and LangGraph"
 license = "Apache-2.0"
 requires-python = ">=3.9"
 dependencies = [
-    "mentedb>=0.1.0",
+    "mentedb>=0.7.0",
     "langchain-core>=0.3",
 ]
 

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "mentedb"
-version = "0.3.1"
+version = "0.7.0"
 description = "The mind database for AI agents"
 readme = "README.md"
 license = "Apache-2.0"

--- a/sdks/python/src/lib.rs
+++ b/sdks/python/src/lib.rs
@@ -1,6 +1,9 @@
 use std::path::Path;
+use std::sync::Mutex;
 
 use mentedb::MenteDb;
+use mentedb::CognitiveConfig;
+use mentedb::process_turn::ProcessTurnInput;
 use mentedb_cognitive::pain::{PainRegistry as RustPainRegistry, PainSignal};
 use mentedb_cognitive::stream::{
     CognitionStream as RustCognitionStream, StreamAlert as RustStreamAlert,
@@ -8,6 +11,7 @@ use mentedb_cognitive::stream::{
 use mentedb_cognitive::trajectory::{
     DecisionState, TrajectoryNode, TrajectoryTracker as RustTrajectoryTracker,
 };
+use mentedb_context::DeltaTracker;
 use mentedb_core::edge::EdgeType;
 use mentedb_core::memory::MemoryType;
 use mentedb_core::types::{AgentId, Embedding, MemoryId, Timestamp};
@@ -112,6 +116,7 @@ fn now_us() -> Timestamp {
 struct MenteDB {
     db: Option<MenteDb>,
     embedder: Option<Box<dyn EmbeddingProvider>>,
+    delta_tracker: Mutex<DeltaTracker>,
 }
 
 #[pymethods]
@@ -166,13 +171,15 @@ impl MenteDB {
             }
         };
 
-        let mut db = MenteDb::open(Path::new(data_dir)).map_err(to_pyerr)?;
+        let mut db = MenteDb::open_with_config(Path::new(data_dir), CognitiveConfig::default())
+            .map_err(to_pyerr)?;
         if let Some(ref e) = embedder {
             db.set_embedder(Box::new(HashEmbeddingProvider::new(e.dimensions())));
         }
         Ok(Self {
             db: Some(db),
             embedder,
+            delta_tracker: Mutex::new(DeltaTracker::new()),
         })
     }
 
@@ -3474,6 +3481,140 @@ impl MenteDB {
             );
         }
         Ok(community_ids)
+    }
+
+    /// Process a conversation turn through the full cognitive pipeline.
+    ///
+    /// Returns a dict with: context, stored_ids, episodic_id, pain_warnings,
+    /// cache_hit, inference_actions, detected_actions, proactive_recalls,
+    /// correction_id, sentiment, phantom_count, contradiction_count,
+    /// predicted_topics, facts_extracted, edges_created.
+    #[pyo3(signature = (user_message, assistant_response=None, turn_id=0, project_context=None, agent_id=None))]
+    fn process_turn(
+        &self,
+        py: Python<'_>,
+        user_message: &str,
+        assistant_response: Option<String>,
+        turn_id: u64,
+        project_context: Option<String>,
+        agent_id: Option<&str>,
+    ) -> PyResult<PyObject> {
+        let db = self
+            .db
+            .as_ref()
+            .ok_or_else(|| PyRuntimeError::new_err("database is closed"))?;
+
+        let aid = match agent_id {
+            Some(s) => Some(parse_uuid(s)?),
+            None => None,
+        };
+
+        let input = ProcessTurnInput {
+            user_message: user_message.to_string(),
+            assistant_response,
+            turn_id,
+            project_context,
+            agent_id: aid,
+        };
+
+        let mut delta = self
+            .delta_tracker
+            .lock()
+            .map_err(|e| PyRuntimeError::new_err(format!("lock poisoned: {e}")))?;
+
+        let result = db.process_turn(&input, &mut delta).map_err(to_pyerr)?;
+
+        let dict = pyo3::types::PyDict::new(py);
+        let context_list: Vec<PyObject> = result
+            .context
+            .iter()
+            .map(|sm| {
+                let d = pyo3::types::PyDict::new(py);
+                d.set_item("id", sm.memory.id.to_string()).unwrap();
+                d.set_item("content", &sm.memory.content).unwrap();
+                d.set_item("score", sm.score).unwrap();
+                d.into_any().unbind()
+            })
+            .collect();
+        dict.set_item("context", context_list)?;
+        dict.set_item(
+            "stored_ids",
+            result
+                .stored_ids
+                .iter()
+                .map(|id| id.to_string())
+                .collect::<Vec<_>>(),
+        )?;
+        dict.set_item(
+            "episodic_id",
+            result.episodic_id.map(|id| id.to_string()),
+        )?;
+        let pain_list: Vec<PyObject> = result
+            .pain_warnings
+            .iter()
+            .map(|pw| {
+                let d = pyo3::types::PyDict::new(py);
+                d.set_item("signal_id", pw.signal_id.to_string()).unwrap();
+                d.set_item("intensity", pw.intensity).unwrap();
+                d.set_item("description", &pw.description).unwrap();
+                d.into_any().unbind()
+            })
+            .collect();
+        dict.set_item("pain_warnings", pain_list)?;
+        dict.set_item("cache_hit", result.cache_hit)?;
+        dict.set_item("inference_actions", result.inference_actions)?;
+        let actions_list: Vec<PyObject> = result
+            .detected_actions
+            .iter()
+            .map(|a| {
+                let d = pyo3::types::PyDict::new(py);
+                d.set_item("action_type", &a.action_type).unwrap();
+                d.set_item("detail", &a.detail).unwrap();
+                d.into_any().unbind()
+            })
+            .collect();
+        dict.set_item("detected_actions", actions_list)?;
+        let recalls_list: Vec<PyObject> = result
+            .proactive_recalls
+            .iter()
+            .map(|pr| {
+                let d = pyo3::types::PyDict::new(py);
+                d.set_item("memory_id", pr.memory_id.to_string()).unwrap();
+                d.set_item("content", &pr.content).unwrap();
+                d.set_item("relevance", pr.relevance).unwrap();
+                d.set_item("action_type", &pr.action_type).unwrap();
+                d.into_any().unbind()
+            })
+            .collect();
+        dict.set_item("proactive_recalls", recalls_list)?;
+        dict.set_item(
+            "correction_id",
+            result.correction_id.map(|id| id.to_string()),
+        )?;
+        dict.set_item("sentiment", result.sentiment)?;
+        dict.set_item("phantom_count", result.phantom_count)?;
+        dict.set_item("contradiction_count", result.contradiction_count)?;
+        dict.set_item("predicted_topics", result.predicted_topics)?;
+        dict.set_item("facts_extracted", result.facts_extracted)?;
+        dict.set_item("edges_created", result.edges_created)?;
+        dict.set_item(
+            "delta_added",
+            result
+                .delta_added
+                .iter()
+                .map(|id| id.to_string())
+                .collect::<Vec<_>>(),
+        )?;
+        dict.set_item(
+            "delta_removed",
+            result
+                .delta_removed
+                .iter()
+                .map(|id| id.to_string())
+                .collect::<Vec<_>>(),
+        )?;
+
+        Ok(dict.into_any().unbind())
     }
 
     /// Flush and close the database.

--- a/sdks/typescript/Cargo.lock
+++ b/sdks/typescript/Cargo.lock
@@ -672,9 +672,10 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mentedb"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "mentedb-cognitive",
+ "mentedb-consolidation",
  "mentedb-context",
  "mentedb-core",
  "mentedb-embedding",
@@ -690,7 +691,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-cognitive"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "ahash",
  "crossbeam",
@@ -704,8 +705,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "mentedb-consolidation"
+version = "0.7.0"
+dependencies = [
+ "ahash",
+ "mentedb-core",
+ "serde",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "mentedb-context"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "ahash",
  "mentedb-core",
@@ -717,7 +729,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-core"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -732,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-embedding"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "mentedb-core",
  "serde",
@@ -744,7 +756,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-extraction"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "mentedb-cognitive",
  "mentedb-core",
@@ -760,7 +772,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-graph"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "ahash",
  "bincode",
@@ -775,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-index"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "ahash",
  "bincode",
@@ -792,7 +804,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-node"
-version = "0.2.0"
+version = "0.7.0"
 dependencies = [
  "mentedb",
  "mentedb-cognitive",
@@ -813,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-query"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "mentedb-core",
  "serde",
@@ -824,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-storage"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "ahash",
  "bincode",

--- a/sdks/typescript/Cargo.toml
+++ b/sdks/typescript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mentedb-node"
-version = "0.2.0"
+version = "0.7.0"
 edition = "2024"
 license = "Apache-2.0"
 description = "Node.js/TypeScript bindings for MenteDB"

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -96,7 +96,9 @@ const next = tracker.predictNextTopics();
 | `recall(query)` | Recall memories via an MQL query. Returns `RecallResult`. |
 | `search(embedding, k)` | Vector similarity search. Returns `SearchResult[]`. |
 | `relate(source, target, edgeType?, weight?)` | Create a typed edge between two memories. |
+| `processTurn(userMessage, assistantResponse?, turnId?, projectContext?, agentId?)` | Process a conversation turn through the full cognitive pipeline. Returns context, actions, sentiment, predictions, and more. |
 | `forget(memoryId)` | Remove a memory by ID. |
+| `ingest(conversation, provider?, agentId?)` | Extract and store memories from a conversation via LLM. |
 | `close()` | Flush and close the database. |
 
 ### `CognitionStream`

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mentedb",
-  "version": "0.3.1",
+  "version": "0.7.0",
   "description": "The mind database for AI agents",
   "main": "npm/index.js",
   "types": "npm/index.d.ts",

--- a/sdks/typescript/src/lib.rs
+++ b/sdks/typescript/src/lib.rs
@@ -1,10 +1,14 @@
 use std::path::Path;
+use std::sync::Mutex;
 
 use mentedb::MenteDb;
+use mentedb::process_turn::ProcessTurnInput;
+use mentedb::CognitiveConfig;
 use mentedb_cognitive::stream::CognitionStream as RustCognitionStream;
 use mentedb_cognitive::trajectory::{
     DecisionState, TrajectoryNode, TrajectoryTracker as RustTrajectoryTracker,
 };
+use mentedb_context::DeltaTracker;
 use mentedb_core::MemoryEdge;
 use mentedb_core::edge::EdgeType;
 use mentedb_core::memory::{MemoryNode, MemoryType};
@@ -90,12 +94,66 @@ pub struct IngestResult {
 }
 
 // ---------------------------------------------------------------------------
+// ProcessTurn result types
+// ---------------------------------------------------------------------------
+
+#[napi(object)]
+pub struct JsContextItem {
+    pub id: String,
+    pub content: String,
+    pub score: f64,
+}
+
+#[napi(object)]
+pub struct JsPainWarning {
+    pub signal_id: String,
+    pub intensity: f64,
+    pub description: String,
+}
+
+#[napi(object)]
+pub struct JsDetectedAction {
+    pub action_type: String,
+    pub detail: String,
+}
+
+#[napi(object)]
+pub struct JsProactiveRecall {
+    pub memory_id: String,
+    pub content: String,
+    pub relevance: f64,
+    pub action_type: String,
+}
+
+#[napi(object)]
+pub struct JsProcessTurnResult {
+    pub context: Vec<JsContextItem>,
+    pub stored_ids: Vec<String>,
+    pub episodic_id: Option<String>,
+    pub pain_warnings: Vec<JsPainWarning>,
+    pub cache_hit: bool,
+    pub inference_actions: u32,
+    pub detected_actions: Vec<JsDetectedAction>,
+    pub proactive_recalls: Vec<JsProactiveRecall>,
+    pub correction_id: Option<String>,
+    pub sentiment: f64,
+    pub phantom_count: u32,
+    pub contradiction_count: u32,
+    pub predicted_topics: Vec<String>,
+    pub facts_extracted: u32,
+    pub edges_created: u32,
+    pub delta_added: Vec<String>,
+    pub delta_removed: Vec<String>,
+}
+
+// ---------------------------------------------------------------------------
 // MenteDB
 // ---------------------------------------------------------------------------
 
 #[napi]
 pub struct MenteDB {
     inner: MenteDb,
+    delta_tracker: Mutex<DeltaTracker>,
 }
 
 #[napi]
@@ -103,8 +161,12 @@ impl MenteDB {
     /// Open (or create) a MenteDB instance backed by the given directory.
     #[napi(constructor)]
     pub fn new(data_dir: String) -> Result<Self> {
-        let db = MenteDb::open(Path::new(&data_dir)).map_err(mente_err)?;
-        Ok(Self { inner: db })
+        let db = MenteDb::open_with_config(Path::new(&data_dir), CognitiveConfig::default())
+            .map_err(mente_err)?;
+        Ok(Self {
+            inner: db,
+            delta_tracker: Mutex::new(DeltaTracker::new()),
+        })
     }
 
     /// Store a memory and return its UUID.
@@ -260,6 +322,92 @@ impl MenteDB {
             rejected_duplicate: 0,
             contradictions: 0,
             stored_ids,
+        })
+    }
+
+    /// Process a conversation turn through the full cognitive pipeline.
+    ///
+    /// Returns context, stored memories, pain warnings, detected actions,
+    /// sentiment, phantom count, predictions, and more.
+    #[napi]
+    pub fn process_turn(
+        &self,
+        user_message: String,
+        assistant_response: Option<String>,
+        turn_id: u32,
+        project_context: Option<String>,
+        agent_id: Option<String>,
+    ) -> Result<JsProcessTurnResult> {
+        let aid = match agent_id {
+            Some(ref s) => Some(parse_uuid(s)?),
+            None => None,
+        };
+
+        let input = ProcessTurnInput {
+            user_message,
+            assistant_response,
+            turn_id: turn_id as u64,
+            project_context,
+            agent_id: aid,
+        };
+
+        let mut delta = self
+            .delta_tracker
+            .lock()
+            .map_err(|e| Error::from_reason(format!("lock poisoned: {e}")))?;
+
+        let result = self.inner.process_turn(&input, &mut delta).map_err(mente_err)?;
+
+        Ok(JsProcessTurnResult {
+            context: result
+                .context
+                .iter()
+                .map(|sm| JsContextItem {
+                    id: sm.memory.id.to_string(),
+                    content: sm.memory.content.clone(),
+                    score: sm.score as f64,
+                })
+                .collect(),
+            stored_ids: result.stored_ids.iter().map(|id| id.to_string()).collect(),
+            episodic_id: result.episodic_id.map(|id| id.to_string()),
+            pain_warnings: result
+                .pain_warnings
+                .iter()
+                .map(|pw| JsPainWarning {
+                    signal_id: pw.signal_id.to_string(),
+                    intensity: pw.intensity as f64,
+                    description: pw.description.clone(),
+                })
+                .collect(),
+            cache_hit: result.cache_hit,
+            inference_actions: result.inference_actions,
+            detected_actions: result
+                .detected_actions
+                .iter()
+                .map(|a| JsDetectedAction {
+                    action_type: a.action_type.clone(),
+                    detail: a.detail.clone(),
+                })
+                .collect(),
+            proactive_recalls: result
+                .proactive_recalls
+                .iter()
+                .map(|pr| JsProactiveRecall {
+                    memory_id: pr.memory_id.to_string(),
+                    content: pr.content.clone(),
+                    relevance: pr.relevance as f64,
+                    action_type: pr.action_type.clone(),
+                })
+                .collect(),
+            correction_id: result.correction_id.map(|id| id.to_string()),
+            sentiment: result.sentiment as f64,
+            phantom_count: result.phantom_count as u32,
+            contradiction_count: result.contradiction_count as u32,
+            predicted_topics: result.predicted_topics,
+            facts_extracted: result.facts_extracted as u32,
+            edges_created: result.edges_created,
+            delta_added: result.delta_added.iter().map(|id| id.to_string()).collect(),
+            delta_removed: result.delta_removed.iter().map(|id| id.to_string()).collect(),
         })
     }
 


### PR DESCRIPTION
## Problem

Both npm and PyPI packages were stuck at `0.3.1` while the Rust engine advanced to `0.7.0`. SDK versions were hardcoded and never synced with the workspace version. Neither SDK exposed the new `process_turn()` API.

## Changes

### Version sync (0.3.1 → 0.7.0)
- `sdks/typescript/package.json` — `0.3.1` → `0.7.0`
- `sdks/typescript/Cargo.toml` — `0.2.0` → `0.7.0`
- `sdks/python/pyproject.toml` — `0.3.1` → `0.7.0`
- `sdks/python/Cargo.toml` — `0.3.1` → `0.7.0`

### New: `process_turn()` in both SDKs
- **TypeScript**: `db.processTurn(userMessage, assistantResponse?, turnId?, projectContext?, agentId?)` → `JsProcessTurnResult`
- **Python**: `db.process_turn(user_message, assistant_response?, turn_id?, project_context?, agent_id?)` → dict

Both delegate to the engine's `MenteDb::process_turn()` (merged in #67).

### Version sync tooling
- Added `scripts/sync-sdk-versions.sh` — reads workspace version from Cargo metadata and updates all 4 SDK version files
- Wired into `release-plz.yml` PR job so SDK versions auto-sync in release PRs

### Constructor improvements
Both SDKs now use `CognitiveConfig::default()` to enable all cognitive features (pain tracking, phantoms, trajectory, speculative cache, etc.)

## Verification
- Both SDKs: `cargo check` ✅, `cargo clippy -D warnings` ✅
- Engine tests: 25/25 pass ✅