### PR TITLE
fix: publish pipeline — npm napi build, integration ordering, changelog

### DIFF
--- a/.github/workflows/publish-sdks.yml
+++ b/.github/workflows/publish-sdks.yml
@@ -122,6 +122,9 @@ jobs:
             exit 1
           fi
           echo "✅ All $EXPECTED platform binaries present"
+      - name: Install dependencies
+        working-directory: sdks/typescript
+        run: npm install
       - name: Compile TypeScript
         working-directory: sdks/typescript
         run: npx tsc

--- a/.github/workflows/publish-sdks.yml
+++ b/.github/workflows/publish-sdks.yml
@@ -57,12 +57,26 @@ jobs:
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org
-      - run: cd sdks/typescript && npm publish --access public --provenance
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install protobuf compiler
+        run: sudo apt-get install -y protobuf-compiler
+      - name: Install napi-rs CLI
+        run: npm install -g @napi-rs/cli
+      - name: Build native module
+        working-directory: sdks/typescript
+        run: napi build --release
+      - name: Compile TypeScript
+        working-directory: sdks/typescript
+        run: npx tsc
+      - name: Publish to npm
+        working-directory: sdks/typescript
+        run: npm publish --access public --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   publish-integrations:
     name: Publish LangChain & CrewAI
+    needs: upload-pypi
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/.github/workflows/publish-sdks.yml
+++ b/.github/workflows/publish-sdks.yml
@@ -45,8 +45,55 @@ jobs:
         with:
           packages-dir: dist/
 
