### PR TITLE
fix: allow results file in .gitignore to unblock release-plz

### DIFF
--- a/benchmarks/longmemeval/.gitignore
+++ b/benchmarks/longmemeval/.gitignore
@@ -3,4 +3,5 @@ data/
 
 # Benchmark results and eval logs
 results/
+!results/longmemeval_s_results.jsonl
 extraction_cache.json


### PR DESCRIPTION
The release-plz CI fails because `longmemeval_s_results.jsonl` is both committed and ignored by `benchmarks/longmemeval/.gitignore`. This adds a negation rule to exclude that specific file.