### PR TITLE
feat: Enrichment orchestrator + Phase 3 & 4 + SDK docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2224,6 +2224,7 @@ dependencies = [
  "mentedb-context",
  "mentedb-core",
  "mentedb-embedding",
+ "mentedb-extraction",
  "mentedb-graph",
  "mentedb-index",
  "mentedb-query",

--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ result = db.process_turn(
 
 One function call runs the full 14-step cognitive pipeline: embedding, speculative cache, hybrid search, pain signals, episodic storage, fact extraction, contradiction detection, sentiment analysis, and more.
 
+> **Enrichment runs automatically in the background** — semantic facts, entity graphs,
+> community summaries, and a user profile are built over time after each `process_turn`.
+
 **Via MCP (zero code):**
 
 ```bash
@@ -468,6 +471,31 @@ for (id, decision) in decisions {
         _ => {}
     }
 }
+```
+
+## Sleeptime Enrichment
+
+MenteDB includes a 4-phase background enrichment pipeline that automatically converts raw conversations into structured knowledge. It runs after `process_turn` when enough new memories accumulate — no manual trigger needed.
+
+| Phase | What it does |
+|-------|-------------|
+| **Batch LLM Extraction** | Converts episodic memories into semantic facts and entity nodes |
+| **Entity Linking** | Resolves duplicates and aliases (e.g., "JS" ↔ "JavaScript") via rules + LLM |
+| **Community Detection** | Groups related entities by category and generates LLM summaries |
+| **User Model** | Builds an always-available user profile from accumulated knowledge |
+
+Enrichment results feed back into `process_turn` context retrieval — richer semantic memories, entity graphs, community summaries, and the user profile all improve recall quality. The pipeline is idempotent and tracks provenance via `source:enrichment` tags and `Derived` edges.
+
+**Requires an LLM provider** (OpenAI, Anthropic, or Ollama). Without one, the engine works perfectly — enrichment just doesn't run. See [LLM Extraction Config](#llm-extraction-config) for setup.
+
+```rust
+// Enable enrichment in Cargo.toml:
+// mentedb = { version = "0.8", features = ["enrichment"] }
+
+use mentedb::enrichment::{run_enrichment, EnrichmentResult};
+
+let result = run_enrichment(&db, config, &embedder, Some(&cognitive_llm), turn_id).await;
+println!("Stored {} memories, linked {} entities", result.memories_stored, result.sync_linked + result.llm_linked);
 ```
 
 ## Crates

--- a/crates/mentedb/Cargo.toml
+++ b/crates/mentedb/Cargo.toml
@@ -20,10 +20,15 @@ mentedb-context = { workspace = true }
 mentedb-embedding = { workspace = true }
 mentedb-cognitive = { workspace = true }
 mentedb-consolidation = { workspace = true }
+mentedb-extraction = { workspace = true, optional = true }
 uuid = { workspace = true }
 tracing = { workspace = true }
 thiserror = { workspace = true }
 parking_lot.workspace = true
+
+[features]
+default = []
+enrichment = ["dep:mentedb-extraction"]
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/mentedb/src/enrichment.rs
+++ b/crates/mentedb/src/enrichment.rs
@@ -1,0 +1,459 @@
+//! Sleeptime enrichment pipeline orchestrator.
+//!
+//! Runs the full 4-phase enrichment pipeline:
+//! 1. **Batch LLM Extraction** — episodic memories → semantic + entities
+//! 2. **Entity Linking** — rule-based + LLM resolution
+//! 3. **Community Detection** — category clustering + LLM summaries
+//! 4. **User Model** — always-scoped profile from all knowledge
+//!
+//! This module requires the `enrichment` feature flag.
+
+use std::collections::HashSet;
+
+use mentedb_cognitive::llm::{CognitiveLlmService, LlmJudge};
+use mentedb_core::memory::MemoryType;
+use mentedb_core::types::AgentId;
+use mentedb_core::MemoryNode;
+use mentedb_embedding::provider::EmbeddingProvider;
+use mentedb_extraction::{ExtractionConfig, ExtractionPipeline, HttpExtractionProvider};
+
+use crate::MenteDb;
+
+/// Result of a full enrichment run.
+#[derive(Debug, Default)]
+pub struct EnrichmentResult {
+    /// Semantic memories stored from extraction.
+    pub memories_stored: usize,
+    /// Graph edges created across all phases.
+    pub edges_created: usize,
+    /// Entity nodes extracted.
+    pub entities_extracted: usize,
+    /// Duplicate memories skipped.
+    pub duplicates_skipped: usize,
+    /// Contradictions detected.
+    pub contradictions_found: usize,
+    /// Entities linked via sync (cache) resolution.
+    pub sync_linked: usize,
+    /// Entities linked via LLM resolution.
+    pub llm_linked: usize,
+    /// Community summaries created.
+    pub communities_created: usize,
+    /// Whether the user profile was updated.
+    pub user_model_updated: bool,
+}
+
+/// Run the full 4-phase enrichment pipeline.
+///
+/// This is the main entry point for enrichment. Call it when
+/// `db.needs_enrichment()` returns true.
+///
+/// # Arguments
+/// * `db` — The MenteDb instance
+/// * `extraction_config` — LLM extraction provider config
+/// * `embedder` — Embedding provider for new memories
+/// * `cognitive_llm` — Optional LLM service for entity linking, community detection, and user model
+/// * `current_turn` — Current conversation turn (for marking enrichment complete)
+pub async fn run_enrichment<J: LlmJudge>(
+    db: &MenteDb,
+    extraction_config: ExtractionConfig,
+    embedder: &dyn EmbeddingProvider,
+    cognitive_llm: Option<&CognitiveLlmService<J>>,
+    current_turn: u64,
+) -> EnrichmentResult {
+    let mut result = EnrichmentResult::default();
+
+    let candidates = db.enrichment_candidates();
+    if candidates.is_empty() {
+        tracing::debug!("enrichment: no candidates, marking complete");
+        db.mark_enrichment_complete(current_turn);
+        return result;
+    }
+
+    tracing::info!(
+        candidates = candidates.len(),
+        "starting sleeptime enrichment"
+    );
+
+    // ── Phase 1: Batch LLM Extraction ──
+    let http_provider = match HttpExtractionProvider::new(extraction_config.clone()) {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::error!(error = %e, "enrichment: failed to create HTTP provider");
+            db.mark_enrichment_complete(current_turn);
+            return result;
+        }
+    };
+
+    let enrichment_config = db.enrichment_config().clone();
+    let pipeline_cfg = ExtractionConfig {
+        quality_threshold: enrichment_config.min_confidence,
+        ..extraction_config
+    };
+    let pipeline = ExtractionPipeline::new(http_provider, pipeline_cfg);
+
+    let batches = batch_conversations(&candidates, 10);
+
+    for (batch_idx, batch) in batches.iter().enumerate() {
+        let conversation = batch
+            .iter()
+            .map(|m| m.content.as_str())
+            .collect::<Vec<_>>()
+            .join("\n---\n");
+
+        let source_ids: Vec<mentedb_core::types::MemoryId> = batch.iter().map(|m| m.id).collect();
+
+        // Get existing memories for dedup
+        let existing: Vec<MemoryNode> =
+            if let Ok(Some(emb)) = db.embed_text(&conversation[..conversation.len().min(500)]) {
+                db.recall_similar(&emb, 30)
+                    .unwrap_or_default()
+                    .into_iter()
+                    .filter_map(|(id, _)| db.get_memory(id).ok())
+                    .collect()
+            } else {
+                Vec::new()
+            };
+
+        match pipeline.process(&conversation, &existing, embedder).await {
+            Ok(extraction_result) => {
+                result.duplicates_skipped += extraction_result.stats.rejected_duplicate;
+                result.contradictions_found += extraction_result.stats.contradictions_found;
+
+                let mut nodes = Vec::new();
+                for mem in extraction_result
+                    .to_store
+                    .iter()
+                    .chain(extraction_result.contradictions.iter().map(|(m, _)| m))
+                {
+                    let mem_type =
+                        mentedb_extraction::map_extraction_type_to_memory_type(&mem.memory_type);
+                    let embedding = match embedder.embed(&mem.content) {
+                        Ok(e) => e,
+                        Err(e) => {
+                            tracing::warn!(error = %e, "enrichment: embedding failed");
+                            continue;
+                        }
+                    };
+                    let mut node = MemoryNode::new(AgentId::nil(), mem_type, mem.content.clone(), embedding);
+                    node.tags = mem.tags.clone();
+                    node.confidence = mem.confidence;
+                    nodes.push(node);
+                }
+
+                // Build entity nodes
+                for entity in &extraction_result.entities {
+                    let content = entity.to_content();
+                    let embedding_text = entity.embedding_key();
+                    let embedding = match embedder.embed(&embedding_text) {
+                        Ok(e) => e,
+                        Err(e) => {
+                            tracing::warn!(error = %e, "enrichment: entity embedding failed");
+                            continue;
+                        }
+                    };
+                    let mut node =
+                        MemoryNode::new(AgentId::nil(), MemoryType::Semantic, content, embedding);
+                    let name_lower = entity.name.to_lowercase();
+                    node.tags.push(format!("entity:{}", name_lower));
+                    node.tags
+                        .push(format!("entity_type:{}", entity.entity_type));
+                    if let Some(cat) = entity.attributes.get("category") {
+                        for c in cat.split(',').map(|s| s.trim()).filter(|s| !s.is_empty()) {
+                            node.tags.push(format!("category:{}", c.to_lowercase()));
+                        }
+                    }
+                    nodes.push(node);
+                    result.entities_extracted += 1;
+                }
+
+                match db.store_enrichment_memories(nodes, &source_ids) {
+                    Ok((stored, edges)) => {
+                        result.memories_stored += stored;
+                        result.edges_created += edges;
+                    }
+                    Err(e) => {
+                        tracing::error!(batch = batch_idx, error = %e, "enrichment: failed to store batch");
+                    }
+                }
+            }
+            Err(e) => {
+                tracing::error!(batch = batch_idx, error = %e, "enrichment: extraction failed");
+            }
+        }
+    }
+
+    // ── Phase 2: Entity Linking ──
+    let sync_link_result = match db.link_entities() {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::error!(error = %e, "enrichment: sync entity linking failed");
+            crate::EntityLinkResult::default()
+        }
+    };
+    result.sync_linked = sync_link_result.linked;
+    result.edges_created += sync_link_result.edges_created;
+
+    if let Some(llm) = cognitive_llm {
+        let llm_link = run_llm_entity_linking(db, llm).await;
+        result.llm_linked = llm_link.linked;
+        result.edges_created += llm_link.edges_created;
+    }
+
+    // ── Phase 3: Community Detection ──
+    if let Some(llm) = cognitive_llm {
+        result.communities_created = run_community_detection(db, llm).await;
+    }
+
+    // ── Phase 4: User Model ──
+    if let Some(llm) = cognitive_llm {
+        result.user_model_updated = run_user_model(db, llm).await;
+    }
+
+    db.mark_enrichment_complete(current_turn);
+
+    tracing::info!(
+        stored = result.memories_stored,
+        edges = result.edges_created,
+        entities = result.entities_extracted,
+        sync_linked = result.sync_linked,
+        llm_linked = result.llm_linked,
+        duplicates_skipped = result.duplicates_skipped,
+        contradictions = result.contradictions_found,
+        communities = result.communities_created,
+        user_model = result.user_model_updated,
+        batches = batches.len(),
+        "sleeptime enrichment complete"
+    );
+
+    result
+}
+
+/// Phase 2b: LLM entity resolution for unresolved entities.
+async fn run_llm_entity_linking<J: LlmJudge>(
+    db: &MenteDb,
+    llm: &CognitiveLlmService<J>,
+) -> crate::EntityLinkResult {
+    let all_entities_with_context = db.entity_names_with_context();
+    let unresolved = db.unresolved_entity_names();
+
+    if unresolved.is_empty() {
+        return crate::EntityLinkResult::default();
+    }
+
+    tracing::info!(
+        total_entities = all_entities_with_context.len(),
+        unresolved = unresolved.len(),
+        "running LLM entity resolution"
+    );
+
+    let mut candidates: Vec<mentedb_cognitive::EntityCandidate> = all_entities_with_context
+        .iter()
+        .map(|(name, ctx)| mentedb_cognitive::EntityCandidate {
+            name: name.clone(),
+            context: ctx.clone(),
+            memory_id: None,
+        })
+        .collect();
+    candidates.sort_by(|a, b| a.name.cmp(&b.name));
+
+    let batch_size = 50;
+    let mut all_merge_groups = Vec::new();
+
+    for chunk in candidates.chunks(batch_size) {
+        match llm.resolve_entities(chunk).await {
+            Ok(groups) => all_merge_groups.extend(groups),
+            Err(e) => tracing::error!(error = %e, "enrichment: LLM entity resolution failed"),
+        }
+    }
+
+    if all_merge_groups.len() > 1 {
+        all_merge_groups = consolidate_merge_groups(all_merge_groups);
+    }
+
+    if all_merge_groups.is_empty() {
+        return crate::EntityLinkResult::default();
+    }
+
+    let resolutions: Vec<crate::EntityLinkResolution> = all_merge_groups
+        .iter()
+        .map(|g| crate::EntityLinkResolution {
+            canonical: g.canonical.clone(),
+            aliases: g.aliases.clone(),
+            confidence: g.confidence,
+        })
+        .collect();
+
+    let separations: Vec<crate::EntitySeparation> = Vec::new();
+
+    match db.apply_entity_link_resolutions(&resolutions, &separations) {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::error!(error = %e, "enrichment: failed to apply entity resolutions");
+            crate::EntityLinkResult::default()
+        }
+    }
+}
+
+/// Phase 3: Community detection — group entities by category, generate LLM summaries.
+async fn run_community_detection<J: LlmJudge>(
+    db: &MenteDb,
+    llm: &CognitiveLlmService<J>,
+) -> usize {
+    let communities = db.entity_communities();
+    let existing_summaries: HashSet<String> = db
+        .community_summaries()
+        .iter()
+        .flat_map(|m| {
+            m.tags
+                .iter()
+                .filter_map(|t| t.strip_prefix("community:").map(|s| s.to_string()))
+        })
+        .collect();
+
+    let mut created = 0;
+
+    for (category, members) in &communities {
+        if existing_summaries.contains(category) {
+            tracing::debug!(category = %category, "community summary already exists, skipping");
+            continue;
+        }
+
+        let entity_pairs: Vec<(String, String)> =
+            members.iter().take(20).cloned().collect();
+
+        match llm.generate_community_summary(category, &entity_pairs).await {
+            Ok(summary) => {
+                let member_names: Vec<String> =
+                    entity_pairs.iter().map(|(n, _)| n.clone()).collect();
+                match db.store_community_summary(category, &summary.summary, &member_names) {
+                    Ok(_) => {
+                        created += 1;
+                        tracing::info!(category = %category, members = members.len(), "community summary created");
+                    }
+                    Err(e) => {
+                        tracing::error!(error = %e, category = %category, "failed to store community summary");
+                    }
+                }
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, category = %category, "LLM community summary failed");
+            }
+        }
+    }
+
+    created
+}
+
+/// Phase 4: User model generation — synthesize always-scoped profile.
+async fn run_user_model<J: LlmJudge>(
+    db: &MenteDb,
+    llm: &CognitiveLlmService<J>,
+) -> bool {
+    let facts = db.profile_facts();
+    let community_texts: Vec<String> = db
+        .community_summaries()
+        .iter()
+        .map(|m| m.content.clone())
+        .collect();
+
+    if facts.len() < 3 && community_texts.is_empty() {
+        return false;
+    }
+
+    match llm.generate_user_profile(&facts, &community_texts).await {
+        Ok(profile) => match db.store_user_profile(&profile.profile) {
+            Ok(_) => {
+                tracing::info!("user profile updated");
+                true
+            }
+            Err(e) => {
+                tracing::error!(error = %e, "failed to store user profile");
+                false
+            }
+        },
+        Err(e) => {
+            tracing::warn!(error = %e, "LLM user profile generation failed");
+            false
+        }
+    }
+}
+
+/// Split memories into batches.
+fn batch_conversations(memories: &[MemoryNode], batch_size: usize) -> Vec<Vec<MemoryNode>> {
+    memories
+        .chunks(batch_size)
+        .map(|chunk| chunk.to_vec())
+        .collect()
+}
+
+/// Transitively consolidate merge groups from independent LLM batches.
+///
+/// Uses union-find to merge groups that share entity names across batch boundaries.
+fn consolidate_merge_groups(
+    groups: Vec<mentedb_cognitive::llm::EntityMergeGroup>,
+) -> Vec<mentedb_cognitive::llm::EntityMergeGroup> {
+    use std::collections::{HashMap, HashSet};
+
+    let mut name_to_group: HashMap<String, usize> = HashMap::new();
+    let mut parent: Vec<usize> = (0..groups.len()).collect();
+
+    fn find(parent: &mut [usize], i: usize) -> usize {
+        if parent[i] != i {
+            parent[i] = find(parent, parent[i]);
+        }
+        parent[i]
+    }
+
+    fn union(parent: &mut [usize], a: usize, b: usize) {
+        let ra = find(parent, a);
+        let rb = find(parent, b);
+        if ra != rb {
+            parent[ra] = rb;
+        }
+    }
+
+    for (idx, group) in groups.iter().enumerate() {
+        let all_names = std::iter::once(&group.canonical).chain(group.aliases.iter());
+        for name in all_names {
+            let key = name.to_lowercase();
+            if let Some(&existing_idx) = name_to_group.get(&key) {
+                union(&mut parent, idx, existing_idx);
+            }
+            name_to_group.insert(key, idx);
+        }
+    }
+
+    let mut root_groups: HashMap<usize, Vec<usize>> = HashMap::new();
+    for i in 0..groups.len() {
+        let root = find(&mut parent, i);
+        root_groups.entry(root).or_default().push(i);
+    }
+
+    root_groups
+        .into_values()
+        .map(|indices| {
+            let mut all_names: HashSet<String> = HashSet::new();
+            let mut best_confidence: f32 = 0.0;
+            let mut canonical = String::new();
+
+            for &idx in &indices {
+                let g = &groups[idx];
+                all_names.insert(g.canonical.clone());
+                for a in &g.aliases {
+                    all_names.insert(a.clone());
+                }
+                if g.confidence > best_confidence {
+                    best_confidence = g.confidence;
+                    canonical = g.canonical.clone();
+                }
+            }
+
+            all_names.remove(&canonical);
+            mentedb_cognitive::llm::EntityMergeGroup {
+                canonical,
+                aliases: all_names.into_iter().collect(),
+                confidence: best_confidence,
+            }
+        })
+        .collect()
+}

