### PR TITLE
feat: Community Detection & User Model (Enrichment Phase 3 & 4)

### DIFF
--- a/crates/mentedb-cognitive/src/llm.rs
+++ b/crates/mentedb-cognitive/src/llm.rs
@@ -138,6 +138,18 @@ pub struct TopicLabel {
     pub is_new: bool,
 }
 
+/// LLM-generated community summary for a cluster of entities.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CommunitySummary {
+    pub summary: String,
+}
+
+/// LLM-generated user profile from accumulated knowledge.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct UserProfile {
+    pub profile: String,
+}
+
 // ---------------------------------------------------------------------------
 // Compact memory representation for prompts
 // ---------------------------------------------------------------------------
@@ -228,6 +240,36 @@ Rules:
 
 Respond with ONLY a JSON object:
 {"topic": "authentication", "is_new": false}"#;
+
+    pub const COMMUNITY_SUMMARY_SYSTEM: &str = r#"You are a knowledge summarizer for an AI agent's long-term memory system.
+
+Given a category name and a list of entities the user has interacted with, create a concise summary that captures the user's relationship to this cluster of entities.
+
+Rules:
+- Mention EVERY entity by name — do not omit any
+- Focus on the user's relationship to each (uses, likes, works with, etc.)
+- Keep it to 2-3 sentences maximum
+- The summary should be findable when someone searches for this topic
+- Write in third person ("The user...")
+
+Respond with ONLY a JSON object:
+{"summary": "The user works with Python and Rust for systems programming, uses PostgreSQL for databases, and deploys on AWS."}"#;
+
+    pub const USER_PROFILE_SYSTEM: &str = r#"You are a profile generator for an AI agent's long-term memory system.
+
+Given a collection of facts, preferences, and patterns about a user, generate a concise profile that captures the most important information an AI assistant should know.
+
+Rules:
+- Prioritize: preferences > active projects > skills > relationships > habits
+- Be factual — only include what the evidence supports
+- Keep it under 200 words
+- Write in third person ("The user...")
+- Group related facts together
+- Include specific names, tools, and preferences — not vague generalities
+- This profile will be included in EVERY conversation, so only include persistently relevant facts
+
+Respond with ONLY a JSON object:
+{"profile": "The user is a software engineer who prefers Rust and Python. They are building MenteDB, a cognitive memory database..."}"#;
 }
 
 // ---------------------------------------------------------------------------
@@ -358,6 +400,69 @@ impl<J: LlmJudge> CognitiveLlmService<J> {
             .complete(prompts::TOPIC_SYSTEM, &user_prompt)
             .await?;
         parse_json_response::<TopicLabel>(&response)
+    }
+
+    /// Generate a summary for a community (cluster of related entities).
+    pub async fn generate_community_summary(
+        &self,
+        category: &str,
+        entities: &[(String, String)], // (name, context/relationship)
+    ) -> Result<CommunitySummary, LlmJudgeError> {
+        let entity_list = entities
+            .iter()
+            .map(|(name, ctx)| format!("- {} — {}", name, ctx))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        let user_prompt = format!(
+            "Category: {}\n\nEntities in this cluster:\n{}",
+            category, entity_list
+        );
+
+        let response = self
+            .judge
+            .complete(prompts::COMMUNITY_SUMMARY_SYSTEM, &user_prompt)
+            .await?;
+        parse_json_response::<CommunitySummary>(&response)
+    }
+
+    /// Generate a user profile from accumulated knowledge.
+    pub async fn generate_user_profile(
+        &self,
+        facts: &[String],
+        community_summaries: &[String],
+    ) -> Result<UserProfile, LlmJudgeError> {
+        let mut sections = Vec::new();
+
+        if !facts.is_empty() {
+            sections.push(format!(
+                "Known facts about the user:\n{}",
+                facts
+                    .iter()
+                    .map(|f| format!("- {}", f))
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            ));
+        }
+
+        if !community_summaries.is_empty() {
+            sections.push(format!(
+                "Community summaries:\n{}",
+                community_summaries
+                    .iter()
+                    .map(|s| format!("- {}", s))
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            ));
+        }
+
+        let user_prompt = sections.join("\n\n");
+
+        let response = self
+            .judge
+            .complete(prompts::USER_PROFILE_SYSTEM, &user_prompt)
+            .await?;
+        parse_json_response::<UserProfile>(&response)
     }
 }
 

--- a/crates/mentedb-cognitive/src/llm.rs
+++ b/crates/mentedb-cognitive/src/llm.rs
@@ -246,7 +246,7 @@ Respond with ONLY a JSON object:
 Given a category name and a list of entities the user has interacted with, create a concise summary that captures the user's relationship to this cluster of entities.
 
 Rules:
