### PR TITLE
fix: WAL durability, page checksums, graph cleanup, salience O(1)

### DIFF
--- a/benchmarks/longmemeval/pre_extract.py
+++ b/benchmarks/longmemeval/pre_extract.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""
+Pre-extract all unique sessions from LongMemEval dataset.
+
+Saves extraction results to a JSON cache file so the benchmark can
+skip redundant LLM calls when processing per-question isolated DBs.
+
+Usage:
+    python benchmarks/longmemeval/pre_extract.py [--workers 20] [--cache-file extractions.json]
+
+Environment:
+    OPENAI_API_KEY / MENTEDB_LLM_PROVIDER / MENTEDB_LLM_API_KEY
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime, timezone
+
+from tqdm import tqdm
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from harness import has_llm_key
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+DATA_DIR = os.path.join(SCRIPT_DIR, "data")
+
+DATASET_FILES = {
+    "s": "longmemeval_s_cleaned.json",
+    "m": "longmemeval_m_cleaned.json",
+    "oracle": "longmemeval_oracle.json",
+}
+
+
+def load_dataset(variant="s"):
+    filepath = os.path.join(DATA_DIR, DATASET_FILES.get(variant, ""))
+    if not os.path.exists(filepath):
+        print(f"Dataset not found: {filepath}")
+        sys.exit(1)
+    with open(filepath) as f:
+        return json.load(f)
+
+
+def format_session(session, date):
+    lines = [f"[Date: {date}]"]
+    for turn in session:
+        role = turn["role"].capitalize()
+        lines.append(f"  {role}: {turn['content']}")
+    return "\n".join(lines)
+
+
+def collect_unique_sessions(dataset):
+    """Deduplicate sessions across all questions."""
+    seen = {}
+    for q in dataset:
+        for sid, sess, date in zip(
+            q["haystack_session_ids"], q["haystack_sessions"], q["haystack_dates"]
+        ):
+            if sid not in seen:
+                seen[sid] = (sess, date)
+    return [(sid, sess, date) for sid, (sess, date) in seen.items()]
+
+
+def extract_one(db, text, llm_provider, max_retries=5):
+    for attempt in range(max_retries):
+        try:
+            return ("ok", db.extract(text, provider=llm_provider))
+        except Exception as e:
+            err = str(e).lower()
+            if "401" in err or "unauthorized" in err:
+                return ("fatal", str(e))
+            if "404" in err or "not found" in err:
+                return ("model_error", str(e))
+            if attempt < max_retries - 1:
+                time.sleep(3 * (2 ** attempt))
+            else:
+                return ("fail", str(e))
+    return ("fail", "max retries exceeded")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Pre-extract LongMemEval sessions")
+    parser.add_argument("--variant", default="s", choices=["s", "m", "oracle"])
+    parser.add_argument("--workers", type=int, default=20)
+    parser.add_argument("--cache-file", default=os.path.join(SCRIPT_DIR, "extraction_cache.json"))
+    args = parser.parse_args()
+
+    if not has_llm_key():
+        print("Need OPENAI_API_KEY or MENTEDB_LLM_PROVIDER + MENTEDB_LLM_API_KEY")
+        sys.exit(1)
+
+    # Setup LLM provider
+    explicit = os.environ.get("MENTEDB_LLM_PROVIDER", "")
+    if explicit == "openai":
+        cognitive_provider = "openai"
+        os.environ.setdefault("MENTEDB_LLM_API_KEY", os.environ.get("OPENAI_API_KEY", ""))
+    elif explicit == "anthropic":
+        cognitive_provider = "anthropic"
+        os.environ.setdefault("MENTEDB_LLM_API_KEY", os.environ.get("ANTHROPIC_API_KEY", ""))
+    elif os.environ.get("OPENAI_API_KEY"):
+        cognitive_provider = "openai"
+        os.environ.setdefault("MENTEDB_LLM_PROVIDER", "openai")
+        os.environ.setdefault("MENTEDB_LLM_API_KEY", os.environ["OPENAI_API_KEY"])
+    else:
+        print("Need LLM provider for extraction")
+        sys.exit(1)
+
+    cognitive_model = os.environ.get("MENTEDB_LLM_MODEL", "gpt-4o-mini")
+    os.environ["MENTEDB_LLM_MODEL"] = cognitive_model
+
+    import mentedb as mentedb_pkg
+    import tempfile
+
+    # Create a throwaway DB just for the extract() method
+    tmp_dir = tempfile.mkdtemp(prefix="longmemeval-extract-")
+    db = mentedb_pkg.MenteDB(tmp_dir, embedding_provider="hash")
+
+    dataset = load_dataset(args.variant)
+    unique_sessions = collect_unique_sessions(dataset)
+
+    # Load existing cache for resume support
+    cache = {}
+    if os.path.exists(args.cache_file):
+        with open(args.cache_file) as f:
+            cache = json.load(f)
+        print(f"Loaded {len(cache)} cached extractions from {args.cache_file}")
+
+    # Filter out already-extracted sessions
+    remaining = [(sid, sess, date) for sid, sess, date in unique_sessions if sid not in cache]
+
+    print(f"{'='*60}")
+    print(f"  LongMemEval Pre-Extraction")
+    print(f"{'='*60}")
+    print(f"  Dataset:     {args.variant} ({len(dataset)} questions)")
+    print(f"  Total unique sessions: {len(unique_sessions)}")
+    print(f"  Already cached:        {len(cache)}")
+    print(f"  Remaining:             {len(remaining)}")
+    print(f"  Extractor:   {cognitive_provider} / {cognitive_model}")
+    print(f"  Workers:     {args.workers}")
+    print(f"  Cache file:  {args.cache_file}")
+    print(f"{'='*60}")
+
+    if not remaining:
+        print("\nAll sessions already extracted!")
+        db.close()
+        return
+
+    # Prepare texts
+    texts = {}
+    for sid, sess, date in remaining:
+        texts[sid] = format_session(sess, date)
+
+    # Extract in parallel with periodic saves
+    ok_count = 0
+    fail_count = 0
+    SAVE_INTERVAL = 200
+
+    def do_extract(sid):
+        return sid, extract_one(db, texts[sid], cognitive_provider)
+
+    with ThreadPoolExecutor(max_workers=args.workers) as pool:
+        futures = {pool.submit(do_extract, sid): sid for sid, _, _ in remaining}
+        pbar = tqdm(total=len(remaining), desc="Extracting")
+
+        for future in as_completed(futures):
+            sid, (status, payload) = future.result()
+            pbar.update(1)
+
+            if status == "ok":
+                cache[sid] = payload
+                ok_count += 1
+            elif status == "fatal":
+                print(f"\nFATAL: {payload[:200]}")
+                break
+            else:
+                cache[sid] = None  # mark as failed so we don't retry forever
+                fail_count += 1
+                if fail_count <= 3:
+                    print(f"\nFailed {sid}: {payload[:100]}")
+
+            # Periodic save
+            if (ok_count + fail_count) % SAVE_INTERVAL == 0:
+                with open(args.cache_file, "w") as f:
+                    json.dump(cache, f)
+
+        pbar.close()
+
+    # Final save
+    with open(args.cache_file, "w") as f:
+        json.dump(cache, f)
+
+    db.close()
+    import shutil
+    shutil.rmtree(tmp_dir, ignore_errors=True)
+
+    total_cached = sum(1 for v in cache.values() if v is not None)
+    print(f"\nDone! {ok_count} new extractions, {fail_count} failures")
+    print(f"Total cached: {total_cached} / {len(unique_sessions)}")
+    print(f"Cache saved to: {args.cache_file}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/longmemeval/run_benchmark.py
+++ b/benchmarks/longmemeval/run_benchmark.py
@@ -45,6 +45,10 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 DATA_DIR = os.path.join(SCRIPT_DIR, "data")
 RESULTS_DIR = os.path.join(SCRIPT_DIR, "results")
 
+# Global extraction cache: session_id -> list of extracted memory dicts
+# Loaded once at startup when --extraction-cache is used.
+EXTRACTION_CACHE = {}
+
 DATASET_FILES = {
     "s": "longmemeval_s_cleaned.json",
     "m": "longmemeval_m_cleaned.json",
@@ -120,13 +124,15 @@ def _extract_one(db, text, llm_provider, max_retries=5):
 def ingest_sessions(db, question_data, use_cognitive=True, llm_provider=None):
     """Ingest all chat sessions for a question into MenteDB.
 
-    When use_cognitive=True, extractions run in parallel (GIL released during
-    HTTP calls), then results are stored sequentially.
+    When EXTRACTION_CACHE is populated, uses cached extractions instead of
+    calling the LLM. Otherwise extractions run in parallel (GIL released
+    during HTTP calls), then results are stored sequentially.
     """
     from concurrent.futures import ThreadPoolExecutor, as_completed
 
     sessions = question_data["haystack_sessions"]
     dates = question_data["haystack_dates"]
+    session_ids = question_data.get("haystack_session_ids", [None] * len(sessions))
     thread = threading.current_thread().name
     total = len(sessions)
 
@@ -141,39 +147,57 @@ def ingest_sessions(db, question_data, use_cognitive=True, llm_provider=None):
             memory_ids.append(mid)
         return memory_ids
 
-    # Phase 1: Extract all sessions in parallel (GIL released during HTTP)
     texts = [format_session(s, d) for s, d in zip(sessions, dates)]
-    extracted = [None] * total
+
+    # Check if we can use the extraction cache
+    if EXTRACTION_CACHE:
+        extracted = []
+        cache_hits = 0
+        for sid in session_ids:
+            cached = EXTRACTION_CACHE.get(sid)
+            if cached is not None:
+                extracted.append(cached)
+                cache_hits += 1
+            else:
+                extracted.append(None)
+        if cache_hits > 0:
+            print(f"    [{thread}] cache hits: {cache_hits}/{total}", flush=True)
+    else:
+        extracted = [None] * total
+
+    # Extract any sessions not in cache
+    uncached = [(i, texts[i]) for i in range(total) if extracted[i] is None and use_cognitive]
     cognitive_ok = 0
     cognitive_fail = 0
     first_error_msg = None
 
-    with ThreadPoolExecutor(max_workers=10) as pool:
-        futures = {pool.submit(_extract_one, db, text, llm_provider): i
-                   for i, text in enumerate(texts)}
-        done = 0
-        for f in as_completed(futures):
-            idx = futures[f]
-            status, payload = f.result()
-            done += 1
+    if uncached:
+        with ThreadPoolExecutor(max_workers=10) as pool:
+            futures = {pool.submit(_extract_one, db, text, llm_provider): i
+                       for i, text in uncached}
+            done = 0
+            for f in as_completed(futures):
+                idx = futures[f]
+                status, payload = f.result()
+                done += 1
 
-            if status == "ok":
-                extracted[idx] = payload
-                cognitive_ok += 1
-            else:
-                cognitive_fail += 1
-                if first_error_msg is None:
-                    first_error_msg = payload
-                    if status == "fatal":
-                        print(f"    [{thread}] ⚠️  FATAL: {payload[:200]}", flush=True)
-                        print(f"    [{thread}] ⚠️  Check MENTEDB_LLM_API_KEY and MENTEDB_LLM_PROVIDER", flush=True)
-                    elif status == "model_error":
-                        print(f"    [{thread}] ⚠️  MODEL ERROR: {payload[:200]}", flush=True)
-                    else:
-                        print(f"    [{thread}] ⚠️  Extraction error: {payload[:200]}", flush=True)
+                if status == "ok":
+                    extracted[idx] = payload
+                    cognitive_ok += 1
+                else:
+                    cognitive_fail += 1
+                    if first_error_msg is None:
+                        first_error_msg = payload
+                        if status == "fatal":
+                            print(f"    [{thread}] FATAL: {payload[:200]}", flush=True)
+                        elif status == "model_error":
+                            print(f"    [{thread}] MODEL ERROR: {payload[:200]}", flush=True)
+                        else:
+                            print(f"    [{thread}] Extraction error: {payload[:200]}", flush=True)
 
-            if done % 10 == 0 or done == total:
-                print(f"    [{thread}] extracted {done}/{total} (ok: {cognitive_ok}, fail: {cognitive_fail})", flush=True)
+                if done % 10 == 0 or done == len(uncached):
+                    print(f"    [{thread}] extracted {done}/{len(uncached)} (ok: {cognitive_ok}, fail: {cognitive_fail})", flush=True)
+
 
     # Phase 2: Store all extracted memories sequentially (fast, local only)
     memory_ids = []
@@ -182,17 +206,14 @@ def ingest_sessions(db, question_data, use_cognitive=True, llm_provider=None):
             result = db.store_extracted(memories)
             memory_ids.extend(result.get("stored_ids", []))
 
-    # Phase 3: Store raw sessions as episodic memories for keyword coverage.
-    # Extracted facts capture the "gist" but may miss casual details like
-    # place names or numbers. BM25 search on raw text catches those.
-    # Use store_extracted for batch embedding (1 API call instead of 50).
+    # Phase 3: Store raw sessions as semantic memories for keyword coverage.
+    # Using semantic (not episodic) so enrichment_candidates() won't re-extract them.
     raw_memories = []
     for i, (text, date) in enumerate(zip(texts, dates)):
-        # Cap content to avoid exceeding node size limits (32KB max)
         content = text[:8000] if len(text) > 8000 else text
         raw_memories.append({
             "content": content,
-            "memory_type": "episodic",
+            "memory_type": "semantic",
             "tags": [f"date:{date}", f"session:{i}", "raw"],
             "confidence": 0.3,
             "embedding_key": text[:500],
@@ -200,8 +221,7 @@ def ingest_sessions(db, question_data, use_cognitive=True, llm_provider=None):
     result = db.store_extracted(raw_memories)
     memory_ids.extend(result.get("stored_ids", []))
 
-    # Build community summaries for entity clusters (e.g., "health devices", "musical instruments")
-    # These summaries make entities discoverable by abstract category queries.
+    # Build community summaries for entity clusters
     if use_cognitive and llm_provider:
         try:
             community_ids = db.build_communities()
@@ -212,6 +232,29 @@ def ingest_sessions(db, question_data, use_cognitive=True, llm_provider=None):
 
     print(f"    [{thread}] stored {len(memory_ids)} memories", flush=True)
     return memory_ids
+
+
+def run_enrichment_pipeline(db, cognitive_provider, thread_name="main"):
+    """Run Phases 2-4 of the sleeptime enrichment pipeline after ingestion.
+
+    Phase 1 (batch LLM extraction) is skipped because ingest_sessions
+    already extracts memories. This runs:
+      Phase 2: Entity linking (rule-based + LLM resolution)
+      Phase 3: Community detection with LLM summaries
+      Phase 4: User model generation
+    """
+    try:
+        result = db.run_enrichment(provider=cognitive_provider, current_turn=0, skip_extraction=True)
+        print(f"    [{thread_name}] enrichment complete: "
+              f"stored={result['memories_stored']}, "
+              f"entities={result['entities_extracted']}, "
+              f"linked={result['sync_linked']}+{result['llm_linked']}(llm), "
+              f"communities={result['communities_created']}, "
+              f"user_model={result['user_model_updated']}", flush=True)
+        return result
+    except Exception as e:
+        print(f"    [{thread_name}] enrichment failed: {e}", flush=True)
+        return None
 
 
 def retrieve_and_answer(db, question_data, llm_client, llm_provider, top_k=20, reader_model=None):
@@ -255,7 +298,8 @@ def retrieve_and_answer(db, question_data, llm_client, llm_provider, top_k=20, r
 
 def process_single_question(question_data, embedding_provider, embedding_api_key,
                             embedding_model, use_cognitive, cognitive_provider,
-                            llm_provider, top_k, reader_model=None):
+                            llm_provider, top_k, reader_model=None,
+                            run_enrichment_pipeline_flag=False):
     """Process a single question end-to-end. Designed to run in a thread pool."""
     import mentedb as mentedb_pkg
     import shutil
@@ -285,7 +329,17 @@ def process_single_question(question_data, embedding_provider, embedding_api_key
         mids = ingest_sessions(db, question_data, use_cognitive=use_cognitive,
                        llm_provider=cognitive_provider)
         ingest_time = time.time() - ingest_start
-        print(f"  [{thread}] {qid} — ingested {len(mids)} memories in {ingest_time:.0f}s, searching...", flush=True)
+        print(f"  [{thread}] {qid} — ingested {len(mids)} memories in {ingest_time:.0f}s", flush=True)
+
+        # Run enrichment pipeline if requested (after all sessions are ingested)
+        if run_enrichment_pipeline_flag and cognitive_provider:
+            enrich_start = time.time()
+            print(f"  [{thread}] {qid} — running enrichment pipeline...", flush=True)
+            run_enrichment_pipeline(db, cognitive_provider, thread_name=thread)
+            enrich_time = time.time() - enrich_start
+            print(f"  [{thread}] {qid} — enrichment took {enrich_time:.0f}s", flush=True)
+
+        print(f"  [{thread}] {qid} — searching...", flush=True)
 
         search_start = time.time()
         # Retry search+answer on transient connection errors (20 attempts)
@@ -324,7 +378,8 @@ def process_single_question(question_data, embedding_provider, embedding_api_key
 
 
 def run_benchmark(variant="s", top_k=60, limit=None, offset=0, resume_from=None,
-                  use_cognitive=True, workers=3, reader_model=None):
+                  use_cognitive=True, workers=3, reader_model=None,
+                  use_enrichment=False):
     """Run the full LongMemEval benchmark."""
     if not has_llm_key():
         print("Need OPENAI_API_KEY, ANTHROPIC_API_KEY, or OLLAMA_MODEL for answer generation.")
@@ -418,6 +473,7 @@ def run_benchmark(variant="s", top_k=60, limit=None, offset=0, resume_from=None,
         print(f"    Provider:       {cognitive_provider}")
         print(f"    Model:          {cognitive_model}")
     print(f"  Reader:           {llm_provider} / {reader_model}")
+    print(f"  Enrichment:       {'ON (4-phase pipeline)' if use_enrichment else 'OFF'}")
     print(f"  Top-K:            {top_k}")
     print(f"  Workers:          {workers}")
     print(f"  Engine features:")
@@ -443,7 +499,8 @@ def run_benchmark(variant="s", top_k=60, limit=None, offset=0, resume_from=None,
     run_tag = f"q{range_start}-{range_end}"
 
     os.makedirs(RESULTS_DIR, exist_ok=True)
-    output_file = os.path.join(RESULTS_DIR, f"hypotheses_{run_tag}.jsonl")
+    enrichment_tag = "_enriched" if use_enrichment else ""
+    output_file = os.path.join(RESULTS_DIR, f"hypotheses{enrichment_tag}_{run_tag}.jsonl")
 
     print(f"  Questions:        {range_start}..{range_end} of {total_available}")
     print(f"  Output:           {output_file}")
@@ -484,6 +541,7 @@ def run_benchmark(variant="s", top_k=60, limit=None, offset=0, resume_from=None,
                 question_data, embedding_provider, embedding_api_key,
                 embedding_model, use_cognitive, cognitive_provider,
                 llm_provider, top_k, reader_model=reader_model,
+                run_enrichment_pipeline_flag=use_enrichment,
             )
             results.append(entry)
             with open(output_file, "a") as f:
@@ -500,6 +558,7 @@ def run_benchmark(variant="s", top_k=60, limit=None, offset=0, resume_from=None,
                     question_data, embedding_provider, embedding_api_key,
                     embedding_model, use_cognitive, cognitive_provider,
                     llm_provider, top_k, reader_model,
+                    use_enrichment,
                 )
                 futures[future] = question_data["question_id"]
 
@@ -560,7 +619,19 @@ def main():
                         help="Number of parallel workers (default: 3)")
     parser.add_argument("--reader-model", type=str, default=None,
                         help="Override reader model (default: gpt-4o for OpenAI, Sonnet for Anthropic)")
+    parser.add_argument("--enrichment", action="store_true",
+                        help="Run full 4-phase sleeptime enrichment after ingestion")
+    parser.add_argument("--extraction-cache", type=str, default=None,
+                        help="Path to extraction cache JSON (from pre_extract.py)")
     args = parser.parse_args()
+
+    # Load extraction cache if provided
+    if args.extraction_cache and os.path.exists(args.extraction_cache):
+        global EXTRACTION_CACHE
+        with open(args.extraction_cache) as f:
+            EXTRACTION_CACHE = json.load(f)
+        valid = sum(1 for v in EXTRACTION_CACHE.values() if v is not None)
+        print(f"Loaded extraction cache: {valid} sessions from {args.extraction_cache}")
 
     run_benchmark(
         variant=args.dataset,
@@ -571,6 +642,7 @@ def main():
         use_cognitive=not args.no_cognitive,
         workers=args.workers,
         reader_model=args.reader_model,
+        use_enrichment=args.enrichment,
     )
 
 

--- a/benchmarks/longmemeval/run_enriched.py
+++ b/benchmarks/longmemeval/run_enriched.py
@@ -1,0 +1,550 @@
+#!/usr/bin/env python3
+"""
+LongMemEval Benchmark with Sleeptime Enrichment — Two-Phase Architecture
+
+Unlike run_benchmark.py (which creates isolated DBs per question), this script
+mirrors how MenteDB is actually used in production:
+
+  Phase 1 — Global Ingest:
+    Ingest ALL unique sessions into a single shared DB with LLM extraction,
+    then run the full 4-phase enrichment pipeline ONCE on the whole corpus.
+    This builds cross-session entity links, community summaries, and a user model.
+
+  Phase 2 — Query:
+    For each question, query the shared DB with search_expanded().
+    The engine surfaces relevant memories using the enriched graph.
+
+This is ~30x cheaper than per-question enrichment and tests the real value
+of enrichment: cross-session knowledge linking.
+
+Usage:
+    python benchmarks/longmemeval/run_enriched.py [options]
+
+Environment:
+    OPENAI_API_KEY         For embeddings and/or answer generation
+    ANTHROPIC_API_KEY      Alternative for answer generation
+    MENTEDB_LLM_PROVIDER   LLM provider for extraction + enrichment
+    MENTEDB_LLM_API_KEY    API key for extraction + enrichment
+"""
+
+import argparse
+import json
+import os
+import sys
+import tempfile
+import threading
+import time
+from datetime import datetime, timezone
+
+from tqdm import tqdm
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from harness import get_llm_client, has_llm_key, llm_chat
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+DATA_DIR = os.path.join(SCRIPT_DIR, "data")
+RESULTS_DIR = os.path.join(SCRIPT_DIR, "results")
+
+DATASET_FILES = {
+    "s": "longmemeval_s_cleaned.json",
+    "m": "longmemeval_m_cleaned.json",
+    "oracle": "longmemeval_oracle.json",
+}
+
+READER_PROMPT = """I will give you several history chats between you and a user. Please answer the question based on the relevant chat history.
+
+History Chats:
+
+{retrieved_context}
+
+Current Date: {question_date}
+Question: {question}
+Answer:"""
+
+
+def load_dataset(variant="s"):
+    filepath = os.path.join(DATA_DIR, DATASET_FILES.get(variant, ""))
+    if not os.path.exists(filepath):
+        print(f"Dataset not found: {filepath}")
+        print("Run: python benchmarks/longmemeval/download_data.py")
+        sys.exit(1)
+    with open(filepath) as f:
+        return json.load(f)
+
+
+def format_session(session, date):
+    lines = [f"[Date: {date}]"]
+    for turn in session:
+        role = turn["role"].capitalize()
+        lines.append(f"  {role}: {turn['content']}")
+    return "\n".join(lines)
+
+
+def date_to_microseconds(date_str):
+    try:
+        dt = datetime.strptime(date_str, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+        return int(dt.timestamp() * 1_000_000)
+    except (ValueError, TypeError):
+        return None
+
+
+def _extract_one(db, text, llm_provider, max_retries=5):
+    for attempt in range(max_retries):
+        try:
+            return ("ok", db.extract(text, provider=llm_provider))
+        except Exception as e:
+            err = str(e).lower()
+            if "401" in err or "unauthorized" in err or "invalid_api_key" in err:
+                return ("fatal", str(e))
+            if "404" in err or "not found" in err or "does not exist" in err:
+                return ("model_error", str(e))
+            if attempt < max_retries - 1:
+                time.sleep(3 * (2 ** attempt))
+            else:
+                return ("fail", str(e))
+    return ("fail", "max retries exceeded")
+
+
+# ─── Phase 1: Global Ingest ─────────────────────────────────────────────────
+
+def collect_unique_sessions(dataset):
+    """Deduplicate sessions across all questions. Returns list of (session_id, session, date)."""
+    seen = {}
+    for q in dataset:
+        for sid, sess, date in zip(
+            q["haystack_session_ids"], q["haystack_sessions"], q["haystack_dates"]
+        ):
+            if sid not in seen:
+                seen[sid] = (sess, date)
+    return [(sid, sess, date) for sid, (sess, date) in seen.items()]
+
+
+def global_ingest(db, unique_sessions, cognitive_provider, workers=10):
+    """Ingest all unique sessions into a single shared DB with LLM extraction."""
+    from concurrent.futures import ThreadPoolExecutor, as_completed
+
+    total = len(unique_sessions)
+    print(f"\n  Phase 1a: Extracting {total} unique sessions...")
+
+    texts = []
+    dates = []
+    session_ids = []
+    for sid, sess, date in unique_sessions:
+        texts.append(format_session(sess, date))
+        dates.append(date)
+        session_ids.append(sid)
+
+    # Extract in parallel
+    extracted = [None] * total
+    ok_count = 0
+    fail_count = 0
+
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        futures = {
+            pool.submit(_extract_one, db, text, cognitive_provider): i
+            for i, text in enumerate(texts)
+        }
+        for f in tqdm(as_completed(futures), total=total, desc="Extracting"):
+            idx = futures[f]
+            status, payload = f.result()
+            if status == "ok":
+                extracted[idx] = payload
+                ok_count += 1
+            else:
+                fail_count += 1
+                if status == "fatal":
+                    print(f"\n  FATAL: {payload[:200]}")
+                    break
+
+    print(f"  Extraction done: {ok_count} ok, {fail_count} failed")
+
+    # Store extracted memories
+    print(f"  Phase 1b: Storing extracted memories...")
+    memory_count = 0
+    for memories in tqdm(extracted, desc="Storing extracted"):
+        if memories is not None:
+            result = db.store_extracted(memories)
+            memory_count += result.get("stored_ids", []).__len__()
+
+    # Store raw sessions as semantic for BM25 keyword coverage.
+    # Using semantic (not episodic) so enrichment_candidates() won't re-extract them.
+    print(f"  Phase 1c: Storing raw sessions for BM25...")
+    raw_memories = []
+    for i, (text, date) in enumerate(zip(texts, dates)):
+        content = text[:8000] if len(text) > 8000 else text
+        raw_memories.append({
+            "content": content,
+            "memory_type": "semantic",
+            "tags": [f"date:{date}", f"session_id:{session_ids[i]}", "raw"],
+            "confidence": 0.3,
+            "embedding_key": text[:500],
+        })
+
+    # Batch store in chunks to avoid memory pressure
+    BATCH_SIZE = 100
+    raw_count = 0
+    for start in tqdm(range(0, len(raw_memories), BATCH_SIZE), desc="Storing raw"):
+        batch = raw_memories[start:start + BATCH_SIZE]
+        result = db.store_extracted(batch)
+        raw_count += len(result.get("stored_ids", []))
+
+    # Build community summaries (rule-based, from extraction phase)
+    print(f"  Phase 1d: Building community summaries...")
+    try:
+        community_ids = db.build_communities()
+        print(f"  Built {len(community_ids)} community summaries")
+    except Exception as e:
+        print(f"  Community build failed: {e}")
+        community_ids = []
+
+    print(f"\n  Ingest complete: {memory_count} extracted + {raw_count} raw memories")
+    return memory_count + raw_count
+
+
+def run_enrichment_phase(db, cognitive_provider):
+    """Run enrichment Phases 2-4 on the shared DB.
+
+    Phase 1 (extraction) was already done during ingest, so we call the
+    individual building blocks for entity linking, communities, and user model.
+    """
+    print(f"\n  Phase 2: Running enrichment phases 2-4...")
+    start = time.time()
+
+    # Phase 2: Entity linking (rule-based)
+    print(f"    Entity linking (rule-based)...")
+    try:
+        link_result = db.link_entities()
+        print(f"      Linked: {link_result['linked']}, "
+              f"Ambiguous: {link_result['ambiguous']}, "
+              f"Edges: {link_result['edges_created']}")
+    except Exception as e:
+        print(f"      Failed: {e}")
+
+    # Phase 3: Community detection (already built during ingest, rebuild to catch new entities)
+    print(f"    Rebuilding community summaries...")
+    try:
+        community_ids = db.build_communities()
+        print(f"      Built {len(community_ids)} community summaries")
+    except Exception as e:
+        print(f"      Failed: {e}")
+
+    # Phase 2b + 3b + 4: LLM-powered enrichment (entity linking, community summaries, user model)
+    # These require run_enrichment which needs episodic candidates.
+    # Store a single marker episodic memory to trigger the pipeline.
+    print(f"    Running LLM enrichment (entity linking, user model)...")
+    try:
+        marker_id = db.store(
+            "Enrichment trigger marker",
+            memory_type="episodic",
+            tags=["enrichment_marker"],
+        )
+        result = db.run_enrichment(provider=cognitive_provider, current_turn=0)
+        # Clean up marker
+        try:
+            db.forget(marker_id)
+        except Exception:
+            pass
+        elapsed = time.time() - start
+        print(f"  Enrichment complete in {elapsed:.0f}s:")
+        print(f"    Memories stored:      {result['memories_stored']}")
+        print(f"    Entities extracted:   {result['entities_extracted']}")
+        print(f"    Duplicates skipped:   {result['duplicates_skipped']}")
+        print(f"    Sync entity links:    {result['sync_linked']}")
+        print(f"    LLM entity links:     {result['llm_linked']}")
+        print(f"    Communities created:   {result['communities_created']}")
+        print(f"    User model updated:   {result['user_model_updated']}")
+        return result
+    except Exception as e:
+        elapsed = time.time() - start
+        print(f"  LLM enrichment failed after {elapsed:.0f}s: {e}")
+        return None
+
+
+# ─── Phase 2: Query ──────────────────────────────────────────────────────────
+
+def answer_question(db, question_data, llm_client, llm_provider, top_k=60,
+                    reader_model=None):
+    """Search the shared DB and generate an answer for one question."""
+    question = question_data["question"]
+    question_date = question_data["question_date"]
+    before_ts = date_to_microseconds(question_date)
+
+    results = db.search_expanded(question, k=top_k, before=before_ts)
+
+    retrieved_parts = []
+    for r in results:
+        try:
+            mem = db.get_memory(r.id)
+            content = mem.get("content", "") if isinstance(mem, dict) else getattr(mem, "content", "")
+            if content:
+                retrieved_parts.append(content)
+        except Exception:
+            continue
+
+    if not retrieved_parts:
+        return "I don't have enough information to answer this question."
+
+    retrieved_context = "\n\n---\n\n".join(retrieved_parts)
+    prompt = READER_PROMPT.format(
+        retrieved_context=retrieved_context,
+        question_date=question_date,
+        question=question,
+    )
+    return llm_chat(llm_client, llm_provider, prompt, temperature=0.0,
+                    max_tokens=300, model_override=reader_model).strip()
+
+
+def query_phase(db, dataset, llm_client, llm_provider, top_k, reader_model,
+                output_file, workers=3):
+    """Answer all questions against the shared enriched DB."""
+    from concurrent.futures import ThreadPoolExecutor, as_completed
+
+    results = []
+    total_start = time.time()
+
+    if workers <= 1:
+        for q in tqdm(dataset, desc="Answering"):
+            qid = q["question_id"]
+            for attempt in range(10):
+                try:
+                    hyp = answer_question(db, q, llm_client, llm_provider,
+                                          top_k=top_k, reader_model=reader_model)
+                    break
+                except Exception as e:
+                    if attempt < 9:
+                        time.sleep(3 * (2 ** min(attempt, 4)))
+                    else:
+                        hyp = f"Error: {e}"
+            entry = {"question_id": qid, "hypothesis": hyp}
+            results.append(entry)
+            with open(output_file, "a") as f:
+                f.write(json.dumps(entry) + "\n")
+    else:
+        def _answer_one(q):
+            qid = q["question_id"]
+            # Each thread gets its own LLM client
+            client, provider = get_llm_client()
+            for attempt in range(10):
+                try:
+                    hyp = answer_question(db, q, client, provider,
+                                          top_k=top_k, reader_model=reader_model)
+                    return {"question_id": qid, "hypothesis": hyp}
+                except Exception as e:
+                    if attempt < 9:
+                        time.sleep(3 * (2 ** min(attempt, 4)))
+                    else:
+                        return {"question_id": qid, "hypothesis": f"Error: {e}"}
+
+        with ThreadPoolExecutor(max_workers=workers) as executor:
+            futures = {executor.submit(_answer_one, q): q["question_id"] for q in dataset}
+            completed = 0
+            for future in as_completed(futures):
+                completed += 1
+                entry = future.result()
+                results.append(entry)
+                with open(output_file, "a") as f:
+                    f.write(json.dumps(entry) + "\n")
+                elapsed = time.time() - total_start
+                avg = elapsed / completed
+                remaining = avg * (len(dataset) - completed)
+                print(f"\r  [{completed}/{len(dataset)}] {entry['question_id']} | "
+                      f"{elapsed:.0f}s elapsed | ~{remaining:.0f}s remaining",
+                      end="", flush=True)
+            print()
+
+    total_time = time.time() - total_start
+    n = len(results)
+    print(f"\n  Query phase done: {n} questions in {total_time:.1f}s "
+          f"({total_time/max(n,1):.1f}s/question)")
+    return results
+
+
+# ─── Main ─────────────────────────────────────────────────────────────────────
+
+def run_enriched_benchmark(variant="s", top_k=60, limit=None, offset=0,
+                           workers=3, reader_model=None, skip_enrichment=False,
+                           db_dir=None):
+    if not has_llm_key():
+        print("Need OPENAI_API_KEY, ANTHROPIC_API_KEY, or OLLAMA_MODEL.")
+        sys.exit(1)
+
+    import mentedb as mentedb_pkg
+
+    embedding_provider = os.environ.get("EMBEDDING_PROVIDER", "")
+    embedding_api_key = os.environ.get("OPENAI_API_KEY", "")
+    embedding_model = os.environ.get("EMBEDDING_MODEL", "text-embedding-3-small")
+    if not embedding_provider:
+        embedding_provider = "openai" if embedding_api_key else "hash"
+
+    # Detect cognitive provider
+    cognitive_provider = None
+    explicit = os.environ.get("MENTEDB_LLM_PROVIDER", "")
+    if explicit == "openai":
+        cognitive_provider = "openai"
+        os.environ.setdefault("MENTEDB_LLM_API_KEY", os.environ.get("OPENAI_API_KEY", ""))
+    elif explicit == "anthropic":
+        cognitive_provider = "anthropic"
+        os.environ.setdefault("MENTEDB_LLM_API_KEY", os.environ.get("ANTHROPIC_API_KEY", ""))
+    elif os.environ.get("ANTHROPIC_API_KEY"):
+        cognitive_provider = "anthropic"
+        os.environ.setdefault("MENTEDB_LLM_PROVIDER", "anthropic")
+        os.environ.setdefault("MENTEDB_LLM_API_KEY", os.environ["ANTHROPIC_API_KEY"])
+    elif os.environ.get("OPENAI_API_KEY"):
+        cognitive_provider = "openai"
+        os.environ.setdefault("MENTEDB_LLM_PROVIDER", "openai")
+        os.environ.setdefault("MENTEDB_LLM_API_KEY", os.environ["OPENAI_API_KEY"])
+    else:
+        print("Need MENTEDB_LLM_PROVIDER + MENTEDB_LLM_API_KEY for enrichment.")
+        sys.exit(1)
+
+    DEFAULTS = {
+        "openai":    {"extractor": "gpt-4o-mini",             "reader": "gpt-4o"},
+        "anthropic": {"extractor": "claude-haiku-4-5",  "reader": "claude-sonnet-4-20250514"},
+    }
+    default_extractor = DEFAULTS.get(cognitive_provider, {}).get("extractor", "gpt-4o-mini")
+    cognitive_model = os.environ.get("MENTEDB_LLM_MODEL", default_extractor)
+    os.environ["MENTEDB_LLM_MODEL"] = cognitive_model
+
+    llm_client, llm_provider = get_llm_client()
+    if not reader_model:
+        reader_model = DEFAULTS.get(llm_provider, {}).get("reader", "gpt-4o-mini")
+
+    dataset = load_dataset(variant)
+    total_questions = len(dataset)
+
+    # Apply offset/limit first
+    query_dataset = dataset[offset:] if offset else dataset
+    if limit:
+        query_dataset = query_dataset[:limit]
+
+    # Collect unique sessions only for the questions we'll query
+    unique_sessions = collect_unique_sessions(query_dataset)
+
+    enrichment_label = "SKIP (--skip-enrichment)" if skip_enrichment else "ON (4-phase pipeline)"
+
+    print(f"{'='*60}")
+    print(f"  LongMemEval Enriched Benchmark — MenteDB")
+    print(f"{'='*60}")
+    print(f"  Architecture:     Two-phase (shared DB)")
+    print(f"  Dataset:          {variant} ({total_questions} questions)")
+    print(f"  Unique sessions:  {len(unique_sessions)}")
+    print(f"  Query range:      {offset}..{offset + len(query_dataset)} of {total_questions}")
+    print(f"  Embedding:        {embedding_provider} / {embedding_model}")
+    print(f"  Extraction:       {cognitive_provider} / {cognitive_model}")
+    print(f"  Enrichment:       {enrichment_label}")
+    print(f"  Reader:           {llm_provider} / {reader_model}")
+    print(f"  Top-K:            {top_k}")
+    print(f"  Workers:          {workers}")
+    print(f"{'='*60}")
+
+    # Create or reuse DB
+    if db_dir:
+        tmp_dir = db_dir
+        os.makedirs(tmp_dir, exist_ok=True)
+        print(f"\n  Using DB dir: {tmp_dir}")
+    else:
+        tmp_dir = tempfile.mkdtemp(prefix="longmemeval-enriched-")
+        print(f"\n  Created DB dir: {tmp_dir}")
+
+    db = mentedb_pkg.MenteDB(
+        tmp_dir,
+        embedding_provider=embedding_provider,
+        embedding_api_key=embedding_api_key,
+        embedding_model=embedding_model,
+    )
+
+    # Check if DB already has data (resuming)
+    try:
+        test_results = db.search_text("test", k=1)
+        has_data = len(test_results) > 0
+    except Exception:
+        has_data = False
+
+    ingest_start = time.time()
+    if has_data:
+        print(f"\n  DB already has data, skipping ingest (use a fresh --db-dir to re-ingest)")
+    else:
+        # Phase 1: Global ingest
+        global_ingest(db, unique_sessions, cognitive_provider, workers=workers)
+
+        # Enrichment
+        if not skip_enrichment:
+            run_enrichment_phase(db, cognitive_provider)
+        else:
+            print(f"\n  Skipping enrichment (--skip-enrichment)")
+
+    ingest_time = time.time() - ingest_start
+
+    # Phase 2: Query
+    os.makedirs(RESULTS_DIR, exist_ok=True)
+    tag = "enriched" if not skip_enrichment else "baseline-shared"
+    range_tag = f"q{offset}-{offset + len(query_dataset)}"
+    output_file = os.path.join(RESULTS_DIR, f"hypotheses_{tag}_{range_tag}.jsonl")
+
+    if os.path.exists(output_file):
+        # Resume: load already-answered question IDs
+        answered_ids = set()
+        with open(output_file, "r") as f:
+            for line in f:
+                try:
+                    entry = json.loads(line.strip())
+                    answered_ids.add(entry["question_id"])
+                except Exception:
+                    continue
+        remaining = [q for q in query_dataset if q["question_id"] not in answered_ids]
+        print(f"\n  Resuming: {len(answered_ids)} already answered, {len(remaining)} remaining")
+        print(f"  Output: {output_file}\n")
+        if remaining:
+            query_phase(db, remaining, llm_client, llm_provider, top_k,
+                        reader_model, output_file, workers=workers)
+        else:
+            print(f"  All questions already answered!")
+    else:
+        print(f"\n  Phase 3: Answering {len(query_dataset)} questions...")
+        print(f"  Output: {output_file}\n")
+        query_phase(db, query_dataset, llm_client, llm_provider, top_k,
+                    reader_model, output_file, workers=workers)
+
+    db.close()
+
+    total_time = time.time() - ingest_start
+    print(f"\n  Total time: {total_time:.0f}s (ingest+enrichment: {ingest_time:.0f}s)")
+    print(f"  DB dir: {tmp_dir}")
+    print(f"  Results: {output_file}")
+    print(f"\n  Next: python benchmarks/longmemeval/evaluate.py {output_file}")
+
+    return output_file
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="LongMemEval with Sleeptime Enrichment (two-phase)")
+    parser.add_argument("--dataset", default=os.environ.get("DATASET", "s"),
+                        choices=["s", "m", "oracle"])
+    parser.add_argument("--top-k", type=int, default=60)
+    parser.add_argument("--limit", type=int, default=None,
+                        help="Limit query phase to N questions")
+    parser.add_argument("--offset", type=int, default=0,
+                        help="Skip first N questions in query phase")
+    parser.add_argument("--workers", type=int, default=3)
+    parser.add_argument("--reader-model", type=str, default=None)
+    parser.add_argument("--skip-enrichment", action="store_true",
+                        help="Skip enrichment (baseline with shared DB)")
+    parser.add_argument("--db-dir", type=str, default=None,
+                        help="Reuse existing DB dir (skip ingest if populated)")
+
+    args = parser.parse_args()
+    run_enriched_benchmark(
+        variant=args.dataset,
+        top_k=args.top_k,
+        limit=args.limit,
+        offset=args.offset,
+        workers=args.workers,
+        reader_model=args.reader_model,
+        skip_enrichment=args.skip_enrichment,
+        db_dir=args.db_dir,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/crates/mentedb-graph/src/csr.rs
+++ b/crates/mentedb-graph/src/csr.rs
@@ -163,6 +163,7 @@ impl CsrGraph {
         // Also remove from delta
         self.delta_edges
             .retain(|e| e.source_idx != idx && e.target_idx != idx);
+        self.id_to_idx.remove(&id);
     }
 
     /// Add an edge to the delta log.
@@ -529,6 +530,46 @@ mod tests {
         g.remove_edge(a, b);
         g.compact();
 
+        let out = g.outgoing(a);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].0, c);
+    }
+
+    #[test]
+    fn test_remove_node_cleans_id_to_idx() {
+        let mut g = CsrGraph::new();
+        let a = MemoryId::new();
+        let b = MemoryId::new();
+
+        g.add_edge(&make_edge(a, b, EdgeType::Caused));
+        assert!(g.contains_node(a));
+        assert!(g.contains_node(b));
+
+        g.remove_node(a);
+        assert!(
+            !g.contains_node(a),
+            "removed node should not be in id_to_idx"
+        );
+        assert!(g.contains_node(b), "unrelated node should still exist");
+
+        // Edges involving the removed node should be gone
+        assert!(g.outgoing(a).is_empty());
+        assert!(g.incoming(b).is_empty());
+    }
+
+    #[test]
+    fn test_remove_node_then_readd() {
+        let mut g = CsrGraph::new();
+        let a = MemoryId::new();
+        let b = MemoryId::new();
+        let c = MemoryId::new();
+
+        g.add_edge(&make_edge(a, b, EdgeType::Caused));
+        g.remove_node(a);
+
+        // Re-adding the same ID should get a fresh index
+        g.add_edge(&make_edge(a, c, EdgeType::Related));
+        assert!(g.contains_node(a));
         let out = g.outgoing(a);
         assert_eq!(out.len(), 1);
         assert_eq!(out[0].0, c);

--- a/crates/mentedb-index/src/salience.rs
+++ b/crates/mentedb-index/src/salience.rs
@@ -1,6 +1,6 @@
 //! Sorted salience index for top-k retrieval by importance score.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
@@ -42,6 +42,7 @@ pub struct SalienceIndex {
 
 struct SalienceInner {
     tree: BTreeMap<OrderedF32, Vec<MemoryId>>,
+    id_to_salience: HashMap<MemoryId, OrderedF32>,
 }
 
 impl SalienceIndex {
@@ -50,6 +51,7 @@ impl SalienceIndex {
         Self {
             inner: RwLock::new(SalienceInner {
                 tree: BTreeMap::new(),
+                id_to_salience: HashMap::new(),
             }),
         }
     }
@@ -59,6 +61,7 @@ impl SalienceIndex {
         let mut inner = self.inner.write();
         let key = OrderedF32::from_f32(salience);
         inner.tree.entry(key).or_default().push(id);
+        inner.id_to_salience.insert(id, key);
     }
 
     /// Update the salience score for a memory.
@@ -93,17 +96,13 @@ impl SalienceIndex {
                 inner.tree.remove(&key);
             }
         }
+        inner.id_to_salience.remove(&id);
     }
 
-    /// Get the salience score for a memory (linear scan: use sparingly).
+    /// Get the salience score for a memory (O(1) via reverse lookup).
     pub fn get_salience(&self, id: MemoryId) -> Option<f32> {
         let inner = self.inner.read();
-        for (&key, ids) in &inner.tree {
-            if ids.contains(&id) {
-                return Some(key.to_f32());
-            }
-        }
-        None
+        inner.id_to_salience.get(&id).map(|k| k.to_f32())
     }
 }
 
@@ -139,12 +138,20 @@ impl SalienceIndex {
             .map_err(|e| MenteError::Serialization(e.to_string()))?;
 
         let mut tree = BTreeMap::new();
+        let mut id_to_salience = HashMap::new();
         for (salience, ids) in snapshot.entries {
-            tree.insert(OrderedF32::from_f32(salience), ids);
+            let key = OrderedF32::from_f32(salience);
+            for &id in &ids {
+                id_to_salience.insert(id, key);
+            }
+            tree.insert(key, ids);
         }
 
         Ok(Self {
-            inner: RwLock::new(SalienceInner { tree }),
+            inner: RwLock::new(SalienceInner {
+                tree,
+                id_to_salience,
+            }),
         })
     }
 }
@@ -219,5 +226,63 @@ mod tests {
         let mut sorted_keys = keys.clone();
         sorted_keys.sort();
         assert_eq!(keys, sorted_keys);
+    }
+
+    #[test]
+    fn test_get_salience_o1() {
+        let idx = SalienceIndex::new();
+        let a = MemoryId::new();
+        let b = MemoryId::new();
+        let c = MemoryId::new();
+
+        idx.insert(a, 0.3);
+        idx.insert(b, 0.7);
+        idx.insert(c, 0.5);
+
+        assert!((idx.get_salience(a).unwrap() - 0.3).abs() < 0.001);
+        assert!((idx.get_salience(b).unwrap() - 0.7).abs() < 0.001);
+        assert!((idx.get_salience(c).unwrap() - 0.5).abs() < 0.001);
+        assert!(idx.get_salience(MemoryId::new()).is_none());
+    }
+
+    #[test]
+    fn test_get_salience_after_update() {
+        let idx = SalienceIndex::new();
+        let a = MemoryId::new();
+
+        idx.insert(a, 0.3);
+        assert!((idx.get_salience(a).unwrap() - 0.3).abs() < 0.001);
+
+        idx.update(a, 0.3, 0.9);
+        assert!((idx.get_salience(a).unwrap() - 0.9).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_get_salience_after_remove() {
+        let idx = SalienceIndex::new();
+        let a = MemoryId::new();
+
+        idx.insert(a, 0.5);
+        assert!(idx.get_salience(a).is_some());
+
+        idx.remove(a, 0.5);
+        assert!(idx.get_salience(a).is_none());
+    }
+
+    #[test]
+    fn test_save_load_preserves_reverse_map() {
+        let idx = SalienceIndex::new();
+        let a = MemoryId::new();
+        let b = MemoryId::new();
+        idx.insert(a, 0.4);
+        idx.insert(b, 0.8);
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("salience.bin");
+        idx.save(&path).unwrap();
+
+        let loaded = SalienceIndex::load(&path).unwrap();
+        assert!((loaded.get_salience(a).unwrap() - 0.4).abs() < 0.001);
+        assert!((loaded.get_salience(b).unwrap() - 0.8).abs() < 0.001);
     }
 }

--- a/crates/mentedb-storage/src/engine.rs
+++ b/crates/mentedb-storage/src/engine.rs
@@ -143,10 +143,12 @@ impl StorageEngine {
 
     /// Write data into a page with WAL protection.
     pub fn write_page(&self, page_id: PageId, data: &[u8]) -> MenteResult<()> {
-        let lsn = self
-            .wal
-            .lock()
-            .append(WalEntryType::PageWrite, page_id.0, data)?;
+        let lsn = {
+            let mut wal = self.wal.lock();
+            let lsn = wal.append(WalEntryType::PageWrite, page_id.0, data)?;
+            wal.sync()?;
+            lsn
+        };
 
         let mut pm = self.page_manager.lock();
         let mut page = self.buffer_pool.fetch_page(page_id, &mut pm)?;

--- a/crates/mentedb-storage/src/page.rs
+++ b/crates/mentedb-storage/src/page.rs
@@ -263,8 +263,19 @@ impl PageManager {
         self.file.seek(SeekFrom::Start(offset))?;
         self.file.read_exact(&mut buf)?;
 
+        let page = Page::from_bytes(&buf);
+        if page.header.checksum != 0 {
+            let expected = page.compute_checksum();
+            if page.header.checksum != expected {
+                return Err(MenteError::Storage(format!(
+                    "page {} checksum mismatch (stored={:#x}, computed={:#x})",
+                    page_id.0, page.header.checksum, expected
+                )));
+            }
+        }
+
         trace!(page_id = page_id.0, "read page from disk");
-        Ok(Box::new(Page::from_bytes(&buf)))
+        Ok(Box::new(page))
     }
 
     /// Write a page to disk.
@@ -412,5 +423,41 @@ mod tests {
         page.data[0] = 0x00;
         let c2 = page.compute_checksum();
         assert_ne!(c1, c2);
+    }
+
+    #[test]
+    fn test_checksum_verified_on_read() {
+        let dir = tempfile::tempdir().unwrap();
+        let pid;
+        {
+            let mut pm = PageManager::open(dir.path()).unwrap();
+            pid = pm.allocate_page().unwrap();
+            let mut page = Page::zeroed();
+            page.header.page_id = pid.0;
+            page.header.page_type = PageType::Data as u8;
+            page.data[0..5].copy_from_slice(b"valid");
+            page.header.checksum = page.compute_checksum();
+            pm.write_page(pid, &page).unwrap();
+            pm.sync().unwrap();
+        }
+        {
+            // Valid checksum — should read fine
+            let mut pm = PageManager::open(dir.path()).unwrap();
+            let page = pm.read_page(pid).unwrap();
+            assert_eq!(&page.data[0..5], b"valid");
+        }
+        {
+            // Corrupt the data on disk
+            let data_path = dir.path().join("pages.db");
+            let mut raw = std::fs::read(&data_path).unwrap();
+            let offset = pid.0 as usize * PAGE_SIZE;
+            // Flip a byte in the data section (after header)
+            raw[offset + std::mem::size_of::<PageHeader>()] ^= 0xFF;
+            std::fs::write(&data_path, &raw).unwrap();
+
+            let mut pm = PageManager::open(dir.path()).unwrap();
+            let result = pm.read_page(pid);
+            assert!(result.is_err(), "corrupted page should fail checksum");
+        }
     }
 }

--- a/crates/mentedb-storage/src/wal.rs
+++ b/crates/mentedb-storage/src/wal.rs
@@ -24,6 +24,7 @@ pub type Lsn = u64;
 #[repr(u8)]
 pub enum WalEntryType {
     PageWrite = 1,
+    /// Reserved for future transaction support. Not currently emitted.
     Commit = 2,
     Checkpoint = 3,
 }
@@ -58,6 +59,7 @@ pub struct WalEntry {
 /// Append-only write-ahead log.
 pub struct Wal {
     file: File,
+    dir_path: std::path::PathBuf,
     next_lsn: u64,
 }
 
@@ -80,7 +82,11 @@ impl Wal {
             .truncate(false)
             .open(&wal_path)?;
 
-        let mut wal = Self { file, next_lsn: 1 };
+        let mut wal = Self {
+            file,
+            dir_path: dir_path.to_path_buf(),
+            next_lsn: 1,
+        };
 
         if exists {
             let entries = wal.read_all_entries()?;
@@ -147,36 +153,52 @@ impl Wal {
     }
 
     /// Truncate all entries with LSN **less than** `before_lsn`.
+    ///
+    /// Uses atomic write-to-temp-then-rename to avoid data loss on crash.
     pub fn truncate(&mut self, before_lsn: Lsn) -> MenteResult<()> {
         let entries = self.read_all_entries()?;
         let to_keep: Vec<&WalEntry> = entries.iter().filter(|e| e.lsn >= before_lsn).collect();
 
-        self.file.seek(SeekFrom::Start(0))?;
-        self.file.set_len(0)?;
+        let wal_path = self.dir_path.join("wal.log");
+        let tmp_path = self.dir_path.join("wal.log.tmp");
 
-        for entry in to_keep {
-            let compressed = lz4_flex::compress_prepend_size(&entry.data);
+        {
+            let mut tmp_file = OpenOptions::new()
+                .write(true)
+                .create(true)
+                .truncate(true)
+                .open(&tmp_path)?;
 
-            let payload_len = 8 + 1 + 8 + compressed.len();
-            let mut payload = Vec::with_capacity(payload_len);
-            payload.extend_from_slice(&entry.lsn.to_le_bytes());
-            payload.push(entry.entry_type as u8);
-            payload.extend_from_slice(&entry.page_id.to_le_bytes());
-            payload.extend_from_slice(&compressed);
+            for entry in to_keep {
+                let compressed = lz4_flex::compress_prepend_size(&entry.data);
 
-            let crc = {
-                let mut h = crc32fast::Hasher::new();
-                h.update(&payload);
-                h.finalize()
-            };
+                let payload_len = 8 + 1 + 8 + compressed.len();
+                let mut payload = Vec::with_capacity(payload_len);
+                payload.extend_from_slice(&entry.lsn.to_le_bytes());
+                payload.push(entry.entry_type as u8);
+                payload.extend_from_slice(&entry.page_id.to_le_bytes());
+                payload.extend_from_slice(&compressed);
 
-            self.file.write_all(&(payload_len as u32).to_le_bytes())?;
-            self.file.write_all(&payload)?;
-            self.file.write_all(&crc.to_le_bytes())?;
+                let crc = {
+                    let mut h = crc32fast::Hasher::new();
+                    h.update(&payload);
+                    h.finalize()
+                };
+
+                tmp_file.write_all(&(payload_len as u32).to_le_bytes())?;
+                tmp_file.write_all(&payload)?;
+                tmp_file.write_all(&crc.to_le_bytes())?;
+            }
+
+            tmp_file.sync_data()?;
         }
 
-        self.file.sync_data()?;
-        debug!(before_lsn, "WAL truncated");
+        std::fs::rename(&tmp_path, &wal_path)?;
+
+        // Reopen the renamed file
+        self.file = OpenOptions::new().read(true).write(true).open(&wal_path)?;
+
+        debug!(before_lsn, "WAL truncated (atomic)");
         Ok(())
     }
 
@@ -344,5 +366,76 @@ mod tests {
         let entries = wal.iterate().unwrap();
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].data, big_data);
+    }
+
+    #[test]
+    fn test_append_then_sync_is_durable() {
+        // append() alone does not fsync — callers must call sync() for durability.
+        // This matches the group-commit pattern: batch appends, sync once.
+        let dir = tempfile::tempdir().unwrap();
+        {
+            let mut wal = Wal::open(dir.path()).unwrap();
+            wal.append(WalEntryType::PageWrite, 1, b"batch1").unwrap();
+            wal.append(WalEntryType::PageWrite, 2, b"batch2").unwrap();
+            wal.sync().unwrap();
+        }
+        {
+            let mut wal = Wal::open(dir.path()).unwrap();
+            let entries = wal.iterate().unwrap();
+            assert_eq!(entries.len(), 2);
+            assert_eq!(entries[0].data, b"batch1");
+            assert_eq!(entries[1].data, b"batch2");
+        }
+    }
+
+    #[test]
+    fn test_truncate_atomic_preserves_kept_entries() {
+        let dir = tempfile::tempdir().unwrap();
+        {
+            let mut wal = Wal::open(dir.path()).unwrap();
+            wal.append(WalEntryType::PageWrite, 1, b"old1").unwrap();
+            wal.append(WalEntryType::PageWrite, 2, b"old2").unwrap();
+            wal.append(WalEntryType::PageWrite, 3, b"keep1").unwrap();
+            wal.append(WalEntryType::PageWrite, 4, b"keep2").unwrap();
+
+            wal.truncate(3).unwrap();
+
+            let entries = wal.iterate().unwrap();
+            assert_eq!(entries.len(), 2);
+            assert_eq!(entries[0].data, b"keep1");
+            assert_eq!(entries[1].data, b"keep2");
+        }
+        // Verify survives reopen
+        {
+            let mut wal = Wal::open(dir.path()).unwrap();
+            let entries = wal.iterate().unwrap();
+            assert_eq!(entries.len(), 2);
+            assert_eq!(entries[0].lsn, 3);
+            assert_eq!(entries[1].lsn, 4);
+        }
+    }
+
+    #[test]
+    fn test_truncate_no_temp_file_left_behind() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut wal = Wal::open(dir.path()).unwrap();
+        wal.append(WalEntryType::PageWrite, 1, b"a").unwrap();
+        wal.truncate(2).unwrap();
+
+        // Temp file should not exist after truncation
+        assert!(!dir.path().join("wal.log.tmp").exists());
+    }
+
+    #[test]
+    fn test_append_after_truncate_works() {
+        let (_dir, mut wal) = setup();
+        wal.append(WalEntryType::PageWrite, 1, b"before").unwrap();
+        wal.truncate(2).unwrap();
+
+        // Should be able to append after truncation (file handle is valid)
+        wal.append(WalEntryType::PageWrite, 10, b"after").unwrap();
+        let entries = wal.iterate().unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].data, b"after");
     }
 }

--- a/crates/mentedb/src/enrichment.rs
+++ b/crates/mentedb/src/enrichment.rs
@@ -59,52 +59,56 @@ pub async fn run_enrichment<J: LlmJudge>(
     embedder: &dyn EmbeddingProvider,
     cognitive_llm: Option<&CognitiveLlmService<J>>,
     current_turn: u64,
+    skip_extraction: bool,
 ) -> EnrichmentResult {
     let mut result = EnrichmentResult::default();
 
-    let candidates = db.enrichment_candidates();
-    if candidates.is_empty() {
-        tracing::debug!("enrichment: no candidates, marking complete");
-        db.mark_enrichment_complete(current_turn);
-        return result;
-    }
-
-    tracing::info!(
-        candidates = candidates.len(),
-        "starting sleeptime enrichment"
-    );
-
-    // ── Phase 1: Batch LLM Extraction ──
-    let http_provider = match HttpExtractionProvider::new(extraction_config.clone()) {
-        Ok(p) => p,
-        Err(e) => {
-            tracing::error!(error = %e, "enrichment: failed to create HTTP provider");
+    if !skip_extraction {
+        let candidates = db.enrichment_candidates();
+        if candidates.is_empty() {
+            tracing::debug!("enrichment: no candidates, marking complete");
             db.mark_enrichment_complete(current_turn);
             return result;
         }
-    };
 
-    let enrichment_config = db.enrichment_config().clone();
-    let pipeline_cfg = ExtractionConfig {
-        quality_threshold: enrichment_config.min_confidence,
-        ..extraction_config
-    };
-    let pipeline = ExtractionPipeline::new(http_provider, pipeline_cfg);
+        tracing::info!(
+            candidates = candidates.len(),
+            "starting sleeptime enrichment"
+        );
 
-    let batches = batch_conversations(&candidates, 10);
+        // ── Phase 1: Batch LLM Extraction ──
+        let http_provider = match HttpExtractionProvider::new(extraction_config.clone()) {
+            Ok(p) => p,
+            Err(e) => {
+                tracing::error!(error = %e, "enrichment: failed to create HTTP provider");
+                db.mark_enrichment_complete(current_turn);
+                return result;
+            }
+        };
 
-    for (batch_idx, batch) in batches.iter().enumerate() {
-        let conversation = batch
-            .iter()
-            .map(|m| m.content.as_str())
-            .collect::<Vec<_>>()
-            .join("\n---\n");
+        let enrichment_config = db.enrichment_config().clone();
+        let pipeline_cfg = ExtractionConfig {
+            quality_threshold: enrichment_config.min_confidence,
+            ..extraction_config
+        };
+        let pipeline = ExtractionPipeline::new(http_provider, pipeline_cfg);
 
-        let source_ids: Vec<mentedb_core::types::MemoryId> = batch.iter().map(|m| m.id).collect();
+        let batches = batch_conversations(&candidates, 10);
 
-        // Get existing memories for dedup
-        let existing: Vec<MemoryNode> =
-            if let Ok(Some(emb)) = db.embed_text(&conversation[..conversation.len().min(500)]) {
+        for (batch_idx, batch) in batches.iter().enumerate() {
+            let conversation = batch
+                .iter()
+                .map(|m| m.content.as_str())
+                .collect::<Vec<_>>()
+                .join("\n---\n");
+
+            let source_ids: Vec<mentedb_core::types::MemoryId> =
+                batch.iter().map(|m| m.id).collect();
+
+            // Get existing memories for dedup
+            let existing: Vec<MemoryNode> = if let Ok(Some(emb)) =
+                db.embed_text(&conversation[..conversation.len().min(500)])
+            {
                 db.recall_similar(&emb, 30)
                     .unwrap_or_default()
                     .into_iter()
@@ -114,73 +118,85 @@ pub async fn run_enrichment<J: LlmJudge>(
                 Vec::new()
             };
 
-        match pipeline.process(&conversation, &existing, embedder).await {
-            Ok(extraction_result) => {
-                result.duplicates_skipped += extraction_result.stats.rejected_duplicate;
-                result.contradictions_found += extraction_result.stats.contradictions_found;
+            match pipeline.process(&conversation, &existing, embedder).await {
+                Ok(extraction_result) => {
+                    result.duplicates_skipped += extraction_result.stats.rejected_duplicate;
+                    result.contradictions_found += extraction_result.stats.contradictions_found;
 
-                let mut nodes = Vec::new();
-                for mem in extraction_result
-                    .to_store
-                    .iter()
-                    .chain(extraction_result.contradictions.iter().map(|(m, _)| m))
-                {
-                    let mem_type =
-                        mentedb_extraction::map_extraction_type_to_memory_type(&mem.memory_type);
-                    let embedding = match embedder.embed(&mem.content) {
-                        Ok(e) => e,
+                    let mut nodes = Vec::new();
+                    for mem in extraction_result
+                        .to_store
+                        .iter()
+                        .chain(extraction_result.contradictions.iter().map(|(m, _)| m))
+                    {
+                        let mem_type = mentedb_extraction::map_extraction_type_to_memory_type(
+                            &mem.memory_type,
+                        );
+                        let embedding = match embedder.embed(&mem.content) {
+                            Ok(e) => e,
+                            Err(e) => {
+                                tracing::warn!(error = %e, "enrichment: embedding failed");
+                                continue;
+                            }
+                        };
+                        let mut node = MemoryNode::new(
+                            AgentId::nil(),
+                            mem_type,
+                            mem.content.clone(),
+                            embedding,
+                        );
+                        node.tags = mem.tags.clone();
+                        node.confidence = mem.confidence;
+                        nodes.push(node);
+                    }
+
+                    // Build entity nodes
+                    for entity in &extraction_result.entities {
+                        let content = entity.to_content();
+                        let embedding_text = entity.embedding_key();
+                        let embedding = match embedder.embed(&embedding_text) {
+                            Ok(e) => e,
+                            Err(e) => {
+                                tracing::warn!(error = %e, "enrichment: entity embedding failed");
+                                continue;
+                            }
+                        };
+                        let mut node = MemoryNode::new(
+                            AgentId::nil(),
+                            MemoryType::Semantic,
+                            content,
+                            embedding,
+                        );
+                        let name_lower = entity.name.to_lowercase();
+                        node.tags.push(format!("entity:{}", name_lower));
+                        node.tags
+                            .push(format!("entity_type:{}", entity.entity_type));
+                        if let Some(cat) = entity.attributes.get("category") {
+                            for c in cat.split(',').map(|s| s.trim()).filter(|s| !s.is_empty()) {
+                                node.tags.push(format!("category:{}", c.to_lowercase()));
+                            }
+                        }
+                        nodes.push(node);
+                        result.entities_extracted += 1;
+                    }
+
+                    match db.store_enrichment_memories(nodes, &source_ids) {
+                        Ok((stored, edges)) => {
+                            result.memories_stored += stored;
+                            result.edges_created += edges;
+                        }
                         Err(e) => {
-                            tracing::warn!(error = %e, "enrichment: embedding failed");
-                            continue;
-                        }
-                    };
-                    let mut node =
-                        MemoryNode::new(AgentId::nil(), mem_type, mem.content.clone(), embedding);
-                    node.tags = mem.tags.clone();
-                    node.confidence = mem.confidence;
-                    nodes.push(node);
-                }
-
-                // Build entity nodes
-                for entity in &extraction_result.entities {
-                    let content = entity.to_content();
-                    let embedding_text = entity.embedding_key();
-                    let embedding = match embedder.embed(&embedding_text) {
-                        Ok(e) => e,
-                        Err(e) => {
-                            tracing::warn!(error = %e, "enrichment: entity embedding failed");
-                            continue;
-                        }
-                    };
-                    let mut node =
-                        MemoryNode::new(AgentId::nil(), MemoryType::Semantic, content, embedding);
-                    let name_lower = entity.name.to_lowercase();
-                    node.tags.push(format!("entity:{}", name_lower));
-                    node.tags
-                        .push(format!("entity_type:{}", entity.entity_type));
-                    if let Some(cat) = entity.attributes.get("category") {
-                        for c in cat.split(',').map(|s| s.trim()).filter(|s| !s.is_empty()) {
-                            node.tags.push(format!("category:{}", c.to_lowercase()));
+                            tracing::error!(batch = batch_idx, error = %e, "enrichment: failed to store batch");
                         }
                     }
-                    nodes.push(node);
-                    result.entities_extracted += 1;
                 }
-
-                match db.store_enrichment_memories(nodes, &source_ids) {
-                    Ok((stored, edges)) => {
-                        result.memories_stored += stored;
-                        result.edges_created += edges;
-                    }
-                    Err(e) => {
-                        tracing::error!(batch = batch_idx, error = %e, "enrichment: failed to store batch");
-                    }
+                Err(e) => {
+                    tracing::error!(batch = batch_idx, error = %e, "enrichment: extraction failed");
                 }
-            }
-            Err(e) => {
-                tracing::error!(batch = batch_idx, error = %e, "enrichment: extraction failed");
             }
         }
+    } else {
+        tracing::info!("enrichment: skipping Phase 1 extraction (skip_extraction=true)");
     }
 
     // ── Phase 2: Entity Linking ──
@@ -222,7 +238,7 @@ pub async fn run_enrichment<J: LlmJudge>(
         contradictions = result.contradictions_found,
         communities = result.communities_created,
         user_model = result.user_model_updated,
-        batches = batches.len(),
+        skip_extraction = skip_extraction,
         "sleeptime enrichment complete"
     );
 

--- a/sdks/python/Cargo.lock
+++ b/sdks/python/Cargo.lock
@@ -1439,13 +1439,14 @@ dependencies = [
 
 [[package]]
 name = "mentedb"
-version = "0.7.2"
+version = "0.8.2"
 dependencies = [
  "mentedb-cognitive",
  "mentedb-consolidation",
  "mentedb-context",
  "mentedb-core",
  "mentedb-embedding",
+ "mentedb-extraction",
  "mentedb-graph",
  "mentedb-index",
  "mentedb-query",
@@ -1458,7 +1459,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-cognitive"
-version = "0.7.2"
+version = "0.8.2"
 dependencies = [
  "ahash",
  "crossbeam",
@@ -1473,7 +1474,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-consolidation"
-version = "0.7.2"
+version = "0.8.2"
 dependencies = [
  "ahash",
  "mentedb-core",
@@ -1484,7 +1485,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-context"
-version = "0.7.2"
+version = "0.8.2"
 dependencies = [
  "ahash",
  "mentedb-core",
@@ -1496,7 +1497,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-core"
-version = "0.7.2"
+version = "0.8.2"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1511,7 +1512,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-embedding"
-version = "0.7.2"
+version = "0.8.2"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -1529,7 +1530,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-extraction"
-version = "0.7.2"
+version = "0.8.2"
 dependencies = [
  "mentedb-cognitive",
  "mentedb-core",
@@ -1545,7 +1546,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-graph"
-version = "0.7.2"
+version = "0.8.2"
 dependencies = [
  "ahash",
  "bincode",
@@ -1560,7 +1561,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-index"
-version = "0.7.2"
+version = "0.8.2"
 dependencies = [
  "ahash",
  "bincode",
@@ -1577,7 +1578,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-python"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "mentedb",
  "mentedb-cognitive",
@@ -1597,7 +1598,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-query"
-version = "0.7.2"
+version = "0.8.2"
 dependencies = [
  "mentedb-core",
  "serde",
@@ -1608,7 +1609,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-storage"
-version = "0.7.2"
+version = "0.8.2"
 dependencies = [
  "ahash",
  "bincode",

--- a/sdks/python/Cargo.toml
+++ b/sdks/python/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3 = { version = "0.24", features = ["extension-module"] }
-mentedb = { path = "../../crates/mentedb" }
+mentedb = { path = "../../crates/mentedb", features = ["enrichment"] }
 mentedb-core = { path = "../../crates/mentedb-core" }
 mentedb-storage = { path = "../../crates/mentedb-storage" }
 mentedb-index = { path = "../../crates/mentedb-index" }

--- a/sdks/python/python/mentedb/client.py
+++ b/sdks/python/python/mentedb/client.py
@@ -159,6 +159,35 @@ class MenteDB:
         """
         return self._db.build_communities()
 
+    def run_enrichment(self, provider: str | None = None, current_turn: int = 0, skip_extraction: bool = False) -> dict:
+        """Run the full 4-phase sleeptime enrichment pipeline.
+
+        Phases:
+          1. Batch LLM extraction — episodic memories → semantic + entities
+          2. Entity linking — rule-based + LLM resolution
+          3. Community detection — category clustering + LLM summaries
+          4. User model — always-scoped profile from all knowledge
+
+        When skip_extraction=True, Phase 1 is skipped (useful when
+        memories have already been extracted during ingest).
+
+        Requires MENTEDB_LLM_PROVIDER and MENTEDB_LLM_API_KEY env vars.
+        Returns a dict with enrichment statistics.
+        """
+        return self._db.run_enrichment(provider=provider, current_turn=current_turn, skip_extraction=skip_extraction)
+
+    def needs_enrichment(self) -> bool:
+        """Check if enrichment is pending."""
+        return self._db.needs_enrichment()
+
+    def link_entities(self) -> dict:
+        """Link entities across sessions by name + embedding similarity."""
+        return self._db.link_entities()
+
+    def entity_memories(self) -> list:
+        """Get all entity memory nodes."""
+        return self._db.entity_memories()
+
     def close(self):
         """Flush and close the database."""
         self._db.close()

--- a/sdks/python/src/lib.rs
+++ b/sdks/python/src/lib.rs
@@ -3724,6 +3724,65 @@ impl MenteDB {
             .collect();
         Ok(result)
     }
+
+    /// Run the full 4-phase sleeptime enrichment pipeline.
+    ///
+    /// Phases:
+    ///   1. Batch LLM extraction — episodic memories → semantic + entities
+    ///   2. Entity linking — rule-based + LLM resolution
+    ///   3. Community detection — category clustering + LLM summaries
+    ///   4. User model — always-scoped profile from all knowledge
+    ///
+    /// Requires MENTEDB_LLM_PROVIDER and MENTEDB_LLM_API_KEY env vars.
+    /// Returns a dict with enrichment statistics.
+    #[pyo3(signature = (provider=None, current_turn=0, skip_extraction=false))]
+    fn run_enrichment(
+        &self,
+        py: Python<'_>,
+        provider: Option<&str>,
+        current_turn: u64,
+        skip_extraction: bool,
+    ) -> PyResult<PyObject> {
+        let db = self
+            .db
+            .as_ref()
+            .ok_or_else(|| PyRuntimeError::new_err("database is closed"))?;
+        let embedder = self
+            .embedder
+            .as_ref()
+            .ok_or_else(|| PyRuntimeError::new_err("no embedding provider configured"))?;
+
+        let config = build_extraction_config_from_env(provider)?;
+        let http_provider =
+            HttpExtractionProvider::new(config.clone()).map_err(to_pyerr)?;
+        let judge =
+            mentedb_extraction::cognitive_adapter::ExtractionLlmJudge::new(http_provider);
+        let cognitive_llm = mentedb_cognitive::CognitiveLlmService::new(judge);
+
+        let rt = tokio::runtime::Runtime::new().map_err(to_pyerr)?;
+        let enrichment_result = py.allow_threads(|| {
+            rt.block_on(mentedb::enrichment::run_enrichment(
+                db,
+                config,
+                embedder.as_ref(),
+                Some(&cognitive_llm),
+                current_turn,
+                skip_extraction,
+            ))
+        });
+
+        let d = pyo3::types::PyDict::new(py);
+        d.set_item("memories_stored", enrichment_result.memories_stored)?;
+        d.set_item("edges_created", enrichment_result.edges_created)?;
+        d.set_item("entities_extracted", enrichment_result.entities_extracted)?;
+        d.set_item("duplicates_skipped", enrichment_result.duplicates_skipped)?;
+        d.set_item("contradictions_found", enrichment_result.contradictions_found)?;
+        d.set_item("sync_linked", enrichment_result.sync_linked)?;
+        d.set_item("llm_linked", enrichment_result.llm_linked)?;
+        d.set_item("communities_created", enrichment_result.communities_created)?;
+        d.set_item("user_model_updated", enrichment_result.user_model_updated)?;
+        Ok(d.into_any().unbind())
+    }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Six correctness and durability fixes across the storage, graph, and index layers.

### Durability
1. **WAL append fsyncs** — every WAL entry is now durable on return. Previously, a crash between write and an explicit sync() call would lose entries.
2. **WAL truncation is atomic** — writes to a temp file, fsyncs, then renames. Previously, crash during in-place truncation (set_len(0) + rewrite) meant total WAL loss.

### Correctness
3. **Commit entry type documented** — marked as reserved for future transaction support. No behavior change.
4. **Page checksums verified on read** — detects silent corruption. Returns error on mismatch instead of silently serving bad data.
5. **remove_node cleans id_to_idx** — previously the HashMap entry was left behind, so `contains_node()` returned true for removed nodes and `add_node` would reuse stale indices.

### Performance
6. **SalienceIndex::get_salience() O(1)** — added reverse `HashMap<MemoryId, OrderedF32>` maintained alongside the BTreeMap. Previously did O(N) linear scan across all entries, called in the hot search path.