--- a/crates/mentedb/src/enrichment.rs
+++ b/crates/mentedb/src/enrichment.rs
@@ -11,9 +11,9 @@
 use std::collections::HashSet;
 
 use mentedb_cognitive::llm::{CognitiveLlmService, LlmJudge};
+use mentedb_core::MemoryNode;
 use mentedb_core::memory::MemoryType;
 use mentedb_core::types::AgentId;
-use mentedb_core::MemoryNode;
 use mentedb_embedding::provider::EmbeddingProvider;
 use mentedb_extraction::{ExtractionConfig, ExtractionPipeline, HttpExtractionProvider};
 
@@ -134,7 +134,8 @@ pub async fn run_enrichment<J: LlmJudge>(
                             continue;
                         }
                     };
-                    let mut node = MemoryNode::new(AgentId::nil(), mem_type, mem.content.clone(), embedding);
+                    let mut node =
+                        MemoryNode::new(AgentId::nil(), mem_type, mem.content.clone(), embedding);
                     node.tags = mem.tags.clone();
                     node.confidence = mem.confidence;
                     nodes.push(node);
@@ -295,10 +296,7 @@ async fn run_llm_entity_linking<J: LlmJudge>(
 }
 
 /// Phase 3: Community detection — group entities by category, generate LLM summaries.