-- Mention EVERY entity by name — do not omit any
+- Mention the key entities by name — prioritize the most significant ones
 - Focus on the user's relationship to each (uses, likes, works with, etc.)
 - Keep it to 2-3 sentences maximum
 - The summary should be findable when someone searches for this topic
@@ -457,6 +457,12 @@ impl<J: LlmJudge> CognitiveLlmService<J> {
         }
 
         let user_prompt = sections.join("\n\n");
+
+        if user_prompt.is_empty() {
+            return Err(LlmJudgeError::ParseError(
+                "no facts or summaries provided for profile generation".into(),
+            ));
+        }
 
         let response = self
             .judge

--- a/crates/mentedb/src/lib.rs
+++ b/crates/mentedb/src/lib.rs
@@ -62,6 +62,7 @@ use mentedb_consolidation::decay::{DecayConfig, DecayEngine};
 use mentedb_context::{AssemblyConfig, ContextAssembler, ContextWindow, ScoredMemory};
 use mentedb_core::edge::EdgeType;
 use mentedb_core::error::MenteResult;
+use mentedb_core::memory::MemoryType;
 use mentedb_core::types::{MemoryId, Timestamp};
 use mentedb_core::{MemoryEdge, MemoryNode, MenteError};
 use mentedb_embedding::provider::EmbeddingProvider;
