### PR TITLE
Sleeptime enrichment: foundation, config, API, SDKs

### DIFF
--- a/crates/mentedb-cognitive/src/entity.rs
+++ b/crates/mentedb-cognitive/src/entity.rs
@@ -5,7 +5,7 @@ use std::io;
 use std::path::Path;
 
 const SNAPSHOT_VERSION: u32 = 2;
-const MIN_WORD_LEN: usize = 2;
+
 const WORD_MATCH_CONFIDENCE: f32 = 0.7;
 
 /// Resolves entity references to canonical names using a three-tier strategy:
@@ -205,10 +205,6 @@ impl EntityResolver {
     /// canonical's words or vice versa. Handles "Alice" matching "Alice Smith"
     /// but correctly rejects "Java" matching "JavaScript".
     fn rule_based_match(&self, normalized: &str) -> Option<(String, f32)> {
-        if normalized.len() < MIN_WORD_LEN {
-            return None;
-        }
-
         let input_words: HashSet<&str> = normalized
             .split(|c: char| c.is_whitespace() || c == '-' || c == '_')
             .filter(|w| !w.is_empty())

--- a/crates/mentedb-cognitive/src/entity.rs
+++ b/crates/mentedb-cognitive/src/entity.rs
@@ -1,12 +1,12 @@
 use crate::llm::{CognitiveLlmService, EntityCandidate, EntityMergeGroup, LlmJudge};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::io;
 use std::path::Path;
 
-const SNAPSHOT_VERSION: u32 = 1;
-const MIN_SUBSTRING_LEN: usize = 3;
-const SUBSTRING_CONFIDENCE: f32 = 0.7;
+const SNAPSHOT_VERSION: u32 = 2;
+const MIN_WORD_LEN: usize = 2;
+const WORD_MATCH_CONFIDENCE: f32 = 0.7;
 
 /// Resolves entity references to canonical names using a three-tier strategy:
 ///
@@ -22,6 +22,9 @@ pub struct EntityResolver {
     aliases: HashMap<String, String>,
     /// Tracks confidence for each learned merge.
     confidence: HashMap<String, f32>,
+    /// Pairs of entity names confirmed to be DIFFERENT (negative cache).
+    /// Stored as sorted (a, b) tuples to avoid (A,B) vs (B,A) duplication.
+    negative_pairs: HashSet<(String, String)>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -29,6 +32,8 @@ struct Snapshot {
     version: u32,
     aliases: HashMap<String, String>,
     confidence: HashMap<String, f32>,
+    #[serde(default)]
+    negative_pairs: Vec<(String, String)>,
 }
 
 /// Result of resolving an entity reference.
@@ -56,6 +61,7 @@ impl EntityResolver {
         Self {
             aliases: HashMap::new(),
             confidence: HashMap::new(),
+            negative_pairs: HashSet::new(),
         }
     }
 
@@ -195,10 +201,16 @@ impl EntityResolver {
         self.aliases.len()
     }
 
-    /// Rule-based matching: check if the input is a substring of a known
-    /// canonical or vice versa. Handles "Alice" matching "Alice Smith".
+    /// Rule-based matching: check if the input's words are a subset of a known
+    /// canonical's words or vice versa. Handles "Alice" matching "Alice Smith"
+    /// but correctly rejects "Java" matching "JavaScript".
     fn rule_based_match(&self, normalized: &str) -> Option<(String, f32)> {
-        if normalized.len() < MIN_SUBSTRING_LEN {
+        if normalized.len() < MIN_WORD_LEN {
+            return None;
+        }
+
+        let input_words: HashSet<&str> = normalized.split_whitespace().collect();
+        if input_words.is_empty() {
             return None;
         }
 
@@ -208,12 +220,49 @@ impl EntityResolver {
                 continue;
             }
 
-            // "alice" is a substring of "alice smith"
-            if canonical.contains(normalized) || normalized.contains(canonical.as_str()) {
-                return Some((canonical.clone(), SUBSTRING_CONFIDENCE));
+            let canon_words: HashSet<&str> = canonical.split_whitespace().collect();
+
+            // "alice" ⊂ {"alice", "smith"} → match
+            // "java" ⊄ {"javascript"} → no match (correct!)
+            if input_words.is_subset(&canon_words) || canon_words.is_subset(&input_words) {
+                return Some((canonical.clone(), WORD_MATCH_CONFIDENCE));
             }
         }
         None
+    }
+
+    /// Check if two entity names are known to be different (negative cache).
+    pub fn is_known_different(&self, a: &str, b: &str) -> bool {
+        self.negative_pairs.contains(&Self::negative_key(a, b))
+    }
+
+    /// Mark two entity names as confirmed different (negative cache).
+    pub fn mark_different(&mut self, a: &str, b: &str) {
+        self.negative_pairs.insert(Self::negative_key(a, b));
+    }
+
+    /// Returns the set of entity names that are NOT yet resolved
+    /// (no cache hit, no rule-based match). These need LLM resolution.
+    pub fn unresolved_names(&self, names: &[String]) -> Vec<String> {
+        names
+            .iter()
+            .filter(|name| {
+                let resolved = self.resolve(name);
+                resolved.source == ResolutionSource::Identity
+            })
+            .cloned()
+            .collect()
+    }
+
+    /// Number of negative-cached pairs.
+    pub fn negative_count(&self) -> usize {
+        self.negative_pairs.len()
+    }
+
+    fn negative_key(a: &str, b: &str) -> (String, String) {
+        let na = normalize_entity(a);
+        let nb = normalize_entity(b);
+        if na <= nb { (na, nb) } else { (nb, na) }
     }
 
     /// Save the alias table to a JSON file.
@@ -222,6 +271,7 @@ impl EntityResolver {
             version: SNAPSHOT_VERSION,
             aliases: self.aliases.clone(),
             confidence: self.confidence.clone(),
+            negative_pairs: self.negative_pairs.iter().cloned().collect(),
         };
         let json = serde_json::to_string(&snapshot)
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
@@ -251,6 +301,9 @@ impl EntityResolver {
         }
         for (alias, conf) in snapshot.confidence {
             self.confidence.entry(alias).or_insert(conf);
+        }
+        for pair in snapshot.negative_pairs {
+            self.negative_pairs.insert(pair);
         }
         Ok(())
     }
@@ -307,27 +360,85 @@ mod tests {
     }
 
     #[test]
-    fn test_rule_based_substring_match() {
+    fn test_rule_based_word_match() {
         let mut resolver = EntityResolver::new();
         resolver.add_alias("alice smith", "alice smith", 1.0);
 
-        // "alice" is a substring of "alice smith"
+        // "alice" is a word subset of "alice smith" → match
         let result = resolver.resolve("Alice");
         assert_eq!(result.canonical, "alice smith");
         assert_eq!(result.source, ResolutionSource::RuleBased);
-        assert_eq!(result.confidence, SUBSTRING_CONFIDENCE);
+        assert_eq!(result.confidence, WORD_MATCH_CONFIDENCE);
     }
 
     #[test]
-    fn test_short_names_skip_substring_match() {
+    fn test_word_match_rejects_java_javascript() {
+        let mut resolver = EntityResolver::new();
+        resolver.add_alias("javascript", "javascript", 1.0);
+
+        // "java" is NOT a word match for "javascript" — different words
+        let result = resolver.resolve("Java");
+        assert_eq!(result.canonical, "java");
+        assert_eq!(result.source, ResolutionSource::Identity);
+    }
+
+    #[test]
+    fn test_short_names_skip_word_match() {
         let mut resolver = EntityResolver::new();
         resolver.add_alias("db", "database", 1.0);
 
-        // "db" is too short for substring matching (< 3 chars)
         let result = resolver.resolve("db");
         // Should hit cache directly since we added it as an alias
         assert_eq!(result.canonical, "database");
         assert_eq!(result.source, ResolutionSource::Cache);
+    }
+
+    #[test]
+    fn test_negative_cache() {
+        let mut resolver = EntityResolver::new();
+
+        assert!(!resolver.is_known_different("Python", "python snake"));
+
+        resolver.mark_different("Python", "python snake");
+        assert!(resolver.is_known_different("Python", "python snake"));
+        // Order shouldn't matter
+        assert!(resolver.is_known_different("python snake", "Python"));
+    }
+
+    #[test]
+    fn test_negative_cache_persistence() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("entities.json");
+
+        let mut resolver = EntityResolver::new();
+        resolver.mark_different("Python", "Monty Python");
+        resolver.add_alias("alice", "alice smith", 0.9);
+        resolver.save(&path).unwrap();
+
+        let mut loaded = EntityResolver::new();
+        loaded.load(&path).unwrap();
+
+        assert!(loaded.is_known_different("Python", "Monty Python"));
+        assert_eq!(
+            loaded.get_canonical("alice"),
+            Some(&"alice smith".to_string())
+        );
+    }
+
+    #[test]
+    fn test_unresolved_names() {
+        let mut resolver = EntityResolver::new();
+        resolver.add_alias("alice", "alice smith", 0.9);
+        resolver.add_alias("bob", "bob jones", 0.9);
+
+        let names = vec![
+            "Alice".to_string(),
+            "Bob".to_string(),
+            "Charlie".to_string(),
+            "NYC".to_string(),
+        ];
+        let unresolved = resolver.unresolved_names(&names);
+        assert_eq!(unresolved, vec!["Charlie".to_string(), "NYC".to_string()]);
     }
 
     #[test]

--- a/crates/mentedb-cognitive/src/entity.rs
+++ b/crates/mentedb-cognitive/src/entity.rs
@@ -209,7 +209,10 @@ impl EntityResolver {
             return None;
         }
 
-        let input_words: HashSet<&str> = normalized.split_whitespace().collect();
+        let input_words: HashSet<&str> = normalized
+            .split(|c: char| c.is_whitespace() || c == '-' || c == '_')
+            .filter(|w| !w.is_empty())
+            .collect();
         if input_words.is_empty() {
             return None;
         }
@@ -220,7 +223,10 @@ impl EntityResolver {
                 continue;
             }
 
-            let canon_words: HashSet<&str> = canonical.split_whitespace().collect();
+            let canon_words: HashSet<&str> = canonical
+                .split(|c: char| c.is_whitespace() || c == '-' || c == '_')
+                .filter(|w| !w.is_empty())
+                .collect();
 
             // "alice" ⊂ {"alice", "smith"} → match
             // "java" ⊄ {"javascript"} → no match (correct!)
@@ -380,6 +386,17 @@ mod tests {
         let result = resolver.resolve("Java");
         assert_eq!(result.canonical, "java");
         assert_eq!(result.source, ResolutionSource::Identity);
+    }
+
+    #[test]
+    fn test_hyphenated_names_match() {
+        let mut resolver = EntityResolver::new();
+        resolver.add_alias("gpt-4", "gpt-4", 1.0);
+
+        // "gpt 4" should match "gpt-4" via hyphen-aware word splitting
+        let result = resolver.resolve("gpt 4");
+        assert_eq!(result.canonical, "gpt-4");
+        assert_eq!(result.source, ResolutionSource::RuleBased);
     }
 
     #[test]

--- a/crates/mentedb-extraction/src/pipeline.rs
+++ b/crates/mentedb-extraction/src/pipeline.rs
@@ -6,7 +6,7 @@ use mentedb_embedding::provider::EmbeddingProvider;
 use crate::config::ExtractionConfig;
 use crate::error::ExtractionError;
 use crate::provider::ExtractionProvider;
-use crate::schema::{ExtractedMemory, ExtractionResult};
+use crate::schema::{ExtractedEntity, ExtractedMemory, ExtractionResult};
 
 /// Findings from cognitive checks (contradiction detection).
 #[derive(Debug, Clone)]
@@ -49,6 +49,8 @@ pub struct ProcessedExtractionResult {
     pub rejected_duplicate: Vec<ExtractedMemory>,
     /// Memories that contradict existing ones (stored anyway, with findings).
     pub contradictions: Vec<(ExtractedMemory, Vec<CognitiveFinding>)>,
+    /// Entities extracted from the conversation.
+    pub entities: Vec<ExtractedEntity>,
     /// Summary statistics.
     pub stats: ExtractionStats,
 }
@@ -353,7 +355,9 @@ impl<P: ExtractionProvider> ExtractionPipeline<P> {
         existing_memories: &[MemoryNode],
         embedding_provider: &dyn EmbeddingProvider,
     ) -> Result<ProcessedExtractionResult, ExtractionError> {
-        let all_memories = self.extract_from_conversation(conversation).await?;
+        let full_result = self.extract_full(conversation).await?;
+        let all_memories = full_result.memories;
+        let entities = full_result.entities;
         let total_extracted = all_memories.len();
 
         let quality_passed = self.filter_quality(&all_memories);
@@ -408,6 +412,7 @@ impl<P: ExtractionProvider> ExtractionPipeline<P> {
             rejected_low_quality,
             rejected_duplicate,
             contradictions,
+            entities,
             stats,
         })
     }

--- a/crates/mentedb/src/lib.rs
+++ b/crates/mentedb/src/lib.rs
@@ -128,6 +128,10 @@ pub struct EnrichmentConfig {
     pub max_enrichment_confidence: f32,
     /// Whether to generate a user model summary. Default: false.
     pub enable_user_model: bool,
+    /// Embedding similarity threshold to merge entities. Default: 0.7.
+    pub entity_merge_threshold: f32,
+    /// Embedding similarity below which entities are kept separate. Default: 0.4.
+    pub entity_separate_threshold: f32,
 }
 
 impl Default for EnrichmentConfig {
@@ -138,6 +142,8 @@ impl Default for EnrichmentConfig {
             min_confidence: 0.6,
             max_enrichment_confidence: 0.7,
             enable_user_model: false,
+            entity_merge_threshold: 0.7,
+            entity_separate_threshold: 0.4,
         }
     }
 }
@@ -157,6 +163,21 @@ pub struct EnrichmentResult {
     pub contradictions_found: usize,
     /// Turn ID at which enrichment was completed.
     pub completed_at_turn: u64,
+    /// Number of entity links created (Related edges between same-name entities).
+    pub entities_linked: usize,
+    /// Number of entity pairs left ambiguous (below merge threshold).
+    pub entities_ambiguous: usize,
+}
+
+/// Result of a single entity linking run.
+#[derive(Debug, Clone, Default)]
+pub struct EntityLinkResult {
+    /// Number of entity pairs linked with Related edges.
+    pub linked: usize,
+    /// Number of entity pairs tagged as ambiguous (MaybeRelated).
+    pub ambiguous: usize,
+    /// Number of edges created.
+    pub edges_created: usize,
 }
 
 /// Configuration for the cognitive engine subsystems.
@@ -1677,5 +1698,120 @@ impl MenteDb {
     /// Get the enrichment configuration.
     pub fn enrichment_config(&self) -> &EnrichmentConfig {
         &self.cognitive_config.enrichment_config
+    }
+
+    /// Link entities across sessions by name + embedding similarity.
+    ///
+    /// Scans all semantic memories tagged with `entity:{name}`, groups by
+    /// normalized entity name, then compares embedding similarity within
+    /// each group to decide:
+    /// - **Merge** (sim ≥ merge_threshold): create `Related` edge (weight = similarity)
+    /// - **Ambiguous** (separate_threshold ≤ sim < merge_threshold): tag `maybe_related:{other_id}`
+    /// - **Separate** (sim < separate_threshold): no action
+    ///
+    /// Conservative: when in doubt, don't merge. Two separate nodes > one wrong merge.
+    pub fn link_entities(&self) -> MenteResult<EntityLinkResult> {
+        let merge_thresh = self
+            .cognitive_config
+            .enrichment_config
+            .entity_merge_threshold;
+        let separate_thresh = self
+            .cognitive_config
+            .enrichment_config
+            .entity_separate_threshold;
+        let pm = self.page_map.read();
+
+        // Collect all entity memories grouped by normalized name
+        let mut entity_groups: HashMap<String, Vec<MemoryNode>> = HashMap::new();
+        for pid in pm.values() {
+            if let Ok(mem) = self.storage.load_memory(*pid) {
+                for tag in &mem.tags {
+                    if let Some(name) = tag.strip_prefix("entity:") {
+                        let normalized = name.to_lowercase().trim().to_string();
+                        entity_groups
+                            .entry(normalized)
+                            .or_default()
+                            .push(mem.clone());
+                        break;
+                    }
+                }
+            }
+        }
+
+        let mut result = EntityLinkResult::default();
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_micros() as u64;
+
+        for (entity_name, members) in &entity_groups {
+            if members.len() < 2 {
+                continue;
+            }
+
+            // Compare all pairs within the group
+            for i in 0..members.len() {
+                for j in (i + 1)..members.len() {
+                    let a = &members[i];
+                    let b = &members[j];
+
+                    if a.embedding.is_empty() || b.embedding.is_empty() {
+                        continue;
+                    }
+
+                    let sim = mentedb_consolidation::cosine_similarity(&a.embedding, &b.embedding);
+
+                    if sim >= merge_thresh {
+                        // High confidence: create Related edge
+                        let edge = MemoryEdge {
+                            source: a.id,
+                            target: b.id,
+                            edge_type: EdgeType::Related,
+                            weight: sim,
+                            created_at: now,
+                            valid_from: None,
+                            valid_until: None,
+                            label: Some(format!("entity_link:{}", entity_name)),
+                        };
+                        if self.relate(edge).is_ok() {
+                            result.edges_created += 1;
+                        }
+                        result.linked += 1;
+                        debug!(
+                            entity = entity_name,
+                            a = %a.id, b = %b.id, sim,
+                            "entity link: merged"
+                        );
+                    } else if sim >= separate_thresh {
+                        // Ambiguous: tag for later resolution
+                        result.ambiguous += 1;
+                        debug!(
+                            entity = entity_name,
+                            a = %a.id, b = %b.id, sim,
+                            "entity link: ambiguous"
+                        );
+                    }
+                    // Below separate_threshold: different entities, no action
+                }
+            }
+        }
+
+        debug!(
+            linked = result.linked,
+            ambiguous = result.ambiguous,
+            edges = result.edges_created,
+            groups = entity_groups.len(),
+            "entity linking complete"
+        );
+        Ok(result)
+    }
+
+    /// Get all entity memory nodes (memories tagged with `entity:{name}`).
+    pub fn entity_memories(&self) -> Vec<MemoryNode> {
+        let pm = self.page_map.read();
+        pm.values()
+            .filter_map(|pid| self.storage.load_memory(*pid).ok())
+            .filter(|m| m.tags.iter().any(|t| t.starts_with("entity:")))
+            .collect()
     }
 }

--- a/crates/mentedb/src/lib.rs
+++ b/crates/mentedb/src/lib.rs
@@ -1762,6 +1762,21 @@ impl MenteDb {
                     let sim = mentedb_consolidation::cosine_similarity(&a.embedding, &b.embedding);
 
                     if sim >= merge_thresh {
+                        // Check if edge already exists to avoid duplicates on repeated runs
+                        let graph = self.graph.read_graph();
+                        let already_linked = graph.outgoing(a.id).iter().any(|(tid, e)| {
+                            *tid == b.id
+                                && e.edge_type == EdgeType::Related
+                                && e.label
+                                    .as_ref()
+                                    .is_some_and(|l| l.starts_with("entity_link:"))
+                        });
+                        drop(graph);
+
+                        if already_linked {
+                            continue;
+                        }
+
                         // High confidence: create Related edge
                         let edge = MemoryEdge {
                             source: a.id,

--- a/crates/mentedb/src/lib.rs
+++ b/crates/mentedb/src/lib.rs
@@ -1774,9 +1774,8 @@ impl MenteDb {
                                 if existing.len() < 300 {
                                     existing.push_str(" | ");
                                     let remaining = 500usize.saturating_sub(existing.len());
-                                    existing.push_str(
-                                        &mem.content[..mem.content.len().min(remaining)],
-                                    );
+                                    existing
+                                        .push_str(&mem.content[..mem.content.len().min(remaining)]);
                                 }
                             })
                             .or_insert_with(|| {

--- a/crates/mentedb/src/lib.rs
+++ b/crates/mentedb/src/lib.rs
@@ -1614,9 +1614,9 @@ impl MenteDb {
     /// sorted by creation time. These are the candidates for LLM extraction.
     pub fn enrichment_candidates(&self) -> Vec<MemoryNode> {
         let last_turn = *self.last_enrichment_turn.read();
-        let pm = self.page_map.read();
-        let mut candidates: Vec<MemoryNode> = pm
-            .values()
+        let page_ids: Vec<PageId> = self.page_map.read().values().copied().collect();
+        let mut candidates: Vec<MemoryNode> = page_ids
+            .iter()
             .filter_map(|pid| self.storage.load_memory(*pid).ok())
             .filter(|m| {
                 m.memory_type == mentedb_core::memory::MemoryType::Episodic
@@ -1719,11 +1719,13 @@ impl MenteDb {
             .cognitive_config
             .enrichment_config
             .entity_separate_threshold;
-        let pm = self.page_map.read();
+
+        // Collect page IDs under lock, then drop before loading memories
+        let page_ids: Vec<PageId> = self.page_map.read().values().copied().collect();
 
         // Collect all entity memories grouped by normalized name
         let mut entity_groups: HashMap<String, Vec<MemoryNode>> = HashMap::new();
-        for pid in pm.values() {
+        for pid in &page_ids {
             if let Ok(mem) = self.storage.load_memory(*pid) {
                 for tag in &mem.tags {
                     if let Some(name) = tag.strip_prefix("entity:") {
@@ -1823,8 +1825,9 @@ impl MenteDb {
 
     /// Get all entity memory nodes (memories tagged with `entity:{name}`).
     pub fn entity_memories(&self) -> Vec<MemoryNode> {
-        let pm = self.page_map.read();
-        pm.values()
+        let page_ids: Vec<PageId> = self.page_map.read().values().copied().collect();
+        page_ids
+            .iter()
             .filter_map(|pid| self.storage.load_memory(*pid).ok())
             .filter(|m| m.tags.iter().any(|t| t.starts_with("entity:")))
             .collect()

--- a/crates/mentedb/src/lib.rs
+++ b/crates/mentedb/src/lib.rs
@@ -46,6 +46,7 @@ use std::path::{Path, PathBuf};
 
 use mentedb_cognitive::EntityResolver;
 use mentedb_cognitive::interference::{InterferenceDetector, InterferencePair};
+use mentedb_cognitive::llm::EntityMergeGroup;
 use mentedb_cognitive::pain::{PainRegistry, PainSignal};
 use mentedb_cognitive::phantom::{PhantomConfig, PhantomMemory, PhantomTracker};
 use mentedb_cognitive::speculative::{CacheEntry, CacheStats, SpeculativeCache};
@@ -178,6 +179,27 @@ pub struct EntityLinkResult {
     pub ambiguous: usize,
     /// Number of edges created.
     pub edges_created: usize,
+}
+
+/// A confirmed entity resolution from an external resolver (LLM).
+///
+/// Used to feed LLM entity resolution results back into the engine
+/// so it can create graph edges and update the EntityResolver cache.
+#[derive(Debug, Clone)]
+pub struct EntityLinkResolution {
+    /// The canonical entity name decided by the resolver.
+    pub canonical: String,
+    /// All aliases that map to this canonical name.
+    pub aliases: Vec<String>,
+    /// Confidence in this resolution (0.0 to 1.0).
+    pub confidence: f32,
+}
+
+/// A pair of entity names that the LLM confirmed are DIFFERENT entities.
+#[derive(Debug, Clone)]
+pub struct EntitySeparation {
+    pub name_a: String,
+    pub name_b: String,
 }
 
 /// Configuration for the cognitive engine subsystems.
@@ -1700,45 +1722,221 @@ impl MenteDb {
         &self.cognitive_config.enrichment_config
     }
 
-    /// Link entities across sessions by name + embedding similarity.
+    /// Get all unique entity names from stored entity memories.
     ///
-    /// Scans all semantic memories tagged with `entity:{name}`, groups by
-    /// normalized entity name, then compares embedding similarity within
-    /// each group to decide:
-    /// - **Merge** (sim ≥ merge_threshold): create `Related` edge (weight = similarity)
-    /// - **Ambiguous** (separate_threshold ≤ sim < merge_threshold): tag `maybe_related:{other_id}`
-    /// - **Separate** (sim < separate_threshold): no action
-    ///
-    /// Conservative: when in doubt, don't merge. Two separate nodes > one wrong merge.
-    pub fn link_entities(&self) -> MenteResult<EntityLinkResult> {
-        let merge_thresh = self
-            .cognitive_config
-            .enrichment_config
-            .entity_merge_threshold;
-        let separate_thresh = self
-            .cognitive_config
-            .enrichment_config
-            .entity_separate_threshold;
-
-        // Collect page IDs under lock, then drop before loading memories
+    /// Returns deduplicated, normalized entity names extracted from
+    /// `entity:{name}` tags across all stored memories.
+    pub fn all_entity_names(&self) -> Vec<String> {
         let page_ids: Vec<PageId> = self.page_map.read().values().copied().collect();
+        let mut names = std::collections::HashSet::new();
+        for pid in &page_ids {
+            if let Ok(mem) = self.storage.load_memory(*pid) {
+                for tag in &mem.tags {
+                    if let Some(name) = tag.strip_prefix("entity:") {
+                        names.insert(name.to_lowercase().trim().to_string());
+                    }
+                }
+            }
+        }
+        let mut sorted: Vec<String> = names.into_iter().collect();
+        sorted.sort();
+        sorted
+    }
 
-        // Collect all entity memories grouped by normalized name
-        let mut entity_groups: HashMap<String, Vec<MemoryNode>> = HashMap::new();
+    /// Get entity names that the EntityResolver hasn't resolved yet.
+    ///
+    /// These are the entities that need LLM resolution. The EntityResolver
+    /// cache handles known entities for free.
+    pub fn unresolved_entity_names(&self) -> Vec<String> {
+        let all_names = self.all_entity_names();
+        self.entity_resolver.read().unresolved_names(&all_names)
+    }
+
+    /// Get entity names with their memory content for LLM context.
+    ///
+    /// Returns (name, content) pairs for entities that need resolution.
+    /// The content helps the LLM disambiguate (e.g., "Python" near
+    /// "web framework" vs "Python" near "Monty Python").
+    pub fn entity_names_with_context(&self) -> Vec<(String, Option<String>)> {
+        let page_ids: Vec<PageId> = self.page_map.read().values().copied().collect();
+        let mut entity_contexts: HashMap<String, String> = HashMap::new();
+
         for pid in &page_ids {
             if let Ok(mem) = self.storage.load_memory(*pid) {
                 for tag in &mem.tags {
                     if let Some(name) = tag.strip_prefix("entity:") {
                         let normalized = name.to_lowercase().trim().to_string();
-                        entity_groups
+                        entity_contexts
                             .entry(normalized)
-                            .or_default()
-                            .push(mem.clone());
+                            .and_modify(|existing| {
+                                // Append content from multiple mentions, cap at 500 chars
+                                if existing.len() < 500 {
+                                    existing.push_str(" | ");
+                                    existing.push_str(&mem.content[..mem.content.len().min(200)]);
+                                }
+                            })
+                            .or_insert_with(|| {
+                                mem.content[..mem.content.len().min(300)].to_string()
+                            });
                         break;
                     }
                 }
             }
         }
+
+        entity_contexts
+            .into_iter()
+            .map(|(name, ctx)| (name, Some(ctx)))
+            .collect()
+    }
+
+    /// Apply LLM entity resolution results: create graph edges and update cache.
+    ///
+    /// Takes merge groups from the LLM (via `CognitiveLlmService.resolve_entities()`)
+    /// and confirmed-different pairs. Creates `entity_link:` edges between entity
+    /// memories that belong to the same group, learns aliases in the EntityResolver,
+    /// and negative-caches confirmed-different pairs.
+    pub fn apply_entity_link_resolutions(
+        &self,
+        merge_groups: &[EntityLinkResolution],
+        separations: &[EntitySeparation],
+    ) -> MenteResult<EntityLinkResult> {
+        let mut result = EntityLinkResult::default();
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_micros() as u64;
+
+        // Build a map: normalized entity name → list of memory IDs
+        let entity_memory_map = self.build_entity_memory_map();
+
+        let mut resolver = self.entity_resolver.write();
+
+        for group in merge_groups {
+            // Learn the group in the resolver cache
+            let mut aliases: Vec<String> = group.aliases.clone();
+            aliases.retain(|a| a.to_lowercase() != group.canonical.to_lowercase());
+            resolver.learn_group(&EntityMergeGroup {
+                canonical: group.canonical.clone(),
+                aliases,
+                confidence: group.confidence,
+            });
+
+            // Collect all memory IDs for this merge group
+            let mut group_memory_ids: Vec<MemoryId> = Vec::new();
+
+            // Add memories for the canonical name
+            let canonical_norm = group.canonical.to_lowercase();
+            if let Some(ids) = entity_memory_map.get(&canonical_norm) {
+                group_memory_ids.extend(ids);
+            }
+
+            // Add memories for each alias
+            for alias in &group.aliases {
+                let alias_norm = alias.to_lowercase();
+                if let Some(ids) = entity_memory_map.get(&alias_norm) {
+                    group_memory_ids.extend(ids);
+                }
+            }
+
+            group_memory_ids.sort();
+            group_memory_ids.dedup();
+
+            // Create edges between all pairs in the group
+            let label = format!("entity_link:{}", canonical_norm);
+            for i in 0..group_memory_ids.len() {
+                for j in (i + 1)..group_memory_ids.len() {
+                    let a_id = group_memory_ids[i];
+                    let b_id = group_memory_ids[j];
+
+                    // Check for existing edge
+                    let graph = self.graph.read_graph();
+                    let already_linked = graph.outgoing(a_id).iter().any(|(tid, e)| {
+                        *tid == b_id
+                            && e.edge_type == EdgeType::Related
+                            && e.label
+                                .as_ref()
+                                .is_some_and(|l| l.starts_with("entity_link:"))
+                    });
+                    drop(graph);
+
+                    if already_linked {
+                        continue;
+                    }
+
+                    let edge = MemoryEdge {
+                        source: a_id,
+                        target: b_id,
+                        edge_type: EdgeType::Related,
+                        weight: group.confidence,
+                        created_at: now,
+                        valid_from: None,
+                        valid_until: None,
+                        label: Some(label.clone()),
+                    };
+                    if self.relate(edge).is_ok() {
+                        result.edges_created += 1;
+                    }
+                    result.linked += 1;
+                }
+            }
+
+            debug!(
+                canonical = group.canonical,
+                aliases = ?group.aliases,
+                memories = group_memory_ids.len(),
+                "entity resolution: merged group"
+            );
+        }
+
+        // Process negative cache entries
+        for sep in separations {
+            resolver.mark_different(&sep.name_a, &sep.name_b);
+            debug!(
+                a = sep.name_a,
+                b = sep.name_b,
+                "entity resolution: confirmed different"
+            );
+        }
+
+        // Persist resolver state
+        let cognitive_dir = self.path.join("cognitive");
+        if cognitive_dir.exists() || std::fs::create_dir_all(&cognitive_dir).is_ok() {
+            let _ = resolver.save(&cognitive_dir.join("entities.json"));
+        }
+
+        debug!(
+            linked = result.linked,
+            edges = result.edges_created,
+            groups = merge_groups.len(),
+            separations = separations.len(),
+            "entity link resolutions applied"
+        );
+        Ok(result)
+    }
+
+    /// Link entities using only the sync EntityResolver (cache + rules, no LLM).
+    ///
+    /// This is the fast path — links entities that are already known to be
+    /// the same from previous LLM resolutions. For full LLM-powered resolution,
+    /// use `unresolved_entity_names()` + `apply_entity_link_resolutions()`.
+    pub fn link_entities(&self) -> MenteResult<EntityLinkResult> {
+        let entity_memory_map = self.build_entity_memory_map();
+        let resolver = self.entity_resolver.read();
+
+        // Group entity names by their resolved canonical name
+        let mut canonical_groups: HashMap<String, Vec<String>> = HashMap::new();
+        for entity_name in entity_memory_map.keys() {
+            let resolved = resolver.resolve(entity_name);
+            if resolved.source != mentedb_cognitive::ResolutionSource::Identity {
+                canonical_groups
+                    .entry(resolved.canonical.clone())
+                    .or_default()
+                    .push(entity_name.clone());
+            }
+        }
+
+        drop(resolver);
 
         let mut result = EntityLinkResult::default();
         let now = std::time::SystemTime::now()
@@ -1746,81 +1944,88 @@ impl MenteDb {
             .unwrap_or_default()
             .as_micros() as u64;
 
-        for (entity_name, members) in &entity_groups {
-            if members.len() < 2 {
+        for (canonical, names) in &canonical_groups {
+            // Collect all memory IDs across all aliases in this group
+            let mut group_memory_ids: Vec<MemoryId> = Vec::new();
+            for name in names {
+                if let Some(ids) = entity_memory_map.get(name) {
+                    group_memory_ids.extend(ids);
+                }
+            }
+            // Also include the canonical name itself
+            if let Some(ids) = entity_memory_map.get(canonical) {
+                group_memory_ids.extend(ids);
+            }
+            group_memory_ids.sort();
+            group_memory_ids.dedup();
+
+            if group_memory_ids.len() < 2 {
                 continue;
             }
 
-            // Compare all pairs within the group
-            for i in 0..members.len() {
-                for j in (i + 1)..members.len() {
-                    let a = &members[i];
-                    let b = &members[j];
+            let label = format!("entity_link:{}", canonical);
+            for i in 0..group_memory_ids.len() {
+                for j in (i + 1)..group_memory_ids.len() {
+                    let a_id = group_memory_ids[i];
+                    let b_id = group_memory_ids[j];
 
-                    if a.embedding.is_empty() || b.embedding.is_empty() {
+                    let graph = self.graph.read_graph();
+                    let already_linked = graph.outgoing(a_id).iter().any(|(tid, e)| {
+                        *tid == b_id
+                            && e.edge_type == EdgeType::Related
+                            && e.label
+                                .as_ref()
+                                .is_some_and(|l| l.starts_with("entity_link:"))
+                    });
+                    drop(graph);
+
+                    if already_linked {
                         continue;
                     }
 
-                    let sim = mentedb_consolidation::cosine_similarity(&a.embedding, &b.embedding);
-
-                    if sim >= merge_thresh {
-                        // Check if edge already exists to avoid duplicates on repeated runs
-                        let graph = self.graph.read_graph();
-                        let already_linked = graph.outgoing(a.id).iter().any(|(tid, e)| {
-                            *tid == b.id
-                                && e.edge_type == EdgeType::Related
-                                && e.label
-                                    .as_ref()
-                                    .is_some_and(|l| l.starts_with("entity_link:"))
-                        });
-                        drop(graph);
-
-                        if already_linked {
-                            continue;
-                        }
-
-                        // High confidence: create Related edge
-                        let edge = MemoryEdge {
-                            source: a.id,
-                            target: b.id,
-                            edge_type: EdgeType::Related,
-                            weight: sim,
-                            created_at: now,
-                            valid_from: None,
-                            valid_until: None,
-                            label: Some(format!("entity_link:{}", entity_name)),
-                        };
-                        if self.relate(edge).is_ok() {
-                            result.edges_created += 1;
-                        }
-                        result.linked += 1;
-                        debug!(
-                            entity = entity_name,
-                            a = %a.id, b = %b.id, sim,
-                            "entity link: merged"
-                        );
-                    } else if sim >= separate_thresh {
-                        // Ambiguous: tag for later resolution
-                        result.ambiguous += 1;
-                        debug!(
-                            entity = entity_name,
-                            a = %a.id, b = %b.id, sim,
-                            "entity link: ambiguous"
-                        );
+                    let edge = MemoryEdge {
+                        source: a_id,
+                        target: b_id,
+                        edge_type: EdgeType::Related,
+                        weight: 1.0,
+                        created_at: now,
+                        valid_from: None,
+                        valid_until: None,
+                        label: Some(label.clone()),
+                    };
+                    if self.relate(edge).is_ok() {
+                        result.edges_created += 1;
                     }
-                    // Below separate_threshold: different entities, no action
+                    result.linked += 1;
                 }
             }
         }
 
         debug!(
             linked = result.linked,
-            ambiguous = result.ambiguous,
             edges = result.edges_created,
-            groups = entity_groups.len(),
-            "entity linking complete"
+            groups = canonical_groups.len(),
+            "sync entity linking complete"
         );
         Ok(result)
+    }
+
+    /// Build a map of normalized entity name → list of MemoryIds.
+    fn build_entity_memory_map(&self) -> HashMap<String, Vec<MemoryId>> {
+        let page_ids: Vec<PageId> = self.page_map.read().values().copied().collect();
+        let mut map: HashMap<String, Vec<MemoryId>> = HashMap::new();
+        for pid in &page_ids {
+            if let Ok(mem) = self.storage.load_memory(*pid) {
+                for tag in &mem.tags {
+                    if let Some(name) = tag.strip_prefix("entity:") {
+                        let normalized = name.to_lowercase().trim().to_string();
+                        map.entry(normalized).or_default().push(mem.id);
+                        break;
+                    }
+                }
+            }
+        }
+        map
     }
 
     /// Get all entity memory nodes (memories tagged with `entity:{name}`).

--- a/crates/mentedb/src/lib.rs
+++ b/crates/mentedb/src/lib.rs
@@ -1766,13 +1766,17 @@ impl MenteDb {
                 for tag in &mem.tags {
                     if let Some(name) = tag.strip_prefix("entity:") {
                         let normalized = name.to_lowercase().trim().to_string();
+                        // One entity tag per memory (enrichment creates separate memories per entity)
                         entity_contexts
                             .entry(normalized)
                             .and_modify(|existing| {
-                                // Append content from multiple mentions, cap at 500 chars
-                                if existing.len() < 500 {
+                                // Append content from multiple mentions, cap at ~500 chars
+                                if existing.len() < 300 {
                                     existing.push_str(" | ");
-                                    existing.push_str(&mem.content[..mem.content.len().min(200)]);
+                                    let remaining = 500usize.saturating_sub(existing.len());
+                                    existing.push_str(
+                                        &mem.content[..mem.content.len().min(remaining)],
+                                    );
                                 }
                             })
                             .or_insert_with(|| {
@@ -2019,6 +2023,7 @@ impl MenteDb {
                 for tag in &mem.tags {
                     if let Some(name) = tag.strip_prefix("entity:") {
                         let normalized = name.to_lowercase().trim().to_string();
+                        // One entity tag per memory (enrichment creates separate memories per entity)
                         map.entry(normalized).or_default().push(mem.id);
                         break;
                     }

--- a/crates/mentedb/src/lib.rs
+++ b/crates/mentedb/src/lib.rs
@@ -111,6 +111,54 @@ use mentedb_storage::PageId;
 /// Mapping from MemoryId to the storage PageId where it lives.
 use std::collections::HashMap;
 
+/// Configuration for sleeptime enrichment pipeline.
+///
+/// Enrichment runs BETWEEN conversations, never in the hot path.
+/// The engine tracks state and provides candidates; callers invoke
+/// the async LLM pipeline when ready.
+#[derive(Debug, Clone)]
+pub struct EnrichmentConfig {
+    /// Whether enrichment is enabled. Default: false (opt-in).
+    pub enabled: bool,
+    /// Run enrichment after this many process_turn calls. Default: 50.
+    pub trigger_interval: u64,
+    /// Minimum confidence for extracted memories to be stored. Default: 0.6.
+    pub min_confidence: f32,
+    /// Maximum confidence for enrichment-generated memories. Default: 0.7.
+    pub max_enrichment_confidence: f32,
+    /// Whether to generate a user model summary. Default: false.
+    pub enable_user_model: bool,
+}
+
+impl Default for EnrichmentConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            trigger_interval: 50,
+            min_confidence: 0.6,
+            max_enrichment_confidence: 0.7,
+            enable_user_model: false,
+        }
+    }
+}
+
+/// Result of running the enrichment pipeline.
+#[derive(Debug, Clone, Default)]
+pub struct EnrichmentResult {
+    /// Number of new memories stored from extraction.
+    pub memories_stored: usize,
+    /// Number of entity nodes created or updated.
+    pub entities_processed: usize,
+    /// Number of edges created (Derived, Related, PartOf).
+    pub edges_created: usize,
+    /// Number of memories skipped as duplicates.
+    pub duplicates_skipped: usize,
+    /// Number of contradictions detected.
+    pub contradictions_found: usize,
+    /// Turn ID at which enrichment was completed.
+    pub completed_at_turn: u64,
+}
+
 /// Configuration for the cognitive engine subsystems.
 #[derive(Debug, Clone)]
 pub struct CognitiveConfig {
@@ -138,6 +186,8 @@ pub struct CognitiveConfig {
     pub archival_config: ArchivalConfig,
     /// Configuration for the cognition stream.
     pub stream_config: StreamConfig,
+    /// Configuration for sleeptime enrichment.
+    pub enrichment_config: EnrichmentConfig,
     /// Similarity threshold for interference detection.
     pub interference_threshold: f32,
     /// Maximum trajectory turns to track.
@@ -163,6 +213,7 @@ impl Default for CognitiveConfig {
             phantom_config: PhantomConfig::default(),
             archival_config: ArchivalConfig::default(),
             stream_config: StreamConfig::default(),
+            enrichment_config: EnrichmentConfig::default(),
             interference_threshold: 0.8,
             trajectory_max_turns: 100,
             speculative_cache_size: 10,
@@ -217,6 +268,10 @@ pub struct MenteDb {
     compressor: MemoryCompressor,
     /// Archival pipeline for lifecycle evaluation.
     archival: ArchivalPipeline,
+    /// Turn ID of the last completed enrichment cycle.
+    last_enrichment_turn: RwLock<u64>,
+    /// Whether enrichment is currently pending (set by maintenance trigger).
+    enrichment_pending: RwLock<bool>,
 }
 
 impl MenteDb {
@@ -313,6 +368,8 @@ impl MenteDb {
             entity_resolver,
             compressor,
             archival,
+            last_enrichment_turn: RwLock::new(0),
+            enrichment_pending: RwLock::new(false),
         })
     }
 
@@ -1506,5 +1563,119 @@ impl MenteDb {
             .collect();
         drop(pm);
         Ok(self.archival.evaluate_batch(&memories, now))
+    }
+
+    // -----------------------------------------------------------------------
+    // Sleeptime Enrichment Pipeline
+    // -----------------------------------------------------------------------
+
+    /// Check whether enrichment is pending (triggered by turn count or manual).
+    pub fn needs_enrichment(&self) -> bool {
+        if !self.cognitive_config.enrichment_config.enabled {
+            return false;
+        }
+        *self.enrichment_pending.read()
+    }
+
+    /// Get the turn ID when enrichment last completed.
+    pub fn last_enrichment_turn(&self) -> u64 {
+        *self.last_enrichment_turn.read()
+    }
+
+    /// Manually trigger enrichment on the next check.
+    pub fn request_enrichment(&self) {
+        *self.enrichment_pending.write() = true;
+    }
+
+    /// Get episodic memories that haven't been enriched yet.
+    ///
+    /// Returns all Episodic memories created after the last enrichment turn,
+    /// sorted by creation time. These are the candidates for LLM extraction.
+    pub fn enrichment_candidates(&self) -> Vec<MemoryNode> {
+        let last_turn = *self.last_enrichment_turn.read();
+        let pm = self.page_map.read();
+        let mut candidates: Vec<MemoryNode> = pm
+            .values()
+            .filter_map(|pid| self.storage.load_memory(*pid).ok())
+            .filter(|m| {
+                m.memory_type == mentedb_core::memory::MemoryType::Episodic
+                    && !m.tags.contains(&"source:enrichment".to_string())
+                    && m.created_at > last_turn
+            })
+            .collect();
+        candidates.sort_by_key(|m| m.created_at);
+        candidates
+    }
+
+    /// Store enrichment results: extracted memories with provenance tracking.
+    ///
+    /// Each stored memory gets:
+    /// - `source:enrichment` tag for identification
+    /// - Confidence capped at `max_enrichment_confidence`
+    /// - `Derived` edges back to source episodic memories
+    ///
+    /// Returns (memories_stored, edges_created).
+    pub fn store_enrichment_memories(
+        &self,
+        memories: Vec<MemoryNode>,
+        source_ids: &[MemoryId],
+    ) -> MenteResult<(usize, usize)> {
+        let max_conf = self
+            .cognitive_config
+            .enrichment_config
+            .max_enrichment_confidence;
+        let mut stored = 0usize;
+        let mut edges = 0usize;
+
+        for mut mem in memories {
+            // Tag as enrichment-generated
+            if !mem.tags.contains(&"source:enrichment".to_string()) {
+                mem.tags.push("source:enrichment".to_string());
+            }
+            // Cap confidence
+            if mem.confidence > max_conf {
+                mem.confidence = max_conf;
+            }
+
+            let mem_id = mem.id;
+            self.store(mem)?;
+            stored += 1;
+
+            // Create Derived edges back to source episodics
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_micros() as u64;
+            for src_id in source_ids {
+                let edge = MemoryEdge {
+                    source: mem_id,
+                    target: *src_id,
+                    edge_type: EdgeType::Derived,
+                    weight: 0.8,
+                    created_at: now,
+                    valid_from: None,
+                    valid_until: None,
+                    label: Some("enrichment".to_string()),
+                };
+                if self.relate(edge).is_ok() {
+                    edges += 1;
+                }
+            }
+        }
+
+        debug!(stored, edges, "enrichment memories stored");
+        Ok((stored, edges))
+    }
+
+    /// Mark enrichment as complete for the given turn.
+    pub fn mark_enrichment_complete(&self, turn_id: u64) {
+        *self.last_enrichment_turn.write() = turn_id;
+        *self.enrichment_pending.write() = false;
+        debug!(turn_id, "enrichment cycle complete");
+    }
+
+    /// Get the enrichment configuration.
+    pub fn enrichment_config(&self) -> &EnrichmentConfig {
+        &self.cognitive_config.enrichment_config
     }
 }

--- a/crates/mentedb/src/process_turn.rs
+++ b/crates/mentedb/src/process_turn.rs
@@ -104,6 +104,8 @@ pub struct ProcessTurnResult {
     pub facts_extracted: usize,
     /// Number of edges created from fact extraction.
     pub edges_created: u32,
+    /// Whether enrichment is pending (caller should invoke enrichment pipeline).
+    pub enrichment_pending: bool,
     /// Delta: memory IDs added since last turn.
     pub delta_added: Vec<MemoryId>,
     /// Delta: memory IDs removed since last turn.
@@ -315,6 +317,7 @@ impl MenteDb {
             predicted_topics,
             facts_extracted,
             edges_created,
+            enrichment_pending: self.needs_enrichment(),
             delta_added: delta.added,
             delta_removed: delta.removed,
         })
@@ -350,7 +353,7 @@ impl MenteDb {
         let now = now_us();
         let results =
             self.recall_hybrid_at(query_embedding, Some(user_message), 10, now, None, None)?;
-        let scored: Vec<ScoredMemory> = results
+        let mut scored: Vec<ScoredMemory> = results
             .iter()
             .filter_map(|(mid, score)| {
                 self.get_memory(*mid).ok().map(|m| ScoredMemory {
@@ -359,6 +362,25 @@ impl MenteDb {
                 })
             })
             .collect();
+
+        // Append always-scoped memories (not already in results)
+        let hybrid_ids: std::collections::HashSet<MemoryId> =
+            scored.iter().map(|sm| sm.memory.id).collect();
+        let always_scope_tag = "scope:always";
+        let pm = self.page_map.read();
+        for pid in pm.values() {
+            if let Ok(mem) = self.storage.load_memory(*pid)
+                && mem.tags.iter().any(|t| t == always_scope_tag)
+                && !hybrid_ids.contains(&mem.id)
+            {
+                scored.push(ScoredMemory {
+                    memory: mem,
+                    score: 0.85,
+                });
+            }
+        }
+        drop(pm);
+
         let ids: Vec<MemoryId> = scored.iter().map(|sm| sm.memory.id).collect();
         Ok((scored, ids, false))
     }
@@ -829,6 +851,22 @@ impl MenteDb {
                 Err(e) => {
                     warn!(turn_id, error = %e, "auto-maintenance: consolidation failed");
                 }
+            }
+        }
+
+        // Enrichment trigger: mark pending when interval is reached
+        let enrichment = &self.cognitive_config.enrichment_config;
+        if enrichment.enabled && enrichment.trigger_interval > 0 {
+            let last = self.last_enrichment_turn();
+            let turns_since = turn_id.saturating_sub(last);
+            if turns_since >= enrichment.trigger_interval && !self.needs_enrichment() {
+                *self.enrichment_pending.write() = true;
+                debug!(
+                    turn_id,
+                    last_enrichment = last,
+                    turns_since,
+                    "enrichment trigger: marked pending"
+                );
             }
         }
     }

--- a/crates/mentedb/tests/process_turn.rs
+++ b/crates/mentedb/tests/process_turn.rs
@@ -489,6 +489,13 @@ fn test_entity_linking_creates_edges() {
         "should link same-name entities with similar embeddings"
     );
     assert!(result.edges_created > 0, "should create edges");
+
+    // Run again — should NOT create duplicate edges
+    let result2 = db.link_entities().unwrap();
+    assert_eq!(
+        result2.edges_created, 0,
+        "should not create duplicate edges"
+    );
 }
 
 #[test]

--- a/crates/mentedb/tests/process_turn.rs
+++ b/crates/mentedb/tests/process_turn.rs
@@ -453,3 +453,134 @@ fn test_always_scope_in_retrieve_context() {
         .any(|sm| sm.memory.tags.contains(&"scope:always".to_string()));
     assert!(has_always, "always-scoped memory should be in context");
 }
+
+#[test]
+fn test_entity_linking_creates_edges() {
+    let (db, _dir) = open_db_with_enrichment(50);
+
+    // Create two entity memories with the same name but different content
+    let emb1 = vec![0.9, 0.1, 0.0, 0.0];
+    let emb2 = vec![0.85, 0.15, 0.05, 0.0];
+
+    let mut node1 = mentedb_core::MemoryNode::new(
+        mentedb_core::types::AgentId::nil(),
+        mentedb_core::memory::MemoryType::Semantic,
+        "Max is a Golden Retriever".to_string(),
+        emb1,
+    );
+    node1.tags.push("entity:max".to_string());
+    node1.tags.push("source:enrichment".to_string());
+    db.store(node1).unwrap();
+
+    let mut node2 = mentedb_core::MemoryNode::new(
+        mentedb_core::types::AgentId::nil(),
+        mentedb_core::memory::MemoryType::Semantic,
+        "Max loves playing fetch in the park".to_string(),
+        emb2,
+    );
+    node2.tags.push("entity:max".to_string());
+    node2.tags.push("source:enrichment".to_string());
+    db.store(node2).unwrap();
+
+    let result = db.link_entities().unwrap();
+    // Embeddings [0.9,0.1,0,0] and [0.85,0.15,0.05,0] have high cosine sim (~0.99)
+    assert!(
+        result.linked > 0,
+        "should link same-name entities with similar embeddings"
+    );
+    assert!(result.edges_created > 0, "should create edges");
+}
+
+#[test]
+fn test_entity_linking_separates_different_entities() {
+    let (db, _dir) = open_db_with_enrichment(50);
+
+    // Two "python" entities with very different embeddings (programming vs comedy)
+    let emb_prog = vec![1.0, 0.0, 0.0, 0.0];
+    let emb_comedy = vec![0.0, 0.0, 0.0, 1.0];
+
+    let mut node1 = mentedb_core::MemoryNode::new(
+        mentedb_core::types::AgentId::nil(),
+        mentedb_core::memory::MemoryType::Semantic,
+        "Python programming language".to_string(),
+        emb_prog,
+    );
+    node1.tags.push("entity:python".to_string());
+    db.store(node1).unwrap();
+
+    let mut node2 = mentedb_core::MemoryNode::new(
+        mentedb_core::types::AgentId::nil(),
+        mentedb_core::memory::MemoryType::Semantic,
+        "Monty Python comedy troupe".to_string(),
+        emb_comedy,
+    );
+    node2.tags.push("entity:python".to_string());
+    db.store(node2).unwrap();
+
+    let result = db.link_entities().unwrap();
+    // Orthogonal embeddings → cosine sim ~0 → below separate_threshold
+    assert_eq!(result.linked, 0, "should NOT link different entities");
+    assert_eq!(result.edges_created, 0, "no edges for different entities");
+}
+
+#[test]
+fn test_entity_linking_ambiguous_range() {
+    let (db, _dir) = open_db_with_enrichment(50);
+
+    // Two entities with moderate similarity (in the ambiguous range 0.4-0.7)
+    let emb1 = vec![1.0, 0.0, 0.0, 0.0];
+    let emb2 = vec![0.6, 0.6, 0.0, 0.0]; // cosine with emb1 ≈ 0.707
+
+    let mut node1 = mentedb_core::MemoryNode::new(
+        mentedb_core::types::AgentId::nil(),
+        mentedb_core::memory::MemoryType::Semantic,
+        "Java island in Indonesia".to_string(),
+        emb1,
+    );
+    node1.tags.push("entity:java".to_string());
+    db.store(node1).unwrap();
+
+    let mut node2 = mentedb_core::MemoryNode::new(
+        mentedb_core::types::AgentId::nil(),
+        mentedb_core::memory::MemoryType::Semantic,
+        "Java programming language".to_string(),
+        emb2,
+    );
+    node2.tags.push("entity:java".to_string());
+    db.store(node2).unwrap();
+
+    let result = db.link_entities().unwrap();
+    // cosine([1,0,0,0], [0.6,0.6,0,0]) ≈ 0.707 — right at the merge threshold (0.7)
+    // Depending on floating point, this could be linked or ambiguous
+    assert!(
+        result.linked > 0 || result.ambiguous > 0,
+        "should be either linked or ambiguous, not ignored"
+    );
+}
+
+#[test]
+fn test_entity_memories_returns_tagged() {
+    let (db, _dir) = open_db();
+
+    let mut entity_node = mentedb_core::MemoryNode::new(
+        mentedb_core::types::AgentId::nil(),
+        mentedb_core::memory::MemoryType::Semantic,
+        "Max the dog".to_string(),
+        vec![0.5, 0.5, 0.0, 0.0],
+    );
+    entity_node.tags.push("entity:max".to_string());
+    db.store(entity_node).unwrap();
+
+    let mut regular_node = mentedb_core::MemoryNode::new(
+        mentedb_core::types::AgentId::nil(),
+        mentedb_core::memory::MemoryType::Semantic,
+        "I like coffee".to_string(),
+        vec![0.0, 0.0, 0.5, 0.5],
+    );
+    regular_node.tags.push("preference".to_string());
+    db.store(regular_node).unwrap();
+
+    let entities = db.entity_memories();
+    assert_eq!(entities.len(), 1);
+    assert!(entities[0].tags.contains(&"entity:max".to_string()));
+}

--- a/crates/mentedb/tests/process_turn.rs
+++ b/crates/mentedb/tests/process_turn.rs
@@ -1,4 +1,5 @@
 use mentedb::CognitiveConfig;
+use mentedb::EnrichmentConfig;
 use mentedb::MenteDb;
 use mentedb::process_turn::ProcessTurnInput;
 use mentedb_context::DeltaTracker;
@@ -6,6 +7,20 @@ use mentedb_context::DeltaTracker;
 fn open_db() -> (MenteDb, tempfile::TempDir) {
     let dir = tempfile::tempdir().unwrap();
     let db = MenteDb::open_with_config(dir.path(), CognitiveConfig::default()).unwrap();
+    (db, dir)
+}
+
+fn open_db_with_enrichment(interval: u64) -> (MenteDb, tempfile::TempDir) {
+    let dir = tempfile::tempdir().unwrap();
+    let config = CognitiveConfig {
+        enrichment_config: EnrichmentConfig {
+            enabled: true,
+            trigger_interval: interval,
+            ..EnrichmentConfig::default()
+        },
+        ..CognitiveConfig::default()
+    };
+    let db = MenteDb::open_with_config(dir.path(), config).unwrap();
     (db, dir)
 }
 
@@ -247,4 +262,194 @@ fn test_process_turn_maintenance_intervals() {
         agent_id: None,
     };
     let _ = db.process_turn(&input200, &mut delta).unwrap();
+}
+
+#[test]
+fn test_enrichment_disabled_by_default() {
+    let (db, _dir) = open_db();
+    assert!(!db.needs_enrichment());
+    assert_eq!(db.last_enrichment_turn(), 0);
+    assert!(db.enrichment_candidates().is_empty());
+}
+
+#[test]
+fn test_enrichment_trigger_after_interval() {
+    let (db, _dir) = open_db_with_enrichment(5);
+    let mut delta = DeltaTracker::new();
+
+    // Run 4 turns — should NOT trigger yet
+    for i in 1..=4 {
+        let input = ProcessTurnInput {
+            user_message: format!("Turn {}", i),
+            assistant_response: None,
+            turn_id: i,
+            project_context: None,
+            agent_id: None,
+        };
+        let result = db.process_turn(&input, &mut delta).unwrap();
+        assert!(!result.enrichment_pending, "turn {} should not trigger", i);
+    }
+
+    // Turn 5 should trigger enrichment
+    let input5 = ProcessTurnInput {
+        user_message: "Turn five".to_string(),
+        assistant_response: None,
+        turn_id: 5,
+        project_context: None,
+        agent_id: None,
+    };
+    let result = db.process_turn(&input5, &mut delta).unwrap();
+    assert!(result.enrichment_pending);
+    assert!(db.needs_enrichment());
+}
+
+#[test]
+fn test_enrichment_candidates_returns_episodics() {
+    let (db, _dir) = open_db_with_enrichment(5);
+    let mut delta = DeltaTracker::new();
+
+    // Store some turns
+    for i in 1..=3 {
+        let input = ProcessTurnInput {
+            user_message: format!("I like {} programming", ["Rust", "Python", "Go"][i - 1]),
+            assistant_response: Some("Nice choice!".to_string()),
+            turn_id: i as u64,
+            project_context: None,
+            agent_id: None,
+        };
+        db.process_turn(&input, &mut delta).unwrap();
+    }
+
+    let candidates = db.enrichment_candidates();
+    assert!(
+        candidates.len() >= 3,
+        "should have at least 3 episodic candidates"
+    );
+
+    // All should be Episodic
+    for c in &candidates {
+        assert_eq!(c.memory_type, mentedb_core::memory::MemoryType::Episodic);
+    }
+}
+
+#[test]
+fn test_enrichment_store_results() {
+    let (db, _dir) = open_db_with_enrichment(5);
+    let mut delta = DeltaTracker::new();
+
+    // Store a turn to get a source memory
+    let input = ProcessTurnInput {
+        user_message: "I prefer using Rust".to_string(),
+        assistant_response: Some("Rust is great!".to_string()),
+        turn_id: 1,
+        project_context: None,
+        agent_id: None,
+    };
+    let result = db.process_turn(&input, &mut delta).unwrap();
+    let source_id = result.episodic_id.unwrap();
+
+    // Create an enrichment memory (simulating extraction output)
+    let enrichment_mem = mentedb_core::MemoryNode::new(
+        mentedb_core::types::AgentId::nil(),
+        mentedb_core::memory::MemoryType::Semantic,
+        "User prefers Rust for programming".to_string(),
+        vec![0.1; 384],
+    );
+
+    let (stored, edges) = db
+        .store_enrichment_memories(vec![enrichment_mem], &[source_id])
+        .unwrap();
+
+    assert_eq!(stored, 1);
+    assert_eq!(edges, 1);
+
+    // Verify the stored memory has enrichment tag and capped confidence
+    let candidates = db.enrichment_candidates();
+    // The enrichment memory should NOT show up as a candidate (it has source:enrichment tag)
+    for c in &candidates {
+        assert!(
+            !c.tags.contains(&"source:enrichment".to_string()),
+            "enrichment memories should not be candidates"
+        );
+    }
+}
+
+#[test]
+fn test_enrichment_mark_complete_resets_pending() {
+    let (db, _dir) = open_db_with_enrichment(3);
+    let mut delta = DeltaTracker::new();
+
+    // Trigger enrichment
+    for i in 1..=3 {
+        let input = ProcessTurnInput {
+            user_message: format!("Turn {}", i),
+            assistant_response: None,
+            turn_id: i,
+            project_context: None,
+            agent_id: None,
+        };
+        db.process_turn(&input, &mut delta).unwrap();
+    }
+    assert!(db.needs_enrichment());
+
+    // Mark complete
+    db.mark_enrichment_complete(3);
+    assert!(!db.needs_enrichment());
+    assert_eq!(db.last_enrichment_turn(), 3);
+
+    // Next 2 turns should not trigger again
+    for i in 4..=5 {
+        let input = ProcessTurnInput {
+            user_message: format!("Turn {}", i),
+            assistant_response: None,
+            turn_id: i,
+            project_context: None,
+            agent_id: None,
+        };
+        let result = db.process_turn(&input, &mut delta).unwrap();
+        assert!(!result.enrichment_pending);
+    }
+
+    // Turn 6 should trigger again (3 turns since last enrichment at turn 3)
+    let input6 = ProcessTurnInput {
+        user_message: "Turn 6".to_string(),
+        assistant_response: None,
+        turn_id: 6,
+        project_context: None,
+        agent_id: None,
+    };
+    let result = db.process_turn(&input6, &mut delta).unwrap();
+    assert!(result.enrichment_pending);
+}
+
+#[test]
+fn test_always_scope_in_retrieve_context() {
+    let (db, _dir) = open_db();
+    let mut delta = DeltaTracker::new();
+
+    // Store an always-scoped memory directly
+    let mut always_mem = mentedb_core::MemoryNode::new(
+        mentedb_core::types::AgentId::nil(),
+        mentedb_core::memory::MemoryType::Semantic,
+        "Always remember: user prefers dark mode".to_string(),
+        vec![0.1; 384],
+    );
+    always_mem.tags.push("scope:always".to_string());
+    db.store(always_mem).unwrap();
+
+    // process_turn on an unrelated topic should still include the always-scoped memory
+    let input = ProcessTurnInput {
+        user_message: "What is the weather today?".to_string(),
+        assistant_response: None,
+        turn_id: 1,
+        project_context: None,
+        agent_id: None,
+    };
+    let result = db.process_turn(&input, &mut delta).unwrap();
+
+    let has_always = result
+        .context
+        .iter()
+        .any(|sm| sm.memory.tags.contains(&"scope:always".to_string()));
+    assert!(has_always, "always-scoped memory should be in context");
 }

--- a/crates/mentedb/tests/process_turn.rs
+++ b/crates/mentedb/tests/process_turn.rs
@@ -482,11 +482,14 @@ fn test_entity_linking_creates_edges() {
     node2.tags.push("source:enrichment".to_string());
     db.store(node2).unwrap();
 
+    // Pre-teach the resolver that "max" is a known entity
+    db.add_entity_alias("max", "max", 1.0);
+
     let result = db.link_entities().unwrap();
-    // Embeddings [0.9,0.1,0,0] and [0.85,0.15,0.05,0] have high cosine sim (~0.99)
+    // Both memories share the canonical name "max" → linked
     assert!(
         result.linked > 0,
-        "should link same-name entities with similar embeddings"
+        "should link same-name entities via EntityResolver cache"
     );
     assert!(result.edges_created > 0, "should create edges");
 
@@ -502,7 +505,7 @@ fn test_entity_linking_creates_edges() {
 fn test_entity_linking_separates_different_entities() {
     let (db, _dir) = open_db_with_enrichment(50);
 
-    // Two "python" entities with very different embeddings (programming vs comedy)
+    // Two "python" entities — resolver doesn't know about them yet
     let emb_prog = vec![1.0, 0.0, 0.0, 0.0];
     let emb_comedy = vec![0.0, 0.0, 0.0, 1.0];
 
@@ -524,19 +527,69 @@ fn test_entity_linking_separates_different_entities() {
     node2.tags.push("entity:python".to_string());
     db.store(node2).unwrap();
 
+    // Without resolver knowledge, link_entities shouldn't link them
     let result = db.link_entities().unwrap();
-    // Orthogonal embeddings → cosine sim ~0 → below separate_threshold
-    assert_eq!(result.linked, 0, "should NOT link different entities");
-    assert_eq!(result.edges_created, 0, "no edges for different entities");
+    assert_eq!(result.linked, 0, "unresolved entities should NOT be linked");
+    assert_eq!(result.edges_created, 0, "no edges for unresolved entities");
 }
 
 #[test]
-fn test_entity_linking_ambiguous_range() {
+fn test_apply_entity_link_resolutions() {
     let (db, _dir) = open_db_with_enrichment(50);
 
-    // Two entities with moderate similarity (in the ambiguous range 0.4-0.7)
+    let emb1 = vec![0.9, 0.1, 0.0, 0.0];
+    let emb2 = vec![0.85, 0.15, 0.05, 0.0];
+
+    let mut node1 = mentedb_core::MemoryNode::new(
+        mentedb_core::types::AgentId::nil(),
+        mentedb_core::memory::MemoryType::Semantic,
+        "NYC is where I live".to_string(),
+        emb1,
+    );
+    node1.tags.push("entity:nyc".to_string());
+    db.store(node1).unwrap();
+
+    let mut node2 = mentedb_core::MemoryNode::new(
+        mentedb_core::types::AgentId::nil(),
+        mentedb_core::memory::MemoryType::Semantic,
+        "New York City has great pizza".to_string(),
+        emb2,
+    );
+    node2.tags.push("entity:new york city".to_string());
+    db.store(node2).unwrap();
+
+    // Simulate LLM resolution: NYC and New York City are the same
+    let resolutions = vec![mentedb::EntityLinkResolution {
+        canonical: "new york city".to_string(),
+        aliases: vec!["nyc".to_string()],
+        confidence: 0.95,
+    }];
+    let separations = vec![];
+
+    let result = db
+        .apply_entity_link_resolutions(&resolutions, &separations)
+        .unwrap();
+    assert!(result.edges_created > 0, "should create cross-name edges");
+    assert!(result.linked > 0, "should report linked pairs");
+
+    // Verify resolver learned the alias
+    assert_eq!(
+        db.get_canonical_entity("nyc"),
+        Some("new york city".to_string())
+    );
+
+    // Now link_entities should also work (uses cache)
+    // (won't create new edges since apply already created them)
+    let sync_result = db.link_entities().unwrap();
+    assert_eq!(sync_result.edges_created, 0, "edges already exist");
+}
+
+#[test]
+fn test_entity_separation_negative_cache() {
+    let (db, _dir) = open_db_with_enrichment(50);
+
     let emb1 = vec![1.0, 0.0, 0.0, 0.0];
-    let emb2 = vec![0.6, 0.6, 0.0, 0.0]; // cosine with emb1 ≈ 0.707
+    let emb2 = vec![0.0, 0.0, 0.0, 1.0];
 
     let mut node1 = mentedb_core::MemoryNode::new(
         mentedb_core::types::AgentId::nil(),
@@ -553,16 +606,25 @@ fn test_entity_linking_ambiguous_range() {
         "Java programming language".to_string(),
         emb2,
     );
-    node2.tags.push("entity:java".to_string());
+    node2.tags.push("entity:java programming".to_string());
     db.store(node2).unwrap();
 
-    let result = db.link_entities().unwrap();
-    // cosine([1,0,0,0], [0.6,0.6,0,0]) ≈ 0.707 — right at the merge threshold (0.7)
-    // Depending on floating point, this could be linked or ambiguous
-    assert!(
-        result.linked > 0 || result.ambiguous > 0,
-        "should be either linked or ambiguous, not ignored"
-    );
+    // LLM says these are different
+    let resolutions = vec![];
+    let separations = vec![mentedb::EntitySeparation {
+        name_a: "java".to_string(),
+        name_b: "java programming".to_string(),
+    }];
+
+    db.apply_entity_link_resolutions(&resolutions, &separations)
+        .unwrap();
+
+    // Verify: "java" and "java programming" should show as unresolved
+    // (negative cache prevents future LLM calls for this pair)
+    let unresolved = db.unresolved_entity_names();
+    // Both are still "unresolved" in terms of having no canonical alias,
+    // but the negative cache will skip them in future LLM batches
+    assert!(unresolved.contains(&"java".to_string()));
 }
 
 #[test]

--- a/sdks/python/Cargo.lock
+++ b/sdks/python/Cargo.lock
@@ -1439,7 +1439,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb"
-version = "0.7.0"
+version = "0.7.2"
 dependencies = [
  "mentedb-cognitive",
  "mentedb-consolidation",
@@ -1458,7 +1458,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-cognitive"
-version = "0.7.0"
+version = "0.7.2"
 dependencies = [
  "ahash",
  "crossbeam",
@@ -1473,7 +1473,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-consolidation"
-version = "0.7.0"
+version = "0.7.2"
 dependencies = [
  "ahash",
  "mentedb-core",
@@ -1484,7 +1484,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-context"
-version = "0.7.0"
+version = "0.7.2"
 dependencies = [
  "ahash",
  "mentedb-core",
@@ -1496,7 +1496,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-core"
-version = "0.7.0"
+version = "0.7.2"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1511,7 +1511,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-embedding"
-version = "0.7.0"
+version = "0.7.2"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -1529,7 +1529,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-extraction"
-version = "0.7.0"
+version = "0.7.2"
 dependencies = [
  "mentedb-cognitive",
  "mentedb-core",
@@ -1545,7 +1545,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-graph"
-version = "0.7.0"
+version = "0.7.2"
 dependencies = [
  "ahash",
  "bincode",
@@ -1560,7 +1560,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-index"
-version = "0.7.0"
+version = "0.7.2"
 dependencies = [
  "ahash",
  "bincode",
@@ -1597,7 +1597,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-query"
-version = "0.7.0"
+version = "0.7.2"
 dependencies = [
  "mentedb-core",
  "serde",
@@ -1608,7 +1608,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-storage"
-version = "0.7.0"
+version = "0.7.2"
 dependencies = [
  "ahash",
  "bincode",

--- a/sdks/python/src/lib.rs
+++ b/sdks/python/src/lib.rs
@@ -3613,6 +3613,7 @@ impl MenteDB {
                 .map(|id| id.to_string())
                 .collect::<Vec<_>>(),
         )?;
+        dict.set_item("enrichment_pending", result.enrichment_pending)?;
 
         Ok(dict.into_any().unbind())
     }
@@ -3622,6 +3623,66 @@ impl MenteDB {
         if let Some(db) = self.db.take() {
             db.close().map_err(to_pyerr)?;
         }
+        Ok(())
+    }
+
+    /// Check if enrichment is pending.
+    fn needs_enrichment(&self) -> PyResult<bool> {
+        let db = self
+            .db
+            .as_ref()
+            .ok_or_else(|| PyRuntimeError::new_err("database is closed"))?;
+        Ok(db.needs_enrichment())
+    }
+
+    /// Get the turn ID of the last completed enrichment.
+    fn last_enrichment_turn(&self) -> PyResult<u64> {
+        let db = self
+            .db
+            .as_ref()
+            .ok_or_else(|| PyRuntimeError::new_err("database is closed"))?;
+        Ok(db.last_enrichment_turn())
+    }
+
+    /// Manually request enrichment on the next check.
+    fn request_enrichment(&self) -> PyResult<()> {
+        let db = self
+            .db
+            .as_ref()
+            .ok_or_else(|| PyRuntimeError::new_err("database is closed"))?;
+        db.request_enrichment();
+        Ok(())
+    }
+
+    /// Get episodic memories that need enrichment.
+    fn enrichment_candidates(&self, py: Python<'_>) -> PyResult<Vec<PyObject>> {
+        let db = self
+            .db
+            .as_ref()
+            .ok_or_else(|| PyRuntimeError::new_err("database is closed"))?;
+        let candidates = db.enrichment_candidates();
+        let result: Vec<PyObject> = candidates
+            .iter()
+            .map(|m| {
+                let d = pyo3::types::PyDict::new(py);
+                d.set_item("id", m.id.to_string()).unwrap();
+                d.set_item("content", &m.content).unwrap();
+                d.set_item("memory_type", format!("{:?}", m.memory_type))
+                    .unwrap();
+                d.set_item("created_at", m.created_at).unwrap();
+                d.into_any().unbind()
+            })
+            .collect();
+        Ok(result)
+    }
+
+    /// Mark enrichment as complete at the given turn.
+    fn mark_enrichment_complete(&self, turn_id: u64) -> PyResult<()> {
+        let db = self
+            .db
+            .as_ref()
+            .ok_or_else(|| PyRuntimeError::new_err("database is closed"))?;
+        db.mark_enrichment_complete(turn_id);
         Ok(())
     }
 }

--- a/sdks/python/src/lib.rs
+++ b/sdks/python/src/lib.rs
@@ -3685,6 +3685,45 @@ impl MenteDB {
         db.mark_enrichment_complete(turn_id);
         Ok(())
     }
+
+    /// Link entities across sessions by name + embedding similarity.
+    ///
+    /// Returns a dict with `linked`, `ambiguous`, and `edges_created` counts.
+    fn link_entities(&self, py: Python<'_>) -> PyResult<PyObject> {
+        let db = self
+            .db
+            .as_ref()
+            .ok_or_else(|| PyRuntimeError::new_err("database is closed"))?;
+        let result = db.link_entities().map_err(to_pyerr)?;
+        let d = pyo3::types::PyDict::new(py);
+        d.set_item("linked", result.linked).unwrap();
+        d.set_item("ambiguous", result.ambiguous).unwrap();
+        d.set_item("edges_created", result.edges_created).unwrap();
+        Ok(d.into_any().unbind())
+    }
+
+    /// Get all entity memory nodes (memories tagged with `entity:{name}`).
+    fn entity_memories(&self, py: Python<'_>) -> PyResult<Vec<PyObject>> {
+        let db = self
+            .db
+            .as_ref()
+            .ok_or_else(|| PyRuntimeError::new_err("database is closed"))?;
+        let entities = db.entity_memories();
+        let result: Vec<PyObject> = entities
+            .iter()
+            .map(|m| {
+                let d = pyo3::types::PyDict::new(py);
+                d.set_item("id", m.id.to_string()).unwrap();
+                d.set_item("content", &m.content).unwrap();
+                d.set_item("memory_type", format!("{:?}", m.memory_type))
+                    .unwrap();
+                d.set_item("tags", &m.tags).unwrap();
+                d.set_item("created_at", m.created_at).unwrap();
+                d.into_any().unbind()
+            })
+            .collect();
+        Ok(result)
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/sdks/typescript/Cargo.lock
+++ b/sdks/typescript/Cargo.lock
@@ -672,7 +672,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mentedb"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "mentedb-cognitive",
  "mentedb-consolidation",
@@ -691,7 +691,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-cognitive"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "ahash",
  "crossbeam",
@@ -706,7 +706,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-consolidation"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "ahash",
  "mentedb-core",
@@ -717,7 +717,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-context"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "ahash",
  "mentedb-core",
@@ -729,7 +729,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-core"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-embedding"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "mentedb-core",
  "serde",
@@ -756,7 +756,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-extraction"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "mentedb-cognitive",
  "mentedb-core",
@@ -772,7 +772,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-graph"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "ahash",
  "bincode",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-index"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "ahash",
  "bincode",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-query"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "mentedb-core",
  "serde",
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-storage"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "ahash",
  "bincode",

--- a/sdks/typescript/src/lib.rs
+++ b/sdks/typescript/src/lib.rs
@@ -142,6 +142,7 @@ pub struct JsProcessTurnResult {
     pub predicted_topics: Vec<String>,
     pub facts_extracted: u32,
     pub edges_created: u32,
+    pub enrichment_pending: bool,
     pub delta_added: Vec<String>,
     pub delta_removed: Vec<String>,
 }
@@ -406,6 +407,7 @@ impl MenteDB {
             predicted_topics: result.predicted_topics,
             facts_extracted: result.facts_extracted as u32,
             edges_created: result.edges_created,
+            enrichment_pending: result.enrichment_pending,
             delta_added: result.delta_added.iter().map(|id| id.to_string()).collect(),
             delta_removed: result.delta_removed.iter().map(|id| id.to_string()).collect(),
         })
@@ -415,6 +417,46 @@ impl MenteDB {
     #[napi]
     pub fn close(&self) -> Result<()> {
         self.inner.close().map_err(mente_err)
+    }
+
+    /// Check if enrichment is pending.
+    #[napi]
+    pub fn needs_enrichment(&self) -> Result<bool> {
+        Ok(self.inner.needs_enrichment())
+    }
+
+    /// Get the turn ID of the last completed enrichment.
+    #[napi]
+    pub fn last_enrichment_turn(&self) -> Result<u32> {
+        Ok(self.inner.last_enrichment_turn() as u32)
+    }
+
+    /// Manually request enrichment on the next check.
+    #[napi]
+    pub fn request_enrichment(&self) -> Result<()> {
+        self.inner.request_enrichment();
+        Ok(())
+    }
+
+    /// Get episodic memories that need enrichment.
+    #[napi]
+    pub fn enrichment_candidates(&self) -> Result<Vec<JsContextItem>> {
+        let candidates = self.inner.enrichment_candidates();
+        Ok(candidates
+            .iter()
+            .map(|m| JsContextItem {
+                id: m.id.to_string(),
+                content: m.content.clone(),
+                score: 1.0,
+            })
+            .collect())
+    }
+
+    /// Mark enrichment as complete at the given turn.
+    #[napi]
+    pub fn mark_enrichment_complete(&self, turn_id: u32) -> Result<()> {
+        self.inner.mark_enrichment_complete(turn_id as u64);
+        Ok(())
     }
 }
 

--- a/sdks/typescript/src/lib.rs
+++ b/sdks/typescript/src/lib.rs
@@ -147,6 +147,13 @@ pub struct JsProcessTurnResult {
     pub delta_removed: Vec<String>,
 }
 
+#[napi(object)]
+pub struct JsEntityLinkResult {
+    pub linked: u32,
+    pub ambiguous: u32,
+    pub edges_created: u32,
+}
+
 // ---------------------------------------------------------------------------
 // MenteDB
 // ---------------------------------------------------------------------------
@@ -457,6 +464,31 @@ impl MenteDB {
     pub fn mark_enrichment_complete(&self, turn_id: u32) -> Result<()> {
         self.inner.mark_enrichment_complete(turn_id as u64);
         Ok(())
+    }
+
+    /// Link entities across sessions by name + embedding similarity.
+    #[napi]
+    pub fn link_entities(&self) -> Result<JsEntityLinkResult> {
+        let result = self.inner.link_entities().map_err(mente_err)?;
+        Ok(JsEntityLinkResult {
+            linked: result.linked as u32,
+            ambiguous: result.ambiguous as u32,
+            edges_created: result.edges_created as u32,
+        })
+    }
+
+    /// Get all entity memory nodes (memories tagged with `entity:{name}`).
+    #[napi]
+    pub fn entity_memories(&self) -> Result<Vec<JsContextItem>> {
+        let entities = self.inner.entity_memories();
+        Ok(entities
+            .iter()
+            .map(|m| JsContextItem {
+                id: m.id.to_string(),
+                content: m.content.clone(),
+                score: 1.0,
+            })
+            .collect())
     }
 }
 


### PR DESCRIPTION
## Sleeptime Enrichment Pipeline — Phase 0+1+2

Adds the core enrichment infrastructure, entity extraction, and **LLM-powered entity linking** to the engine and both SDKs.

### Phase 0+1: Engine Foundation
- **EnrichmentConfig** — enabled flag, trigger_interval (default 50 turns), min_confidence, max_enrichment_confidence (0.7)
- **Enrichment API** — `needs_enrichment()`, `last_enrichment_turn()`, `request_enrichment()`, `enrichment_candidates()`, `store_enrichment_memories()`, `mark_enrichment_complete()`, `enrichment_config()`
- **Always-scope retrieval** — memories tagged `scope:always` now included in `retrieve_context()` (score 0.85)
- **Enrichment trigger** — `maybe_run_maintenance()` checks turn count vs interval, sets `enrichment_pending` flag
- **ProcessTurnResult** — new `enrichment_pending` field signals callers when enrichment should run

### Phase 2: LLM-Powered Entity Linking
Replaces threshold-based heuristics with a proper LLM resolution pipeline:

- **EntityResolver** (cognitive crate) — 3-tier resolution: cache → rule-based word matching → LLM fallback
  - **Word-boundary matching** — "Alice" matches "Alice Smith" but "Java" correctly rejects "JavaScript"
  - **Hyphen-aware splitting** — "gpt-4" matches "gpt 4", "COVID-19" matches "COVID 19"
  - **Negative cache** — confirmed-different pairs stored to avoid re-asking LLM (persisted in snapshot v2)
  - **`unresolved_names()`** — identifies entities needing LLM resolution
- **`link_entities()`** — sync path using EntityResolver cache for instant known-entity linking
- **`apply_entity_link_resolutions()`** — applies LLM merge groups: creates `entity_link:` edges between entity memories, learns aliases in resolver, negative-caches separations
- **`entity_names_with_context()`** — collects all entity names with content snippets for LLM disambiguation
- **Pipeline flow**: sync cache resolution → collect unresolved → LLM resolves all → apply results → learn cache
- No thresholds — ALL unresolved entities go to LLM, cache handles repeats for free

### SDK Changes
- **Python** — `enrichment_pending` + 7 enrichment/entity methods
- **TypeScript** — `enrichment_pending` + 7 enrichment/entity methods + `JsEntityLinkResult` type

### Extraction Pipeline Enhancement
- `ProcessedExtractionResult` now includes `entities: Vec<ExtractedEntity>` from LLM extraction
- `process()` calls `extract_full()` instead of `extract_from_conversation()` to capture entities

### Tests
- Entity resolver: 19 tests including hyphenated matching, negative cache, word-boundary rejection, snapshot persistence
- Entity linking integration: 4 tests covering cache-based linking, LLM resolution application, negative cache learning, separation handling
- All workspace tests pass (280+), clippy clean, fmt clean

### Design Principles
- Engine stays IO-free — callers handle async LLM calls
- Enrichment memories get lower confidence (0.7) and `source:enrichment` tag
- `Derived` edges link back to source episodics
- `Related` edges link entity groups (weighted by LLM confidence)
- Disabled by default, opt-in via config