-async fn run_community_detection<J: LlmJudge>(
-    db: &MenteDb,
-    llm: &CognitiveLlmService<J>,
-) -> usize {
+async fn run_community_detection<J: LlmJudge>(db: &MenteDb, llm: &CognitiveLlmService<J>) -> usize {
     let communities = db.entity_communities();
     let existing_summaries: HashSet<String> = db
         .community_summaries()
@@ -318,10 +316,12 @@ async fn run_community_detection<J: LlmJudge>(
             continue;
         }
 
-        let entity_pairs: Vec<(String, String)> =
-            members.iter().take(20).cloned().collect();
+        let entity_pairs: Vec<(String, String)> = members.iter().take(20).cloned().collect();
 
-        match llm.generate_community_summary(category, &entity_pairs).await {
+        match llm
+            .generate_community_summary(category, &entity_pairs)
+            .await
+        {
             Ok(summary) => {
                 let member_names: Vec<String> =
                     entity_pairs.iter().map(|(n, _)| n.clone()).collect();
@@ -345,10 +345,7 @@ async fn run_community_detection<J: LlmJudge>(
 }
 
 /// Phase 4: User model generation — synthesize always-scoped profile.
-async fn run_user_model<J: LlmJudge>(
-    db: &MenteDb,
-    llm: &CognitiveLlmService<J>,
-) -> bool {
+async fn run_user_model<J: LlmJudge>(db: &MenteDb, llm: &CognitiveLlmService<J>) -> bool {
     let facts = db.profile_facts();
     let community_texts: Vec<String> = db
         .community_summaries()

--- a/crates/mentedb/src/lib.rs
+++ b/crates/mentedb/src/lib.rs
@@ -98,6 +98,10 @@ pub use mentedb_storage as storage;
 /// Unified process_turn orchestration.
 pub mod process_turn;
 
+/// Sleeptime enrichment pipeline (requires `enrichment` feature).
+#[cfg(feature = "enrichment")]
+pub mod enrichment;
+
 /// Commonly used types, re-exported for convenience.
 pub mod prelude {
     pub use mentedb_core::edge::EdgeType;

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -36,6 +36,12 @@ with MenteDB("./agent-memory") as db:
     # result.facts_extracted — what was learned this turn
     # result.contradiction_count — conflicting beliefs detected
 
+    # Sleeptime enrichment runs automatically after process_turn:
+    # - Extracts semantic facts from conversations
+    # - Links and deduplicates entities
+    # - Builds community summaries and user profile
+    # Requires LLM config: MENTEDB_OPENAI_API_KEY or MENTEDB_ANTHROPIC_API_KEY
+
     # Or use low-level APIs directly:
 
     # Store a memory
@@ -66,6 +72,14 @@ with MenteDB("./agent-memory") as db:
 
 The SDK also exposes MenteDB cognitive subsystems for real time stream
 monitoring, conversation trajectory tracking, and pain signal management.
+
+## Sleeptime Enrichment
+
+MenteDB automatically enriches memories in the background after `process_turn`. The pipeline extracts semantic facts, links and deduplicates entities, groups them into communities with summaries, and builds a user profile — all feeding back into future `process_turn` context retrieval.
+
+Requires an LLM provider: set `MENTEDB_OPENAI_API_KEY` or `MENTEDB_ANTHROPIC_API_KEY`. Without one, the engine works normally — enrichment just doesn't run.
+
+## Cognitive subsystems
 
 ```python
 from mentedb._mentedb_python import CognitionStream, TrajectoryTracker, PainRegistry

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -25,6 +25,20 @@ import { MenteDB, MemoryType, EdgeType } from 'mentedb';
 
 const db = new MenteDB('./my-agent-memory');
 
+// Primary API — one call does everything
+const result = await db.processTurn(
+  "I prefer using TypeScript for backend services",
+  "Noted! TypeScript is great for type-safe backends.",
+  0 // turn_id
+);
+
+console.log(result.context);     // relevant memories
+console.log(result.stored);      // number of new memories
+// Enrichment runs automatically — builds semantic facts,
+// entity graphs, and user profile over time
+
+// Low-level APIs:
+
 // Store a memory
 const id = db.store({
   content: 'The deploy key rotates every 90 days',
@@ -84,6 +98,12 @@ tracker.recordTurn('Token lifetime', 'decided:15 minutes');
 const resume = tracker.getResumeContext();
 const next = tracker.predictNextTopics();
 ```
+
+## Sleeptime Enrichment
+
+MenteDB automatically enriches memories in the background after `processTurn`. The pipeline extracts semantic facts, links and deduplicates entities, groups them into communities with summaries, and builds a user profile — all feeding back into future `processTurn` context retrieval.
+
+Requires an LLM provider: set `MENTEDB_OPENAI_API_KEY` or `MENTEDB_ANTHROPIC_API_KEY`. Without one, the engine works normally — enrichment just doesn't run.
 
 ## API reference
 


### PR DESCRIPTION
## Summary

Moves the full 4-phase sleeptime enrichment pipeline into the engine and adds Phase 3 (Community Detection) and Phase 4 (User Model).

### What's new

**Enrichment Orchestrator** (`crates/mentedb/src/enrichment.rs`)
- Feature-gated behind `enrichment` flag — any consumer (MCP, SDK, platform) can call `mentedb::enrichment::run_enrichment()`
- Full 4-phase pipeline: Extraction → Entity Linking → Community Detection → User Model
- Idempotent, provenance-tracked via `source:enrichment` tags and `Derived` edges

**Phase 3: Community Detection**
- Groups entities by category (`entity_type:` tag)
- LLM generates summaries for communities with 2+ members
- Stores as `community_summary` tagged memories with edges to member entities

**Phase 4: User Model**
- Builds always-scoped user profile from semantic/procedural facts + community summaries
- Single memory replaced each cycle — always up-to-date
- Score 0.85 in every retrieval via `scope:always` tag

**Code Review Fixes**
- Timestamp=0 on community edges → use `SystemTime::now()`
- Stale edges on summary update → re-create edges
- LLM sees 20 entities but edges linked ALL → only link entities sent to LLM
- UTF-8 safe truncation via `chars().take(N)`
- Guard for empty inputs in profile/community generation

**README Updates**
- Main README: Sleeptime Enrichment section with 4-phase table + Rust example
- Python SDK: process_turn enrichment note + new section
- TypeScript SDK: processTurn Quick Start example + new section

### Engine API additions
- `entity_communities()`, `store_community_summary()`, `community_summaries()`
- `profile_facts()`, `store_user_profile()`, `user_profile()`
- `enrichment::run_enrichment()` — main orchestrator entry point
- `enrichment::EnrichmentResult` — structured result type