+  build-npm:
+    name: Build npm native (${{ matrix.target }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            artifact: mentedb.linux-x64-gnu.node
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            artifact: mentedb.darwin-arm64.node
+          - os: macos-13
+            target: x86_64-apple-darwin
+            artifact: mentedb.darwin-x64.node
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            artifact: mentedb.win32-x64-msvc.node
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+      - name: Install protobuf compiler (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get install -y protobuf-compiler
+      - name: Install protobuf compiler (macOS)
+        if: runner.os == 'macOS'
+        run: brew install protobuf
+      - name: Install protobuf compiler (Windows)
+        if: runner.os == 'Windows'
+        run: choco install protoc -y
+      - name: Install napi-rs CLI
+        run: npm install -g @napi-rs/cli
+      - name: Build native module
+        working-directory: sdks/typescript
+        run: napi build --release --platform --target ${{ matrix.target }}
+      - name: Upload native artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: npm-${{ matrix.target }}
+          path: sdks/typescript/${{ matrix.artifact }}
+
   publish-npm:
     name: Publish to npm
+    needs: build-npm
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -57,14 +104,24 @@ jobs:
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org
-      - uses: dtolnay/rust-toolchain@stable
-      - name: Install protobuf compiler
-        run: sudo apt-get install -y protobuf-compiler
-      - name: Install napi-rs CLI
-        run: npm install -g @napi-rs/cli
-      - name: Build native module
+      - name: Download all native artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: npm-*
+          merge-multiple: true
+          path: sdks/typescript/
+      - name: Verify native binaries
         working-directory: sdks/typescript
-        run: napi build --release
+        run: |
+          echo "Built native binaries:"
+          ls -la *.node
+          EXPECTED=4
+          ACTUAL=$(ls *.node | wc -l | tr -d ' ')
+          if [ "$ACTUAL" -ne "$EXPECTED" ]; then
+            echo "❌ Expected $EXPECTED .node files, found $ACTUAL"
+            exit 1
+          fi
+          echo "✅ All $EXPECTED platform binaries present"
       - name: Compile TypeScript
         working-directory: sdks/typescript
         run: npx tsc

--- a/.github/workflows/publish-sdks.yml
+++ b/.github/workflows/publish-sdks.yml
@@ -173,6 +173,8 @@ jobs:
           TAG="${{ github.event.release.tag_name }}"
           VERSION="${TAG#mentedb-v}"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -181,6 +183,7 @@ jobs:
       - uses: docker/build-push-action@v6
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ghcr.io/nambok/mentedb:latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+> **Note:** This project uses [release-plz](https://release-plz.ieni.dev/) for automated releases.
+> Each crate maintains its own changelog — see the links below for the latest changes.
+
+## Per-crate changelogs
+
+| Crate | Changelog |
+|-------|-----------|
+| **mentedb** (engine) | [crates/mentedb/CHANGELOG.md](crates/mentedb/CHANGELOG.md) |
+| mentedb-core | [crates/mentedb-core/CHANGELOG.md](crates/mentedb-core/CHANGELOG.md) |
+| mentedb-cognitive | [crates/mentedb-cognitive/CHANGELOG.md](crates/mentedb-cognitive/CHANGELOG.md) |
+| mentedb-consolidation | [crates/mentedb-consolidation/CHANGELOG.md](crates/mentedb-consolidation/CHANGELOG.md) |
+| mentedb-context | [crates/mentedb-context/CHANGELOG.md](crates/mentedb-context/CHANGELOG.md) |
+| mentedb-embedding | [crates/mentedb-embedding/CHANGELOG.md](crates/mentedb-embedding/CHANGELOG.md) |
+| mentedb-extraction | [crates/mentedb-extraction/CHANGELOG.md](crates/mentedb-extraction/CHANGELOG.md) |
+| mentedb-graph | [crates/mentedb-graph/CHANGELOG.md](crates/mentedb-graph/CHANGELOG.md) |
+| mentedb-index | [crates/mentedb-index/CHANGELOG.md](crates/mentedb-index/CHANGELOG.md) |
+| mentedb-query | [crates/mentedb-query/CHANGELOG.md](crates/mentedb-query/CHANGELOG.md) |
+| mentedb-storage | [crates/mentedb-storage/CHANGELOG.md](crates/mentedb-storage/CHANGELOG.md) |
+
+## Legacy changelog (pre-0.4.0, managed by release-please)
+
 ## [0.3.1](https://github.com/nambok/mentedb/compare/mentedb-v0.3.0...mentedb-v0.3.1) (2026-04-07)
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Builder stage
-FROM rust:1.85-slim AS builder
+FROM rust:1.88-slim AS builder
 
 RUN apt-get update && apt-get install -y pkg-config libssl-dev protobuf-compiler && rm -rf /var/lib/apt/lists/*
 
@@ -22,4 +22,4 @@ RUN mkdir -p /var/mentedb/data
 
 EXPOSE 8080
 
-CMD ["mentedb-server", "--host", "0.0.0.0", "--port", "8080", "--data-dir", "/var/mentedb/data"]
+CMD ["mentedb-server", "--port", "8080", "--data-dir", "/var/mentedb/data"]

--- a/crates/mentedb-server/src/handlers.rs
+++ b/crates/mentedb-server/src/handlers.rs
@@ -181,14 +181,15 @@ pub async fn get_memory(
         .map_err(|_| ApiError::BadRequest("invalid memory ID".into()))?;
 
     let db = &*state.db;
-    let node = db.get_memory(id).map_err(|_| {
-        ApiError::NotFound(format!("memory {id} not found"))
-    })?;
+    let node = db
+        .get_memory(id)
+        .map_err(|_| ApiError::NotFound(format!("memory {id} not found")))?;
 
     if let Some(Extension(ref authed)) = agent {
-        let tid: AgentId = authed.agent_id.parse().map_err(|_| {
-            ApiError::Internal("token contains invalid agent_id UUID".into())
-        })?;
+        let tid: AgentId = authed
+            .agent_id
+            .parse()
+            .map_err(|_| ApiError::Internal("token contains invalid agent_id UUID".into()))?;
         if node.agent_id != tid {
             return Err(ApiError::Forbidden(
                 "memory belongs to a different agent".into(),

--- a/crates/mentedb-server/src/handlers.rs
+++ b/crates/mentedb-server/src/handlers.rs
@@ -46,17 +46,8 @@ pub async fn health(State(state): State<Arc<AppState>>) -> impl IntoResponse {
 /// Returns database statistics (memory count, index size, etc.).
 pub async fn stats(State(state): State<Arc<AppState>>) -> Result<impl IntoResponse, ApiError> {
     let uptime = state.start_time.elapsed().as_secs();
-
-    // Scan to count memories (no public count method on MenteDb).
     let db = &*state.db;
-    let memory_count = match db.recall("RECALL memories LIMIT 10000") {
-        Ok(window) => window
-            .blocks
-            .iter()
-            .map(|b| b.memories.len())
-            .sum::<usize>(),
-        Err(_) => 0,
-    };
+    let memory_count = db.memory_count();
 
     Ok(Json(json!({
         "memory_count": memory_count,
@@ -189,33 +180,23 @@ pub async fn get_memory(
         .parse()
         .map_err(|_| ApiError::BadRequest("invalid memory ID".into()))?;
 
-    // PointLookup exists in QueryPlan but is not reachable via MQL syntax,
-    // so we scan and filter client-side until MenteDb exposes a public get(id).
     let db = &*state.db;
-    let window = db.recall("RECALL memories LIMIT 1000").map_err(|e| {
-        error!("recall failed: {e}");
+    let node = db.get_memory(id).map_err(|_| {
         ApiError::NotFound(format!("memory {id} not found"))
     })?;
 
-    for block in &window.blocks {
-        for scored in &block.memories {
-            if scored.memory.id == id {
-                if let Some(Extension(ref authed)) = agent {
-                    let tid: AgentId = authed.agent_id.parse().map_err(|_| {
-                        ApiError::Internal("token contains invalid agent_id UUID".into())
-                    })?;
-                    if scored.memory.agent_id != tid {
-                        return Err(ApiError::Forbidden(
-                            "memory belongs to a different agent".into(),
-                        ));
-                    }
-                }
-                return Ok(Json(memory_node_to_json(&scored.memory)));
-            }
+    if let Some(Extension(ref authed)) = agent {
+        let tid: AgentId = authed.agent_id.parse().map_err(|_| {
+            ApiError::Internal("token contains invalid agent_id UUID".into())
+        })?;
+        if node.agent_id != tid {
+            return Err(ApiError::Forbidden(
+                "memory belongs to a different agent".into(),
+            ));
         }
     }
 
-    Err(ApiError::NotFound(format!("memory {id} not found")))
+    Ok(Json(memory_node_to_json(&node)))
 }
 
 // ---------------------------------------------------------------------------

--- a/sdks/typescript/.gitignore
+++ b/sdks/typescript/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+target/
+dist/
+*.node
+npm/*.js
+npm/*.d.ts

--- a/sdks/typescript/.npmignore
+++ b/sdks/typescript/.npmignore
@@ -5,5 +5,4 @@ Cargo.lock
 build.rs
 __tests__/
 tsconfig.json
-*.node
 .cargo/

--- a/sdks/typescript/.npmignore
+++ b/sdks/typescript/.npmignore
@@ -6,3 +6,6 @@ build.rs
 __tests__/
 tsconfig.json
 .cargo/
+npm/client.ts
+npm/index.ts
+npm/types.ts

--- a/sdks/typescript/Cargo.lock
+++ b/sdks/typescript/Cargo.lock
@@ -672,7 +672,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mentedb"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "mentedb-cognitive",
  "mentedb-consolidation",
@@ -691,7 +691,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-cognitive"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "ahash",
  "crossbeam",
@@ -706,7 +706,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-consolidation"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "ahash",
  "mentedb-core",
@@ -717,7 +717,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-context"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "ahash",
  "mentedb-core",
@@ -729,7 +729,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-core"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-embedding"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "mentedb-core",
  "serde",
@@ -756,7 +756,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-extraction"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "mentedb-cognitive",
  "mentedb-core",
@@ -772,7 +772,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-graph"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "ahash",
  "bincode",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-index"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "ahash",
  "bincode",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-query"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "mentedb-core",
  "serde",
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-storage"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "ahash",
  "bincode",

--- a/sdks/typescript/npm/client.ts
+++ b/sdks/typescript/npm/client.ts
@@ -6,22 +6,41 @@ import {
   type SearchResult,
 } from './types';
 
-let nativeBinding: any;
+import * as os from 'os';
+import * as path from 'path';
 
-try {
-  nativeBinding = require('../mentedb.node');
-} catch {
-  nativeBinding = null;
-}
+const PLATFORM_TRIPLES: Record<string, string> = {
+  'linux-x64': 'linux-x64-gnu',
+  'darwin-arm64': 'darwin-arm64',
+  'darwin-x64': 'darwin-x64',
+  'win32-x64': 'win32-x64-msvc',
+};
 
-function requireNative(): any {
-  if (!nativeBinding) {
-    throw new Error(
-      'Native extension not loaded. Build with: npm run build'
-    );
+function loadNativeBinding(): any {
+  const key = `${os.platform()}-${os.arch()}`;
+  const triple = PLATFORM_TRIPLES[key];
+
+  // Try platform-specific binary first (from CI cross-compile)
+  if (triple) {
+    try {
+      return require(path.join(__dirname, '..', `mentedb.${triple}.node`));
+    } catch {}
   }
-  return nativeBinding;
+
+  // Fall back to unqualified binary (local `napi build --release`)
+  try {
+    return require(path.join(__dirname, '..', 'mentedb.node'));
+  } catch {}
+
+  const supported = Object.keys(PLATFORM_TRIPLES).join(', ');
+  throw new Error(
+    `No native binding found for ${key}. ` +
+    `Supported platforms: ${supported}. ` +
+    `Build locally with: cd sdks/typescript && npm run build`
+  );
 }
+
+const nativeBinding = loadNativeBinding();
 
 /**
  * MenteDB client. Wraps the native Rust database engine and exposes a
@@ -32,8 +51,7 @@ export class MenteDB {
   private native: any;
 
   constructor(dataDir: string = './mentedb-data') {
-    const binding = requireNative();
-    this.native = new binding.MenteDB(dataDir);
+    this.native = new nativeBinding.MenteDB(dataDir);
   }
 
   /** Store a memory and return its UUID. */
@@ -87,8 +105,7 @@ export class CognitionStream {
   private native: any;
 
   constructor(bufferSize: number = 1000) {
-    const binding = requireNative();
-    this.native = new binding.JsCognitionStream(bufferSize);
+    this.native = new nativeBinding.JsCognitionStream(bufferSize);
   }
 
   /** Push a token into the stream buffer. */
@@ -109,8 +126,7 @@ export class TrajectoryTracker {
   private native: any;
 
   constructor(maxTurns: number = 100) {
-    const binding = requireNative();
-    this.native = new binding.JsTrajectoryTracker(maxTurns);
+    this.native = new nativeBinding.JsTrajectoryTracker(maxTurns);
   }
 
   /**

--- a/sdks/typescript/npm/client.ts
+++ b/sdks/typescript/npm/client.ts
@@ -51,7 +51,7 @@ export class MenteDB {
   private native: any;
 
   constructor(dataDir: string = './mentedb-data') {
-    this.native = new nativeBinding.MenteDB(dataDir);
+    this.native = new nativeBinding.MenteDb(dataDir);
   }
 
   /** Store a memory and return its UUID. */

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,0 +1,49 @@
+{
+  "name": "mentedb",
+  "version": "0.7.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "mentedb",
+      "version": "0.7.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "typescript": "^6.0.3"
+      },
+      "devDependencies": {
+        "@types/node": "^25.6.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -29,5 +29,9 @@
   "napi": {
     "name": "mentedb",
     "triples": {}
+  },
+  "devDependencies": {
+    "@types/node": "^25.6.0",
+    "typescript": "^6.0.3"
   }
 }

--- a/sdks/typescript/tsconfig.json
+++ b/sdks/typescript/tsconfig.json
@@ -3,15 +3,17 @@
     "target": "ES2020",
     "module": "commonjs",
     "lib": ["ES2020"],
+    "types": ["node"],
     "declaration": true,
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "outDir": "./dist",
+    "outDir": ".",
     "rootDir": ".",
     "resolveJsonModule": true,
-    "moduleResolution": "node"
+    "moduleResolution": "node10",
+    "ignoreDeprecations": "6.0"
   },
   "include": ["npm/**/*.ts"],
   "exclude": ["node_modules", "__tests__"]


### PR DESCRIPTION
## Fixes

### 1. npm publish was broken (published empty package)
- Added Rust toolchain, protobuf compiler, and `@napi-rs/cli` to npm job
- Added `napi build --release` to compile native `.node` binary before publish
- Added TypeScript compilation step (`npx tsc`)
- Removed `*.node` from `.npmignore` so the built binary is included

### 2. LangChain/CrewAI could race with PyPI
- Added `needs: upload-pypi` to `publish-integrations` job
- Ensures `mentedb>=0.7.0` is on PyPI before langchain/crewai packages are published

### 3. Root CHANGELOG.md was stale
- Root changelog hadn't been updated since 0.3.1 (release-please era)
- Converted to a redirect pointing to per-crate changelogs managed by release-plz
- Kept old entries as legacy reference