@@ -2040,5 +2041,230 @@ impl MenteDb {
             .filter_map(|pid| self.storage.load_memory(*pid).ok())
             .filter(|m| m.tags.iter().any(|t| t.starts_with("entity:")))
             .collect()
+    }
+
+    /// Get entity categories with their member entities for community detection.
+    ///
+    /// Returns a map of category → list of (entity_name, context_snippet).
+    /// Categories come from `entity_type:` tags on entity memories.
+    pub fn entity_communities(&self) -> HashMap<String, Vec<(String, String)>> {
+        let page_ids: Vec<PageId> = self.page_map.read().values().copied().collect();
+        let mut categories: HashMap<String, Vec<(String, String)>> = HashMap::new();
+
+        for pid in &page_ids {
+            if let Ok(mem) = self.storage.load_memory(*pid) {
+                // Skip non-entity memories and existing community summaries
+                if mem.tags.iter().any(|t| t == "community_summary") {
+                    continue;
+                }
+
+                let entity_name = mem
+                    .tags
+                    .iter()
+                    .find_map(|t| t.strip_prefix("entity:"))
+                    .map(|n| n.to_string());
+
+                if let Some(name) = entity_name {
+                    let entity_type = mem
+                        .tags
+                        .iter()
+                        .find_map(|t| t.strip_prefix("entity_type:"))
+                        .unwrap_or("general")
+                        .to_lowercase();
+
+                    let context = mem.content[..mem.content.len().min(200)].to_string();
+                    categories
+                        .entry(entity_type)
+                        .or_default()
+                        .push((name, context));
+                }
+            }
+        }
+
+        // Only return categories with 2+ entities (meaningful clusters)
+        categories.retain(|_, members| members.len() >= 2);
+        categories
+    }
+
+    /// Store a community summary memory with edges to member entities.
+    ///
+    /// Creates a `community_summary` tagged memory and `Derived` edges
+    /// from the summary to each member entity in the category.
+    pub fn store_community_summary(
+        &self,
+        category: &str,
+        summary: &str,
+        member_names: &[String],
+    ) -> MenteResult<MemoryId> {
+        // Check if a community summary already exists for this category
+        let community_tag = format!("community:{}", category);
+        let page_ids: Vec<PageId> = self.page_map.read().values().copied().collect();
+        for pid in &page_ids {
+            if let Ok(mem) = self.storage.load_memory(*pid)
+                && mem.tags.iter().any(|t| t == &community_tag)
+            {
+                // Update existing summary
+                let mut updated = mem.clone();
+                updated.content = summary.to_string();
+                if let Some(ref embedder) = self.embedder {
+                    updated.embedding = embedder
+                        .embed(summary)
+                        .unwrap_or_else(|_| updated.embedding.clone());
+                }
+                self.storage.store_memory(&updated)?;
+                return Ok(updated.id);
+            }
+        }
+
+        // Create new community summary
+        let embedding = self
+            .embedder
+            .as_ref()
+            .and_then(|e| e.embed(summary).ok())
+            .unwrap_or_default();
+
+        let mut node = MemoryNode::new(
+            mentedb_core::types::AgentId::new(),
+            MemoryType::Semantic,
+            summary.to_string(),
+            embedding,
+        );
+        node.tags = vec![
+            "community_summary".to_string(),
+            community_tag,
+            "source:enrichment".to_string(),
+        ];
+        node.confidence = 0.7;
+        let node_id = node.id;
+        self.store(node)?;
+
+        // Create Derived edges from summary to member entity memories
+        let entity_map = self.build_entity_memory_map();
+        for name in member_names {
+            let normalized = name.to_lowercase();
+            if let Some(member_ids) = entity_map.get(&normalized) {
+                for member_id in member_ids {
+                    self.relate(MemoryEdge {
+                        source: node_id,
+                        target: *member_id,
+                        edge_type: EdgeType::Derived,
+                        weight: 0.8,
+                        created_at: mentedb_core::types::Timestamp::default(),
+                        valid_from: None,
+                        valid_until: None,
+                        label: Some(format!("community_member:{}", category)),
+                    })?;
+                }
+            }
+        }
+
+        Ok(node_id)
+    }
+
+    /// Get existing community summaries.
+    pub fn community_summaries(&self) -> Vec<MemoryNode> {
+        let page_ids: Vec<PageId> = self.page_map.read().values().copied().collect();
+        page_ids
+            .iter()
+            .filter_map(|pid| self.storage.load_memory(*pid).ok())
+            .filter(|m| m.tags.iter().any(|t| t == "community_summary"))
+            .collect()
+    }
+
+    /// Collect all semantic/procedural facts for user profile generation.
+    ///
+    /// Returns high-confidence memories suitable for profile building.
+    pub fn profile_facts(&self) -> Vec<String> {
+        let page_ids: Vec<PageId> = self.page_map.read().values().copied().collect();
+        let mut facts = Vec::new();
+
+        for pid in &page_ids {
+            if let Ok(mem) = self.storage.load_memory(*pid) {
+                // Only semantic and procedural memories with decent confidence
+                if mem.confidence < 0.5 {
+                    continue;
+                }
+                match mem.memory_type {
+                    MemoryType::Semantic | MemoryType::Procedural => {
+                        // Skip community summaries and entity nodes
+                        if mem
+                            .tags
+                            .iter()
+                            .any(|t| t == "community_summary" || t.starts_with("entity:"))
+                        {
+                            continue;
+                        }
+                        facts.push(mem.content[..mem.content.len().min(300)].to_string());
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        // Cap at 100 most relevant facts to fit in LLM context
+        facts.truncate(100);
+        facts
+    }
+
+    /// Store or update the user profile as an always-scoped memory.
+    ///
+    /// There is exactly one user profile memory (tagged `user_profile`).
+    /// If one already exists, it's replaced entirely.
+    pub fn store_user_profile(&self, profile: &str) -> MenteResult<MemoryId> {
+        // Find existing profile
+        let page_ids: Vec<PageId> = self.page_map.read().values().copied().collect();
+        for pid in &page_ids {
+            if let Ok(mem) = self.storage.load_memory(*pid)
+                && mem.tags.iter().any(|t| t == "user_profile")
+            {
+                // Update in place
+                let mut updated = mem.clone();
+                updated.content = profile.to_string();
+                if let Some(ref embedder) = self.embedder {
+                    updated.embedding = embedder
+                        .embed(profile)
+                        .unwrap_or_else(|_| updated.embedding.clone());
+                }
+                self.storage.store_memory(&updated)?;
+                return Ok(updated.id);
+            }
+        }
+
+        // Create new profile
+        let embedding = self
+            .embedder
+            .as_ref()
+            .and_then(|e| e.embed(profile).ok())
+            .unwrap_or_default();
+
+        let mut node = MemoryNode::new(
+            mentedb_core::types::AgentId::new(),
+            MemoryType::Semantic,
+            profile.to_string(),
+            embedding,
+        );
+        node.tags = vec![
+            "user_profile".to_string(),
+            "scope:always".to_string(),
+            "source:enrichment".to_string(),
+        ];
+        node.confidence = 0.8;
+        let node_id = node.id;
+        self.store(node)?;
+
+        Ok(node_id)
+    }
+
+    /// Get the current user profile, if one exists.
+    pub fn user_profile(&self) -> Option<MemoryNode> {
+        let page_ids: Vec<PageId> = self.page_map.read().values().copied().collect();
+        for pid in &page_ids {
+            if let Ok(mem) = self.storage.load_memory(*pid)
+                && mem.tags.iter().any(|t| t == "user_profile")
+            {
+                return Some(mem);
+            }
+        }
+        None
     }
 }

--- a/crates/mentedb/src/lib.rs
+++ b/crates/mentedb/src/lib.rs
@@ -2072,7 +2072,7 @@ impl MenteDb {
                         .unwrap_or("general")
                         .to_lowercase();
 
-                    let context = mem.content[..mem.content.len().min(200)].to_string();
+                    let context: String = mem.content.chars().take(200).collect();
                     categories
                         .entry(entity_type)
                         .or_default()
@@ -2096,14 +2096,26 @@ impl MenteDb {
         summary: &str,
         member_names: &[String],
     ) -> MenteResult<MemoryId> {
+        if category.is_empty() {
+            return Err(MenteError::Storage(
+                "community category cannot be empty".into(),
+            ));
+        }
+
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_micros() as u64;
+
         // Check if a community summary already exists for this category
         let community_tag = format!("community:{}", category);
         let page_ids: Vec<PageId> = self.page_map.read().values().copied().collect();
+        let mut existing_id = None;
         for pid in &page_ids {
             if let Ok(mem) = self.storage.load_memory(*pid)
                 && mem.tags.iter().any(|t| t == &community_tag)
             {
-                // Update existing summary
+                // Update existing summary content
                 let mut updated = mem.clone();
                 updated.content = summary.to_string();
                 if let Some(ref embedder) = self.embedder {
@@ -2112,33 +2124,40 @@ impl MenteDb {
                         .unwrap_or_else(|_| updated.embedding.clone());
                 }
                 self.storage.store_memory(&updated)?;
-                return Ok(updated.id);
+                existing_id = Some(updated.id);
+                break;
             }
         }
 
-        // Create new community summary
-        let embedding = self
-            .embedder
-            .as_ref()
-            .and_then(|e| e.embed(summary).ok())
-            .unwrap_or_default();
+        let node_id = if let Some(id) = existing_id {
+            id
+        } else {
+            // Create new community summary
+            let embedding = self
+                .embedder
+                .as_ref()
+                .and_then(|e| e.embed(summary).ok())
+                .unwrap_or_default();
 
-        let mut node = MemoryNode::new(
-            mentedb_core::types::AgentId::new(),
-            MemoryType::Semantic,
-            summary.to_string(),
-            embedding,
-        );
-        node.tags = vec![
-            "community_summary".to_string(),
-            community_tag,
-            "source:enrichment".to_string(),
-        ];
-        node.confidence = 0.7;
-        let node_id = node.id;
-        self.store(node)?;
+            let mut node = MemoryNode::new(
+                mentedb_core::types::AgentId::new(),
+                MemoryType::Semantic,
+                summary.to_string(),
+                embedding,
+            );
+            node.tags = vec![
+                "community_summary".to_string(),
+                community_tag,
+                "source:enrichment".to_string(),
+            ];
+            node.confidence = 0.7;
+            let id = node.id;
+            self.store(node)?;
+            id
+        };
 
-        // Create Derived edges from summary to member entity memories
+        // (Re)create Derived edges from summary to member entity memories.
+        // On update this refreshes edges to reflect current membership.
         let entity_map = self.build_entity_memory_map();
         for name in member_names {
             let normalized = name.to_lowercase();
@@ -2149,7 +2168,7 @@ impl MenteDb {
                         target: *member_id,
                         edge_type: EdgeType::Derived,
                         weight: 0.8,
-                        created_at: mentedb_core::types::Timestamp::default(),
+                        created_at: now,
                         valid_from: None,
                         valid_until: None,
                         label: Some(format!("community_member:{}", category)),
@@ -2194,7 +2213,7 @@ impl MenteDb {
                         {
                             continue;
                         }
-                        facts.push(mem.content[..mem.content.len().min(300)].to_string());
+                        facts.push(mem.content.chars().take(300).collect());
                     }
                     _ => {}
                 }


### PR DESCRIPTION
## Summary

Adds the final two phases of the sleeptime enrichment pipeline:

### Phase 3: Community Detection
- Groups entity memories by `entity_type:` category tags
- Generates LLM-powered community summaries for clusters with 2+ members
- Stores summaries as `community_summary` tagged memories with `Derived` edges to members
- Idempotent: skips categories that already have summaries

### Phase 4: User Model Generation
- Collects high-confidence semantic/procedural memories + community summaries
- Generates a comprehensive user profile via LLM
- Stores as `scope:always` memory (included in every retrieval at score 0.85)
- Single user profile, replaced entirely on each enrichment cycle

### Engine API
| Method | Purpose |
|--------|---------|
| `entity_communities()` | Group entities by category for clustering |
| `store_community_summary()` | Create community node with Derived edges |
| `community_summaries()` | Retrieve existing summaries |
| `profile_facts()` | Collect facts for profile generation |
| `store_user_profile()` | Always-scoped memory, auto-replaces previous |
| `user_profile()` | Get current profile |

### LLM Service
- `generate_community_summary()` — summarize entity clusters
- `generate_user_profile()` — synthesize user model from facts + communities
- New types: `CommunitySummary`, `UserProfile`
- New system prompts for both operations

### Full 4-Phase Pipeline
1. **Batch LLM Extraction** — episodic → semantic memories + entities
2. **Entity Linking** — rule-based + LLM resolution
3. **Community Detection** — category clustering + LLM summaries *(new)*
4. **User Model** — always-scoped profile from all knowledge *(new)*

All 500+ tests pass, clippy clean.