### PR TITLE
fix: durable forget, crash-durable graph edges, real embedder defaults, write-inference dedup

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -103,7 +103,7 @@ Owns all durable state. Implements a page oriented storage engine with
 write ahead logging and a buffer pool.
 
 **Page Manager** (`page.rs`):
-Pages are 16 KB, the same size PostgreSQL uses. Each page carries a header
+Pages are 64 KB, sized to fit large embedding vectors and long content in a single page. Each page carries a header
 with its ID, LSN (log sequence number), checksum, free space counter, slot count,
 and page type (Free, Data, Index, Overflow). The page manager maps a directory
 to a single data file, maintains a free list for page allocation, and provides

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ The server binary is `mentedb-server` and runs on axum with JWT auth, rate limit
 
 ## Architecture notes
 
-- Storage uses 16KB pages with CLOCK eviction buffer pool and WAL with LZ4 + CRC32
+- Storage uses 64KB pages with CLOCK eviction buffer pool and WAL with LZ4 + CRC32
 - HNSW index is built from scratch (not a binding), configurable M and ef parameters
 - Graph uses CSR/CSC hybrid with delta log and compact() to merge
 - MQL is a custom query language parsed by hand written recursive descent parser

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2411,6 +2411,7 @@ dependencies = [
  "mentedb",
  "mentedb-cognitive",
  "mentedb-core",
+ "mentedb-embedding",
  "mentedb-extraction",
  "prost",
  "serde",

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,9 @@ RUN apt-get update && apt-get install -y pkg-config libssl-dev protobuf-compiler
 WORKDIR /build
 COPY . .
 
-RUN cargo build --release --bin mentedb-server
+# local-embeddings bundles the Candle model loader so the container has
+# zero-config semantic search (model downloads on first start).
+RUN cargo build --release --bin mentedb-server --features mentedb-server/local-embeddings
 
 # Production stage
 FROM debian:bookworm-slim

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ The result: a clean, curated memory that actually helps the AI perform better.
 | Entity understanding | Manual schemas | None | **Auto-extracted typed entities with graph edges** |
 | Query result | Raw data | Similarity scores | **Token budget optimized context** |
 | Memory quality | Manual | None | **LLM extract + quality filter + dedup + contradiction** |
-| Retrieval strategy | Index scan | Single-pass kNN | **Adaptive multi-pass + entity graph expansion** |
+| Retrieval strategy | Index scan | Single-pass kNN | **Hybrid vector + BM25 + graph traversal** |
 | Understands AI attention? | No | No | **Yes, U curve ordering** |
 | Tracks what AI knows? | No | No | **Epistemic state tracking** |
 | Multi-agent isolation? | Schema level | Collection level | **Memory spaces with ACLs** |
@@ -135,8 +135,8 @@ The result: a clean, curated memory that actually helps the AI perform better.
 ### Core Features
 
 - **Automatic Memory Extraction** LLM powered pipeline extracts structured memories from raw conversations
-- **Entity-Centric Memory** Extracts typed entities (person, pet, place, event, item, organization) with structured attributes. Entity resolution merges attributes across mentions. Graph edges link memories to the entities they reference
-- **Adaptive Multi-Pass Retrieval** Engine-level 3-pass search (instant recall → active search → deep dig) with progressively increasing depth, reciprocal rank fusion, and entity graph expansion
+- **Entity-Centric Memory** Extracts typed entities (person, pet, place, event, item, organization) with structured attributes. Entity resolution merges attributes across mentions. `Derived` and labeled `Related` edges link entities to the memories they came from
+- **Hybrid Retrieval** Vector similarity (HNSW) fused with BM25 keyword search via reciprocal rank fusion, plus tag, temporal, and validity filtering
 - **Write Time Intelligence** Quality filter, deduplication, and contradiction detection at ingest
 - **LLM Powered Cognitive Inference** CognitiveLlmService judges whether new memories invalidate, update, or are compatible with existing ones (supports Anthropic, OpenAI, Ollama)
 - **Bi-Temporal Validity** Memories and edges carry `valid_from`/`valid_until` timestamps. Temporal invalidation instead of deletion. Point-in-time queries via `recall_similar_at(embedding, k, timestamp)`
@@ -149,7 +149,7 @@ The result: a clean, curated memory that actually helps the AI perform better.
 - **MQL** Mente Query Language with full boolean logic (AND, OR, NOT) and ordering (ASC/DESC)
 - **Type Safe IDs** MemoryId, AgentId, SpaceId newtypes prevent accidental mixing
 - **Binary Embeddings** Base64 encoded storage, 65% smaller than JSON arrays
-- **Local Candle Embeddings** Zero config semantic search using all-MiniLM-L6-v2 (384 dims), no API key required
+- **Local Candle Embeddings** Zero config semantic search using all-MiniLM-L6-v2 (384 dims), no API key required (Docker image includes it; source builds need `--features local-embeddings`)
 - **gRPC + REST + MCP** Three integration paths for any use case
 
 ### Entity-Centric Memory
@@ -163,13 +163,13 @@ Entity: MAX (pet)
   ──linked to──> "User takes Max to the park on weekends"
 ```
 
-**How it works:**
+**How it works** (via the background enrichment pipeline, requires an LLM provider):
 1. **Extraction** — The LLM identifies entities (people, pets, places, events, items) and their attributes, even from incidental mentions
 2. **Resolution** — Multiple mentions of the same entity are merged: "Max", "my dog", "the Golden Retriever" all resolve to one entity node
-3. **Graph linking** — `PartOf` edges connect every memory that mentions an entity back to the entity node
-4. **Search expansion** — When search hits an entity, the engine traverses its subgraph to surface all related memories
+3. **Graph linking** — `Derived` edges connect each entity node back to the episodic memories it was extracted from, and same-entity memories are linked with labeled `Related` edges
+4. **Retrieval** — Entity nodes are indexed like any memory, so "What breed is my dog?" surfaces the MAX entity (with its breed attribute) through hybrid search; the surrounding subgraph can be walked with an MQL `TRAVERSE` query
 
-This means asking *"What breed is my dog?"* finds the entity MAX, follows its edges, and returns the breed attribute — even if no single memory explicitly says "my dog is a Golden Retriever".
+So asking *"What breed is my dog?"* retrieves the entity MAX with its breed attribute, even if no single conversation turn explicitly says "my dog is a Golden Retriever".
 
 ### Performance Targets (10M memories)
 
@@ -307,13 +307,13 @@ graph TD
     subgraph Graph["Knowledge Graph"]
         CSR["CSR/CSC Storage"]
         TRAV["BFS / DFS Traversal"]
-        ENTG["Entity Graph<br/>PartOf edges, resolution"]
+        ENTG["Entity Graph<br/>Derived edges, resolution"]
     end
 
     subgraph Storage["Storage Engine"]
         BUF["Buffer Pool<br/>CLOCK eviction"]
         WAL["Write Ahead Log<br/>LZ4, crash safe"]
-        PAGE["Page Manager<br/>16KB pages"]
+        PAGE["Page Manager<br/>64KB pages"]
     end
 
     LLM --> ENT --> QF --> DEDUP --> CONTRA_EX --> WI
@@ -340,14 +340,14 @@ graph TD
 
 MenteDB isn't just a memory store — it's a cognitive engine that automatically maintains memory health. All cognitive features are wired into the core `MenteDb` facade and run automatically.
 
-### Write Inference (automatic on `store()`)
+### Write Inference (automatic on `store()` and `store_batch()`)
 
-Every time a memory is stored, the engine finds the 20 most similar existing memories and runs heuristic inference:
+Every time a memory is stored, the engine finds the 20 most similar existing memories and runs heuristic inference. The bands are mutually exclusive — each memory pair gets at most one action:
 
 | Cosine Similarity | Action | What happens |
 |-------------------|--------|-------------|
-| **> 0.95** | Contradiction detected | Creates `Contradicts` edge, flags conflict |
-| **> 0.85** | Supersedes old memory | Invalidates older memory (`valid_until` set), creates `Supersedes` edge |
+| **> 0.95** | Contradiction detected | Creates `Contradicts` edge, flags conflict for review (both memories stay valid; a byte-identical duplicate is superseded instead) |
+| **0.85 – 0.95** | Supersedes old memory | Invalidates older memory (`valid_until` set), creates `Supersedes` edge |
 | **0.6 – 0.85** | Related | Creates `Related` edge with similarity as weight |
 | **< 0.6** | No action | Memories are independent |
 
@@ -551,6 +551,9 @@ Configure the extraction pipeline via environment variables:
 | `MENTEDB_LLM_BASE_URL` | Custom base URL (Ollama, proxies) | Provider default |
 | `MENTEDB_EXTRACTION_QUALITY_THRESHOLD` | Min confidence to store (0.0 to 1.0) | 0.7 |
 | `MENTEDB_EXTRACTION_DEDUP_THRESHOLD` | Similarity threshold for dedup (0.0 to 1.0) | 0.85 |
+| `MENTEDB_EMBEDDING_PROVIDER` | Server embeddings: candle, hash, none | candle when built with `local-embeddings`, else hash |
+
+Semantic search, auto-linking, and contradiction detection all depend on real embeddings. The Docker image ships with local Candle embeddings; a plain `cargo install mentedb-server` falls back to non-semantic hash embeddings and warns loudly at startup — build with `--features local-embeddings` for full quality.
 
 ## MQL Examples
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ One function call runs the full 14-step cognitive pipeline: embedding, speculati
 **Via MCP (zero code):**
 
 ```bash
-npx mentedb-mcp@latest setup copilot  # or claude, cursor, vscode
+npx mentedb-mcp@latest setup copilot  # or claude, cursor
 ```
 
 Your AI assistant calls `process_turn` automatically every turn.

--- a/crates/mentedb-cognitive/src/write_inference.rs
+++ b/crates/mentedb-cognitive/src/write_inference.rs
@@ -126,37 +126,41 @@ impl WriteInferenceEngine {
 
             let sim = cosine_similarity(&new_memory.embedding, &existing.embedding);
 
-            // Very high similarity: potential duplicate or contradiction
-            if sim > self.config.contradiction_threshold
-                && existing.agent_id == new_memory.agent_id
-                && existing.content != new_memory.content
+            // The bands are mutually exclusive: each pair gets at most one
+            // action. A contradiction is flagged for review, NOT silently
+            // invalidated; an exact duplicate (same content) is superseded.
+            if sim > self.config.contradiction_threshold {
+                if existing.agent_id == new_memory.agent_id
+                    && existing.content != new_memory.content
+                {
+                    actions.push(InferredAction::FlagContradiction {
+                        existing: existing.id,
+                        new: new_memory.id,
+                        reason: format!(
+                            "High embedding similarity ({:.3}) with different content from same agent",
+                            sim
+                        ),
+                    });
+                } else if new_memory.created_at > existing.created_at {
+                    // Same content (or cross-agent duplicate): supersede the old copy.
+                    actions.push(InferredAction::InvalidateMemory {
+                        memory: existing.id,
+                        superseded_by: new_memory.id,
+                        valid_until: new_memory.created_at,
+                    });
+                }
+            } else if sim > self.config.obsolete_threshold
+                && new_memory.created_at > existing.created_at
             {
-                actions.push(InferredAction::FlagContradiction {
-                    existing: existing.id,
-                    new: new_memory.id,
-                    reason: format!(
-                        "High embedding similarity ({:.3}) with different content from same agent",
-                        sim
-                    ),
-                });
-            }
-
-            // High similarity: mark older as obsolete if newer timestamp
-            if sim > self.config.obsolete_threshold && new_memory.created_at > existing.created_at {
-                actions.push(InferredAction::MarkObsolete {
-                    memory: existing.id,
-                    superseded_by: new_memory.id,
-                });
-                // Also emit temporal invalidation so the old memory gets valid_until set
+                // InvalidateMemory both sets valid_until and creates the
+                // Supersedes edge; emitting MarkObsolete as well would
+                // duplicate the edge and invalidate twice.
                 actions.push(InferredAction::InvalidateMemory {
                     memory: existing.id,
                     superseded_by: new_memory.id,
                     valid_until: new_memory.created_at,
                 });
-            }
-
-            // Moderate similarity: create Related edge
-            if sim > self.config.related_min && sim <= self.config.related_max {
+            } else if sim > self.config.related_min && sim <= self.config.related_max {
                 actions.push(InferredAction::CreateEdge {
                     source: new_memory.id,
                     target: existing.id,
@@ -228,20 +232,12 @@ impl WriteInferenceEngine {
                 if let Ok(verdict) = llm.judge_invalidation(&old_summary, &new_summary).await {
                     match verdict {
                         InvalidationVerdict::Invalidate { reason: _ } => {
-                            actions.push(InferredAction::MarkObsolete {
-                                memory: existing.id,
-                                superseded_by: new_memory.id,
-                            });
+                            // InvalidateMemory sets valid_until and creates the
+                            // Supersedes edge; no separate MarkObsolete/CreateEdge.
                             actions.push(InferredAction::InvalidateMemory {
                                 memory: existing.id,
                                 superseded_by: new_memory.id,
                                 valid_until: new_memory.created_at,
-                            });
-                            actions.push(InferredAction::CreateEdge {
-                                source: new_memory.id,
-                                target: existing.id,
-                                edge_type: EdgeType::Supersedes,
-                                weight: 1.0,
                             });
                             actions.push(InferredAction::UpdateConfidence {
                                 memory: existing.id,
@@ -289,20 +285,10 @@ impl WriteInferenceEngine {
                             } else {
                                 (new_memory.id, existing.id)
                             };
-                            actions.push(InferredAction::MarkObsolete {
-                                memory: obsolete,
-                                superseded_by: superseder,
-                            });
                             actions.push(InferredAction::InvalidateMemory {
                                 memory: obsolete,
                                 superseded_by: superseder,
                                 valid_until: new_memory.created_at,
-                            });
-                            actions.push(InferredAction::CreateEdge {
-                                source: superseder,
-                                target: obsolete,
-                                edge_type: EdgeType::Supersedes,
-                                weight: 1.0,
                             });
                         }
                         ContradictionVerdict::Compatible { .. } => {}
@@ -334,12 +320,6 @@ impl WriteInferenceEngine {
         {
             let sim = cosine_similarity(&new_memory.embedding, &original.embedding);
             if sim > self.config.correction_threshold {
-                actions.push(InferredAction::CreateEdge {
-                    source: new_memory.id,
-                    target: original.id,
-                    edge_type: EdgeType::Supersedes,
-                    weight: 1.0,
-                });
                 actions.push(InferredAction::InvalidateMemory {
                     memory: original.id,
                     superseded_by: new_memory.id,
@@ -463,11 +443,21 @@ mod tests {
             "Expected InvalidateMemory from LLM verdict, got: {:?}",
             actions
         );
-        assert!(
-            actions
-                .iter()
-                .any(|a| matches!(a, InferredAction::MarkObsolete { .. })),
-            "Expected MarkObsolete from LLM verdict, got: {:?}",
+        // Exactly one invalidation action: InvalidateMemory both sets
+        // valid_until and creates the Supersedes edge, so a MarkObsolete
+        // alongside it would duplicate the edge.
+        let invalidation_count = actions
+            .iter()
+            .filter(|a| {
+                matches!(
+                    a,
+                    InferredAction::InvalidateMemory { .. } | InferredAction::MarkObsolete { .. }
+                )
+            })
+            .count();
+        assert_eq!(
+            invalidation_count, 1,
+            "Expected a single invalidation action, got: {:?}",
             actions
         );
     }

--- a/crates/mentedb-core/src/config.rs
+++ b/crates/mentedb-core/src/config.rs
@@ -34,9 +34,15 @@ pub struct StorageConfig {
     /// Directory for data files.
     pub data_dir: String,
     /// Number of pages in the buffer pool.
+    ///
+    /// Currently informational: the storage engine uses a fixed pool of 1024
+    /// frames and does not read this field yet.
     #[serde(default = "default_buffer_pool_size")]
     pub buffer_pool_size: usize,
     /// Page size in bytes.
+    ///
+    /// Currently informational: pages are a fixed 64 KB compile-time constant
+    /// (`mentedb_storage::PAGE_SIZE`) and the engine does not read this field.
     #[serde(default = "default_page_size")]
     pub page_size: usize,
 }
@@ -45,7 +51,7 @@ fn default_buffer_pool_size() -> usize {
     1024
 }
 fn default_page_size() -> usize {
-    16384
+    65536
 }
 
 impl Default for StorageConfig {
@@ -316,7 +322,7 @@ mod tests {
 
         assert_eq!(cfg.storage.data_dir, "data");
         assert_eq!(cfg.storage.buffer_pool_size, 1024);
-        assert_eq!(cfg.storage.page_size, 16384);
+        assert_eq!(cfg.storage.page_size, 65536);
 
         assert_eq!(cfg.index.hnsw_m, 16);
         assert_eq!(cfg.index.hnsw_ef_construction, 200);

--- a/crates/mentedb-graph/src/csr.rs
+++ b/crates/mentedb-graph/src/csr.rs
@@ -167,9 +167,22 @@ impl CsrGraph {
     }
 
     /// Add an edge to the delta log.
+    ///
+    /// Deduplicates: if a currently-valid edge with the same source, target,
+    /// and type already exists (in CSR or the delta log), the graph is left
+    /// unchanged. Write inference and pipeline passes may infer the same
+    /// relationship more than once; parallel duplicates carry no information.
     pub fn add_edge(&mut self, edge: &MemoryEdge) {
         let source_idx = self.add_node(edge.source);
         let target_idx = self.add_node(edge.target);
+
+        let duplicate = self.outgoing_by_idx(source_idx).into_iter().any(|(t, e)| {
+            t == edge.target && e.edge_type == edge.edge_type && e.valid_until.is_none()
+        });
+        if duplicate {
+            return;
+        }
+
         self.delta_edges.push(DeltaEdge {
             source_idx,
             target_idx,
@@ -178,18 +191,38 @@ impl CsrGraph {
     }
 
     /// Strengthen an edge by incrementing its weight (Hebbian learning).
-    /// Adds a delta edge with the new weight; compaction will merge it.
+    ///
+    /// Updates the existing edge rather than appending a parallel duplicate:
+    /// a delta edge is bumped in place; a compressed (CSR) edge is marked
+    /// removed and replaced with a delta override, so compaction keeps
+    /// exactly one copy.
     pub fn strengthen_edge(&mut self, source: MemoryId, target: MemoryId, delta: f32) {
-        // Find the existing edge to get its current data
+        let (Some(&source_idx), Some(&target_idx)) =
+            (self.id_to_idx.get(&source), self.id_to_idx.get(&target))
+        else {
+            return;
+        };
+
+        // Bump an existing delta edge in place.
         if let Some(existing) = self
-            .outgoing(source)
+            .delta_edges
+            .iter_mut()
+            .find(|e| e.source_idx == source_idx && e.target_idx == target_idx)
+        {
+            existing.data.weight = (existing.data.weight + delta).min(1.0);
+            return;
+        }
+
+        // Edge lives in compressed storage: suppress the CSR copy and push a
+        // delta override. Removed-edge filtering only applies to compressed
+        // edges, so the override remains visible.
+        if let Some((_, stored)) = self
+            .outgoing_by_idx(source_idx)
             .into_iter()
             .find(|(id, _)| *id == target)
         {
-            let (_, stored) = existing;
             let new_weight = (stored.weight + delta).min(1.0);
-            let source_idx = self.add_node(source);
-            let target_idx = self.add_node(target);
+            self.removed_edges.push((source_idx, target_idx));
             self.delta_edges.push(DeltaEdge {
                 source_idx,
                 target_idx,

--- a/crates/mentedb-graph/src/csr.rs
+++ b/crates/mentedb-graph/src/csr.rs
@@ -415,11 +415,20 @@ impl CsrGraph {
             edge_data,
         }
     }
-    /// Save the graph to a binary file.
+    /// Save the graph snapshot to a file.
     pub fn save(&self, path: &std::path::Path) -> MenteResult<()> {
         let data =
             serde_json::to_vec(self).map_err(|e| MenteError::Serialization(e.to_string()))?;
-        std::fs::write(path, data)?;
+        // Atomic snapshot: write to a temp file, fsync, then rename over the
+        // old snapshot so a crash mid-save never leaves a truncated graph.
+        let tmp_path = path.with_extension("json.tmp");
+        {
+            use std::io::Write;
+            let mut file = std::fs::File::create(&tmp_path)?;
+            file.write_all(&data)?;
+            file.sync_data()?;
+        }
+        std::fs::rename(&tmp_path, path)?;
         Ok(())
     }
 

--- a/crates/mentedb-graph/src/manager.rs
+++ b/crates/mentedb-graph/src/manager.rs
@@ -1,66 +1,211 @@
 //! High-level knowledge graph manager.
 
-use std::path::Path;
+use std::io::Write;
+use std::path::{Path, PathBuf};
 
 use mentedb_core::edge::MemoryEdge;
 use mentedb_core::error::{MenteError, MenteResult};
 use mentedb_core::types::MemoryId;
-use parking_lot::RwLock;
+use parking_lot::{Mutex, RwLock};
+use serde::{Deserialize, Serialize};
+use tracing::warn;
 
 use crate::belief::propagate_update;
 use crate::contradiction::find_contradictions;
 use crate::csr::CsrGraph;
 use crate::traversal::extract_subgraph;
 
+/// A single durable graph mutation, appended to the edge log as one JSON line.
+#[derive(Debug, Serialize, Deserialize)]
+enum LogRecord {
+    AddNode(MemoryId),
+    RemoveNode(MemoryId),
+    AddEdge(MemoryEdge),
+}
+
+/// Append-only log of graph mutations since the last snapshot.
+///
+/// The snapshot (`graph.json`) is only written on `save()`; without this log
+/// every edge created since the last flush would be lost on crash while the
+/// memories themselves survive via the storage WAL.
+struct EdgeLog {
+    file: std::fs::File,
+}
+
+const EDGE_LOG_FILE: &str = "edges.jsonl";
+
+impl EdgeLog {
+    fn append(&mut self, record: &LogRecord) -> MenteResult<()> {
+        let mut line =
+            serde_json::to_vec(record).map_err(|e| MenteError::Serialization(e.to_string()))?;
+        line.push(b'\n');
+        self.file.write_all(&line)?;
+        self.file.sync_data()?;
+        Ok(())
+    }
+}
+
 /// Owns a `CsrGraph` and provides high-level graph operations.
 ///
 /// All methods take `&self` — internal `RwLock` handles concurrency.
 pub struct GraphManager {
     graph: RwLock<CsrGraph>,
+    /// Directory-backed managers log mutations for crash durability.
+    /// `None` for purely in-memory managers created with `new()`.
+    log: Mutex<Option<EdgeLog>>,
+    dir: Option<PathBuf>,
 }
 
 impl GraphManager {
-    /// Creates a new graph manager with an empty graph.
+    /// Creates a new in-memory graph manager (no durability log).
     pub fn new() -> Self {
         Self {
             graph: RwLock::new(CsrGraph::new()),
+            log: Mutex::new(None),
+            dir: None,
         }
     }
 
-    /// Save the graph to the given directory.
-    pub fn save(&self, dir: &Path) -> MenteResult<()> {
+    /// Open a directory-backed graph manager.
+    ///
+    /// Loads the last snapshot (`graph.json`) if present, replays the edge log
+    /// (`edges.jsonl`) on top of it, and keeps the log open for appending, so
+    /// graph mutations are crash-durable between snapshots.
+    pub fn open(dir: &Path) -> MenteResult<Self> {
         std::fs::create_dir_all(dir)?;
-        self.graph.read().save(&dir.join("graph.json"))
+
+        let snapshot_path = dir.join("graph.json");
+        let mut graph = if snapshot_path.exists() {
+            CsrGraph::load(&snapshot_path)?
+        } else {
+            CsrGraph::new()
+        };
+
+        let log_path = dir.join(EDGE_LOG_FILE);
+        if log_path.exists() {
+            let contents = std::fs::read_to_string(&log_path)?;
+            let lines: Vec<&str> = contents.lines().collect();
+            for (i, line) in lines.iter().enumerate() {
+                if line.trim().is_empty() {
+                    continue;
+                }
+                match serde_json::from_str::<LogRecord>(line) {
+                    Ok(LogRecord::AddNode(id)) => {
+                        graph.add_node(id);
+                    }
+                    Ok(LogRecord::RemoveNode(id)) => {
+                        graph.remove_node(id);
+                    }
+                    Ok(LogRecord::AddEdge(edge)) => {
+                        graph.add_node(edge.source);
+                        graph.add_node(edge.target);
+                        graph.add_edge(&edge);
+                    }
+                    Err(e) => {
+                        // A torn final line is expected after a crash mid-append;
+                        // anything else is corruption worth surfacing.
+                        if i + 1 == lines.len() {
+                            warn!("dropping torn final edge log line: {e}");
+                        } else {
+                            return Err(MenteError::Serialization(format!(
+                                "corrupt edge log line {}: {e}",
+                                i + 1
+                            )));
+                        }
+                    }
+                }
+            }
+        }
+
+        let file = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&log_path)?;
+
+        Ok(Self {
+            graph: RwLock::new(graph),
+            log: Mutex::new(Some(EdgeLog { file })),
+            dir: Some(dir.to_path_buf()),
+        })
     }
 
-    /// Load the graph from the given directory.
+    /// Save a graph snapshot to the given directory and truncate the edge log.
+    pub fn save(&self, dir: &Path) -> MenteResult<()> {
+        std::fs::create_dir_all(dir)?;
+        self.graph.read().save(&dir.join("graph.json"))?;
+
+        // The snapshot now contains everything the log recorded.
+        let mut log = self.log.lock();
+        if log.is_some() && self.dir.as_deref() == Some(dir) {
+            let log_path = dir.join(EDGE_LOG_FILE);
+            let file = std::fs::OpenOptions::new()
+                .create(true)
+                .write(true)
+                .truncate(true)
+                .open(&log_path)?;
+            file.sync_data()?;
+            drop(file);
+            let file = std::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(&log_path)?;
+            *log = Some(EdgeLog { file });
+        }
+        Ok(())
+    }
+
+    /// Load the graph snapshot from the given directory (no durability log).
+    ///
+    /// Prefer `open()`, which also replays and maintains the edge log.
     pub fn load(dir: &Path) -> MenteResult<Self> {
         let graph = CsrGraph::load(&dir.join("graph.json"))?;
         Ok(Self {
             graph: RwLock::new(graph),
+            log: Mutex::new(None),
+            dir: None,
         })
+    }
+
+    fn log_record(&self, record: &LogRecord) {
+        if let Some(log) = self.log.lock().as_mut()
+            && let Err(e) = log.append(record)
+        {
+            warn!("failed to append to graph edge log: {e}");
+        }
     }
 
     /// Register a memory node in the graph.
     pub fn add_memory(&self, id: MemoryId) {
-        self.graph.write().add_node(id);
+        let is_new = {
+            let mut g = self.graph.write();
+            let existed = g.contains_node(id);
+            g.add_node(id);
+            !existed
+        };
+        if is_new {
+            self.log_record(&LogRecord::AddNode(id));
+        }
     }
 
     /// Remove a memory node and all its edges.
     pub fn remove_memory(&self, id: MemoryId) {
         self.graph.write().remove_node(id);
+        self.log_record(&LogRecord::RemoveNode(id));
     }
 
     /// Add a relationship (edge) between two memory nodes.
     pub fn add_relationship(&self, edge: &MemoryEdge) -> MenteResult<()> {
-        let mut g = self.graph.write();
-        if !g.contains_node(edge.source) {
-            return Err(MenteError::MemoryNotFound(edge.source));
+        {
+            let mut g = self.graph.write();
+            if !g.contains_node(edge.source) {
+                return Err(MenteError::MemoryNotFound(edge.source));
+            }
+            if !g.contains_node(edge.target) {
+                return Err(MenteError::MemoryNotFound(edge.target));
+            }
+            g.add_edge(edge);
         }
-        if !g.contains_node(edge.target) {
-            return Err(MenteError::MemoryNotFound(edge.target));
-        }
-        g.add_edge(edge);
+        self.log_record(&LogRecord::AddEdge(edge.clone()));
         Ok(())
     }
 
@@ -192,6 +337,64 @@ mod tests {
 
         let out = mgr.graph().outgoing(a);
         assert_eq!(out.len(), 1);
+    }
+
+    #[test]
+    fn test_edge_log_replay_without_snapshot() {
+        let dir = tempfile::tempdir().unwrap();
+        let a = MemoryId::new();
+        let b = MemoryId::new();
+        {
+            let mgr = GraphManager::open(dir.path()).unwrap();
+            mgr.add_memory(a);
+            mgr.add_memory(b);
+            mgr.add_relationship(&make_edge(a, b, EdgeType::Caused))
+                .unwrap();
+            // No save(): the mutations exist only in the edge log.
+        }
+        {
+            let mgr = GraphManager::open(dir.path()).unwrap();
+            assert!(mgr.read_graph().contains_node(a));
+            let out = mgr.read_graph().outgoing(a);
+            assert_eq!(out.len(), 1);
+            assert_eq!(out[0].0, b);
+        }
+    }
+
+    #[test]
+    fn test_save_truncates_edge_log() {
+        let dir = tempfile::tempdir().unwrap();
+        let a = MemoryId::new();
+        let b = MemoryId::new();
+        {
+            let mgr = GraphManager::open(dir.path()).unwrap();
+            mgr.add_memory(a);
+            mgr.add_memory(b);
+            mgr.add_relationship(&make_edge(a, b, EdgeType::Related))
+                .unwrap();
+            mgr.save(dir.path()).unwrap();
+            let log_len = std::fs::metadata(dir.path().join(super::EDGE_LOG_FILE))
+                .unwrap()
+                .len();
+            assert_eq!(log_len, 0, "save must truncate the edge log");
+        }
+        {
+            // Snapshot alone restores everything; further mutations keep logging.
+            let mgr = GraphManager::open(dir.path()).unwrap();
+            assert_eq!(mgr.read_graph().outgoing(a).len(), 1);
+            let c = MemoryId::new();
+            mgr.add_memory(c);
+            mgr.add_relationship(&make_edge(a, c, EdgeType::Supports))
+                .unwrap();
+        }
+        {
+            let mgr = GraphManager::open(dir.path()).unwrap();
+            assert_eq!(
+                mgr.read_graph().outgoing(a).len(),
+                2,
+                "post-save mutations must replay from the fresh log"
+            );
+        }
     }
 
     #[test]

--- a/crates/mentedb-server/Cargo.toml
+++ b/crates/mentedb-server/Cargo.toml
@@ -15,6 +15,7 @@ mentedb = { workspace = true }
 mentedb-core = { workspace = true }
 mentedb-cognitive = { workspace = true }
 mentedb-extraction = { workspace = true }
+mentedb-embedding = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { version = "0.1", features = ["net"] }
 serde = { workspace = true }
@@ -31,6 +32,12 @@ http-body-util = "0.1"
 jsonwebtoken = { version = "10", features = ["rust_crypto"] }
 tonic = "0.13"
 prost = "0.13"
+
+[features]
+default = []
+# Bundle the local Candle embedding model (all-MiniLM-L6-v2) so the server has
+# zero-config semantic search. Enabled in release/Docker builds.
+local-embeddings = ["mentedb-embedding/local"]
 
 [build-dependencies]
 tonic-build = "0.13"

--- a/crates/mentedb-server/src/main.rs
+++ b/crates/mentedb-server/src/main.rs
@@ -47,6 +47,7 @@ struct ServerConfig {
     llm_base_url: Option<String>,
     extraction_quality_threshold: Option<f32>,
     extraction_dedup_threshold: Option<f32>,
+    embedding_provider: Option<String>,
 }
 fn parse_args() -> ServerConfig {
     let args: Vec<String> = env::args().collect();
@@ -63,6 +64,7 @@ fn parse_args() -> ServerConfig {
     let mut llm_base_url: Option<String> = None;
     let mut extraction_quality_threshold: Option<f32> = None;
     let mut extraction_dedup_threshold: Option<f32> = None;
+    let mut embedding_provider: Option<String> = None;
 
     let mut i = 1;
     while i < args.len() {
@@ -162,6 +164,15 @@ fn parse_args() -> ServerConfig {
                     std::process::exit(1);
                 }
             }
+            "--embedding-provider" => {
+                if i + 1 < args.len() {
+                    embedding_provider = Some(args[i + 1].clone());
+                    i += 2;
+                } else {
+                    eprintln!("Error: --embedding-provider requires a value (candle, hash, none)");
+                    std::process::exit(1);
+                }
+            }
             _ => {
                 eprintln!("Unknown argument: {}", args[i]);
                 std::process::exit(1);
@@ -211,6 +222,11 @@ fn parse_args() -> ServerConfig {
     {
         extraction_dedup_threshold = v.parse().ok();
     }
+    if embedding_provider.is_none()
+        && let Ok(v) = env::var("MENTEDB_EMBEDDING_PROVIDER")
+    {
+        embedding_provider = Some(v);
+    }
     ServerConfig {
         data_dir,
         port,
@@ -225,6 +241,76 @@ fn parse_args() -> ServerConfig {
         llm_base_url,
         extraction_quality_threshold,
         extraction_dedup_threshold,
+        embedding_provider,
+    }
+}
+
+/// Build the embedding provider for the server.
+///
+/// Without an embedder the engine's semantic search, auto-linking, and
+/// contradiction detection are inert (only keyword retrieval works), so the
+/// server always wires one and is loud about quality degradation.
+///
+/// Selection: `candle` (semantic, requires the `local-embeddings` build
+/// feature), `hash` (deterministic but non-semantic), `none` (disable).
+/// Default: candle when compiled in, hash otherwise.
+fn build_embedder(
+    choice: Option<&str>,
+) -> Option<Box<dyn mentedb_embedding::provider::EmbeddingProvider>> {
+    let choice = choice.unwrap_or(if cfg!(feature = "local-embeddings") {
+        "candle"
+    } else {
+        "hash"
+    });
+
+    match choice {
+        "none" => {
+            eprintln!(
+                "WARNING: embeddings disabled (--embedding-provider none). Semantic search, \
+                 auto-linking, and contradiction detection will not work; retrieval is \
+                 keyword-only."
+            );
+            None
+        }
+        "candle" => {
+            #[cfg(feature = "local-embeddings")]
+            {
+                match mentedb_embedding::CandleEmbeddingProvider::new() {
+                    Ok(provider) => {
+                        tracing::info!("using local Candle embeddings (all-MiniLM-L6-v2)");
+                        return Some(Box::new(provider));
+                    }
+                    Err(e) => {
+                        eprintln!(
+                            "WARNING: failed to load Candle embedding model ({e}); falling back \
+                             to non-semantic hash embeddings. Semantic search quality will be \
+                             severely degraded."
+                        );
+                        return Some(Box::new(mentedb_embedding::HashEmbeddingProvider::new(384)));
+                    }
+                }
+            }
+            #[cfg(not(feature = "local-embeddings"))]
+            {
+                eprintln!(
+                    "Error: --embedding-provider candle requires a build with \
+                     --features local-embeddings"
+                );
+                std::process::exit(1);
+            }
+        }
+        "hash" => {
+            eprintln!(
+                "WARNING: using non-semantic hash embeddings. Only byte-identical text matches; \
+                 semantic search, auto-linking, and contradiction detection are effectively \
+                 disabled. Rebuild with --features local-embeddings for real semantic search."
+            );
+            Some(Box::new(mentedb_embedding::HashEmbeddingProvider::new(384)))
+        }
+        other => {
+            eprintln!("Error: unknown embedding provider '{other}' (expected candle, hash, none)");
+            std::process::exit(1);
+        }
     }
 }
 
@@ -262,7 +348,10 @@ async fn main() -> Result<()> {
 
     std::fs::create_dir_all(&data_dir)?;
 
-    let db = MenteDb::open(&data_dir)?;
+    let db = match build_embedder(config.embedding_provider.as_deref()) {
+        Some(embedder) => MenteDb::open_with_embedder(&data_dir, embedder)?,
+        None => MenteDb::open(&data_dir)?,
+    };
     let db = Arc::new(db);
 
     let auth_mode = if jwt_secret.is_some() {

--- a/crates/mentedb-storage/src/buffer.rs
+++ b/crates/mentedb-storage/src/buffer.rs
@@ -150,6 +150,23 @@ impl BufferPool {
         }
     }
 
+    /// Drop a page from the pool without flushing, discarding any dirty state.
+    ///
+    /// Used when a page is freed: the on-disk state is already authoritative,
+    /// so a stale cached copy must never be served or flushed back. A no-op if
+    /// the page is not cached.
+    pub fn invalidate(&self, page_id: PageId) {
+        let mut inner = self.inner.lock();
+        if let Some(fid) = inner.page_table.remove(&page_id) {
+            let frame = &mut inner.frames[fid];
+            frame.page_id = None;
+            frame.pin_count = 0;
+            frame.dirty = false;
+            frame.reference = false;
+            debug!(page_id = page_id.0, "invalidated cached page");
+        }
+    }
+
     /// Replace the cached copy of a page and mark it dirty.
     pub fn update_page(&self, page_id: PageId, page: &Page) -> MenteResult<()> {
         let mut inner = self.inner.lock();

--- a/crates/mentedb-storage/src/engine.rs
+++ b/crates/mentedb-storage/src/engine.rs
@@ -92,11 +92,30 @@ impl StorageEngine {
         // Refresh page count from disk — another process may have written pages.
         pm.reload_header()?;
 
+        // Replay with last-op-wins per page: every PageWrite carries a full page
+        // image and PageFree discards the page, so only the final entry for each
+        // page matters. This is what makes free-then-reuse sequences safe: a
+        // PageFree followed by a later PageWrite for the same page must not
+        // leave the page on the free list.
+        let mut last_op: std::collections::HashMap<u64, &crate::wal::WalEntry> = Default::default();
+        let mut order: Vec<u64> = Vec::new();
         for entry in &entries {
             match entry.entry_type {
-                WalEntryType::PageWrite => {
-                    let page_id = PageId(entry.page_id);
+                WalEntryType::PageWrite | WalEntryType::PageFree => {
+                    if !last_op.contains_key(&entry.page_id) {
+                        order.push(entry.page_id);
+                    }
+                    last_op.insert(entry.page_id, entry);
+                }
+                WalEntryType::Checkpoint | WalEntryType::Commit => {}
+            }
+        }
 
+        for page_id_raw in order {
+            let entry = last_op[&page_id_raw];
+            let page_id = PageId(entry.page_id);
+            match entry.entry_type {
+                WalEntryType::PageWrite => {
                     while pm.page_count() <= entry.page_id {
                         pm.allocate_page()?;
                     }
@@ -116,11 +135,29 @@ impl StorageEngine {
                     pm.write_page(page_id, &page)?;
                     count += 1;
                 }
+                WalEntryType::PageFree => {
+                    // Mark the page Free without touching the free list; the
+                    // list is rebuilt from page types after replay so it stays
+                    // consistent with WAL-derived page states.
+                    if entry.page_id < pm.page_count() {
+                        let mut page = Page::zeroed();
+                        page.header.page_id = entry.page_id;
+                        page.header.page_type = PageType::Free as u8;
+                        pm.write_page(page_id, &page)?;
+                        self.buffer_pool.invalidate(page_id);
+                        count += 1;
+                    }
+                }
                 WalEntryType::Checkpoint | WalEntryType::Commit => {}
             }
         }
 
         if count > 0 {
+            // Header updates (free list head, page count) are not fsynced on
+            // every write, so after a crash the free list can disagree with the
+            // replayed page states. Rebuild it from page types: the WAL is the
+            // sole source of truth for which pages are Free vs Data.
+            pm.rebuild_free_list()?;
             pm.sync()?;
             let next_lsn = wal.next_lsn();
             wal.truncate(next_lsn)?;
@@ -282,8 +319,10 @@ impl StorageEngine {
             (page_id, lsn)
         };
 
-        // Update buffer pool outside the flock (optional optimization)
-        let _ = lsn; // buffer pool update uses the page already written to disk
+        // Drop any stale cached copy (the page may have been reused from the
+        // free list); the next read loads the fresh data from disk.
+        let _ = lsn;
+        self.buffer_pool.invalidate(page_id);
 
         // Auto-checkpoint when WAL exceeds threshold to prevent unbounded growth.
         // This keeps reload_lsn() fast for subsequent writes.
@@ -360,6 +399,11 @@ impl StorageEngine {
             ids
         };
 
+        // Drop stale cached copies for pages reused from the free list.
+        for page_id in &page_ids {
+            self.buffer_pool.invalidate(*page_id);
+        }
+
         // Auto-checkpoint if WAL grew too large
         if self.wal.lock().file_size() > WAL_AUTO_CHECKPOINT_BYTES
             && let Err(e) = self.checkpoint()
@@ -369,6 +413,60 @@ impl StorageEngine {
 
         info!(count = page_ids.len(), "stored memory batch");
         Ok(page_ids)
+    }
+
+    /// Update a [`MemoryNode`] in place on its existing page.
+    ///
+    /// The write goes through the WAL-protected `write_page` path, so it is
+    /// crash-durable and keeps the buffer pool coherent. Unlike storing to a
+    /// fresh page, this never orphans the old copy.
+    pub fn update_memory(&self, page_id: PageId, node: &MemoryNode) -> MenteResult<()> {
+        let serialized =
+            serde_json::to_vec(node).map_err(|e| MenteError::Serialization(e.to_string()))?;
+
+        if serialized.len() + 4 > PAGE_DATA_SIZE {
+            return Err(MenteError::CapacityExceeded(format!(
+                "memory node serialized to {} bytes (max {})",
+                serialized.len(),
+                PAGE_DATA_SIZE - 4,
+            )));
+        }
+
+        let mut buf = Vec::with_capacity(4 + serialized.len());
+        buf.extend_from_slice(&(serialized.len() as u32).to_le_bytes());
+        buf.extend_from_slice(&serialized);
+
+        self.write_page(page_id, &buf)
+    }
+
+    /// Delete a memory by returning its page to the free list.
+    ///
+    /// The deletion is WAL-logged before the page is freed, so it survives a
+    /// crash: recovery replays the `PageFree` entry and the memory does not
+    /// resurrect on reopen. The freed page is reused by later allocations.
+    pub fn delete_memory(&self, page_id: PageId) -> MenteResult<()> {
+        {
+            let mut wal = self.wal.lock();
+            let mut pm = self.page_manager.lock();
+
+            wal.lock_exclusive()?;
+            pm.reload_header()?;
+            wal.reload_lsn()?;
+
+            // WAL fsync guarantees the deletion is durable before the page
+            // is touched; the free-list update itself is recoverable.
+            wal.append(WalEntryType::PageFree, page_id.0, &[])?;
+            wal.sync()?;
+
+            pm.free_page(page_id)?;
+            wal.unlock()?;
+        }
+
+        // A stale cached copy must never be served or flushed back.
+        self.buffer_pool.invalidate(page_id);
+
+        info!(page_id = page_id.0, "deleted memory node");
+        Ok(())
     }
 
     /// Load and deserialize a [`MemoryNode`] from the given page.
@@ -385,6 +483,13 @@ impl StorageEngine {
     pub fn load_memory(&self, page_id: PageId) -> MenteResult<MemoryNode> {
         let page = self.read_page(page_id)?;
         self.buffer_pool.unpin_page(page_id, false).ok();
+
+        if PageType::from(page.header.page_type) != PageType::Data {
+            return Err(MenteError::Storage(format!(
+                "page {} is not a data page",
+                page_id.0
+            )));
+        }
 
         let len = u32::from_le_bytes(page.data[..4].try_into().unwrap()) as usize;
         if len == 0 || len + 4 > PAGE_DATA_SIZE {
@@ -644,6 +749,141 @@ mod tests {
                 let loaded = engine.load_memory(*pid).unwrap();
                 assert_eq!(&loaded.content, expected);
             }
+        }
+    }
+
+    #[test]
+    fn test_delete_memory_durable() {
+        let dir = tempfile::tempdir().unwrap();
+        let pid;
+        {
+            let engine = StorageEngine::open(dir.path()).unwrap();
+            let node = MemoryNode::new(
+                AgentId::new(),
+                MemoryType::Semantic,
+                "to be deleted".to_string(),
+                vec![1.0],
+            );
+            pid = engine.store_memory(&node).unwrap();
+            engine.delete_memory(pid).unwrap();
+            assert!(engine.load_memory(pid).is_err());
+            assert!(engine.scan_all_memories().is_empty());
+            engine.close().unwrap();
+        }
+        {
+            let engine = StorageEngine::open(dir.path()).unwrap();
+            assert!(
+                engine.load_memory(pid).is_err(),
+                "deleted memory must not resurrect on reopen"
+            );
+            assert!(engine.scan_all_memories().is_empty());
+        }
+    }
+
+    #[test]
+    fn test_delete_survives_crash() {
+        let dir = tempfile::tempdir().unwrap();
+        let pid;
+        {
+            let engine = StorageEngine::open(dir.path()).unwrap();
+            let node = MemoryNode::new(
+                AgentId::new(),
+                MemoryType::Semantic,
+                "crash delete".to_string(),
+                vec![1.0],
+            );
+            pid = engine.store_memory(&node).unwrap();
+            engine.delete_memory(pid).unwrap();
+            // Simulate crash: no close, no checkpoint.
+        }
+        {
+            let engine = StorageEngine::open(dir.path()).unwrap();
+            assert!(
+                engine.load_memory(pid).is_err(),
+                "deletion must survive a crash via WAL replay"
+            );
+            assert!(engine.scan_all_memories().is_empty());
+        }
+    }
+
+    #[test]
+    fn test_deleted_page_reused() {
+        let (_dir, engine) = setup();
+
+        let a = MemoryNode::new(AgentId::new(), MemoryType::Semantic, "a".into(), vec![1.0]);
+        let pid_a = engine.store_memory(&a).unwrap();
+        engine.delete_memory(pid_a).unwrap();
+
+        let b = MemoryNode::new(AgentId::new(), MemoryType::Semantic, "b".into(), vec![2.0]);
+        let pid_b = engine.store_memory(&b).unwrap();
+        assert_eq!(pid_a, pid_b, "freed page should be reused");
+
+        let loaded = engine.load_memory(pid_b).unwrap();
+        assert_eq!(loaded.content, "b");
+    }
+
+    #[test]
+    fn test_delete_reuse_crash_recovery() {
+        let dir = tempfile::tempdir().unwrap();
+        let pid;
+        let b_id;
+        {
+            let engine = StorageEngine::open(dir.path()).unwrap();
+            let a = MemoryNode::new(AgentId::new(), MemoryType::Semantic, "a".into(), vec![1.0]);
+            pid = engine.store_memory(&a).unwrap();
+            engine.delete_memory(pid).unwrap();
+            let b = MemoryNode::new(AgentId::new(), MemoryType::Semantic, "b".into(), vec![2.0]);
+            let pid_b = engine.store_memory(&b).unwrap();
+            assert_eq!(pid, pid_b);
+            b_id = b.id;
+            // Simulate crash: the WAL now holds PageFree(p) then PageWrite(p).
+        }
+        {
+            let engine = StorageEngine::open(dir.path()).unwrap();
+            let loaded = engine.load_memory(pid).unwrap();
+            assert_eq!(loaded.content, "b", "later write must win over the free");
+            assert_eq!(loaded.id, b_id);
+            // The page must NOT be on the free list: a fresh allocation must
+            // not clobber b.
+            let c = MemoryNode::new(AgentId::new(), MemoryType::Semantic, "c".into(), vec![3.0]);
+            let pid_c = engine.store_memory(&c).unwrap();
+            assert_ne!(pid_c, pid, "recovered free list must exclude reused page");
+            assert_eq!(engine.load_memory(pid).unwrap().content, "b");
+        }
+    }
+
+    #[test]
+    fn test_update_memory_in_place() {
+        let dir = tempfile::tempdir().unwrap();
+        let pid;
+        let id;
+        {
+            let engine = StorageEngine::open(dir.path()).unwrap();
+            let mut node = MemoryNode::new(
+                AgentId::new(),
+                MemoryType::Semantic,
+                "original".to_string(),
+                vec![1.0],
+            );
+            pid = engine.store_memory(&node).unwrap();
+            id = node.id;
+
+            node.content = "updated".to_string();
+            engine.update_memory(pid, &node).unwrap();
+
+            let loaded = engine.load_memory(pid).unwrap();
+            assert_eq!(loaded.content, "updated");
+            // No orphan copy: exactly one entry in a full scan.
+            let scanned = engine.scan_all_memories();
+            assert_eq!(scanned.len(), 1);
+            engine.close().unwrap();
+        }
+        {
+            let engine = StorageEngine::open(dir.path()).unwrap();
+            let loaded = engine.load_memory(pid).unwrap();
+            assert_eq!(loaded.content, "updated");
+            assert_eq!(loaded.id, id);
+            assert_eq!(engine.scan_all_memories().len(), 1);
         }
     }
 

--- a/crates/mentedb-storage/src/lib.rs
+++ b/crates/mentedb-storage/src/lib.rs
@@ -43,7 +43,7 @@ pub mod backup;
 pub mod buffer;
 /// Unified storage facade for memory persistence.
 pub mod engine;
-/// File backed 16KB page manager with free list allocation.
+/// File backed 64KB page manager with free list allocation.
 pub mod page;
 /// Append only write ahead log with CRC checks and LZ4 compression.
 pub mod wal;

--- a/crates/mentedb-storage/src/page.rs
+++ b/crates/mentedb-storage/src/page.rs
@@ -324,6 +324,34 @@ impl PageManager {
         Ok(())
     }
 
+    /// Rebuild the free list by scanning page types.
+    ///
+    /// Used after WAL recovery: header updates are not fsynced per write, so
+    /// the persisted free list can disagree with WAL-replayed page states.
+    /// Page types are WAL-authoritative; the chain is derived from them.
+    pub fn rebuild_free_list(&mut self) -> MenteResult<()> {
+        let mut head = 0u64;
+        let mut freed = 0usize;
+        for i in (1..self.page_count).rev() {
+            let page = self.read_page(PageId(i))?;
+            if PageType::from(page.header.page_type) == PageType::Free {
+                let mut fresh = Page::zeroed();
+                fresh.header.page_id = i;
+                fresh.header.page_type = PageType::Free as u8;
+                fresh.data[..8].copy_from_slice(&head.to_le_bytes());
+                self.write_page_raw(PageId(i), &fresh)?;
+                head = i;
+                freed += 1;
+            }
+        }
+        self.free_list_head = head;
+        self.write_file_header()?;
+        if freed > 0 {
+            debug!(freed, head, "rebuilt free list from page types");
+        }
+        Ok(())
+    }
+
     /// Total number of pages (including the header page).
     pub fn page_count(&self) -> u64 {
         self.page_count

--- a/crates/mentedb-storage/src/page.rs
+++ b/crates/mentedb-storage/src/page.rs
@@ -1,6 +1,6 @@
 //! Page Manager: file-backed page storage with free list management.
 //!
-//! Pages are 16KB fixed-size blocks used as the fundamental I/O unit.
+//! Pages are 64KB fixed-size blocks used as the fundamental I/O unit.
 //! The page file layout:
 //! - Page 0: file header (magic, version, page count, free list head)
 //! - Page 1..N: data pages

--- a/crates/mentedb-storage/src/wal.rs
+++ b/crates/mentedb-storage/src/wal.rs
@@ -27,6 +27,8 @@ pub enum WalEntryType {
     /// Reserved for future transaction support. Not currently emitted.
     Commit = 2,
     Checkpoint = 3,
+    /// The page was returned to the free list (memory deleted).
+    PageFree = 4,
 }
 
 impl TryFrom<u8> for WalEntryType {
@@ -36,6 +38,7 @@ impl TryFrom<u8> for WalEntryType {
             1 => Ok(Self::PageWrite),
             2 => Ok(Self::Commit),
             3 => Ok(Self::Checkpoint),
+            4 => Ok(Self::PageFree),
             _ => Err(MenteError::Storage(format!("invalid WAL entry type: {v}"))),
         }
     }

--- a/crates/mentedb/src/lib.rs
+++ b/crates/mentedb/src/lib.rs
@@ -343,12 +343,9 @@ impl MenteDb {
             IndexManager::default()
         };
 
-        let graph = if graph_dir.join("graph.json").exists() {
-            debug!("Loading graph from {}", graph_dir.display());
-            GraphManager::load(&graph_dir)?
-        } else {
-            GraphManager::new()
-        };
+        // Directory-backed graph: loads the snapshot and replays the edge log,
+        // so edges created since the last flush survive a crash.
+        let graph = GraphManager::open(&graph_dir)?;
 
         // Rebuild page map by scanning all pages
         let entries = storage.scan_all_memories();
@@ -358,6 +355,15 @@ impl MenteDb {
         }
         if !page_map.is_empty() {
             info!(memories = page_map.len(), "rebuilt page map from storage");
+        }
+
+        // Every stored memory must be a graph node, even when the graph
+        // snapshot/log is missing or behind storage (e.g. after a crash);
+        // otherwise relate() and write inference fail for surviving memories.
+        for memory_id in page_map.keys() {
+            if !graph.read_graph().contains_node(*memory_id) {
+                graph.add_memory(*memory_id);
+            }
         }
 
         let write_inference =

--- a/crates/mentedb/src/lib.rs
+++ b/crates/mentedb/src/lib.rs
@@ -751,8 +751,7 @@ impl MenteDb {
             .ok_or(MenteError::MemoryNotFound(id))?;
         let mut node = self.storage.load_memory(page_id)?;
         node.invalidate(at);
-        let new_page_id = self.storage.store_memory(&node)?;
-        self.page_map.write().insert(id, new_page_id);
+        self.storage.update_memory(page_id, &node)?;
         Ok(())
     }
 
@@ -788,10 +787,13 @@ impl MenteDb {
     pub fn forget(&self, id: MemoryId) -> MenteResult<()> {
         debug!("Forgetting memory {}", id);
 
-        if let Some(&page_id) = self.page_map.read().get(&id)
-            && let Ok(node) = self.storage.load_memory(page_id)
-        {
-            self.index.remove_memory(id, &node);
+        if let Some(&page_id) = self.page_map.read().get(&id) {
+            if let Ok(node) = self.storage.load_memory(page_id) {
+                self.index.remove_memory(id, &node);
+            }
+            // Durable delete: WAL-logged page free, so the memory does not
+            // resurrect when the page map is rebuilt on reopen.
+            self.storage.delete_memory(page_id)?;
         }
 
         self.graph.remove_memory(id);
@@ -989,8 +991,9 @@ impl MenteDb {
                 debug!("Updating confidence for {} to {}", memory, new_confidence);
                 if let Ok(mut node) = self.get_memory(memory) {
                     node.confidence = new_confidence;
-                    let new_page_id = self.storage.store_memory(&node)?;
-                    self.page_map.write().insert(memory, new_page_id);
+                    if let Some(&pid) = self.page_map.read().get(&memory) {
+                        self.storage.update_memory(pid, &node)?;
+                    }
                 }
             }
             InferredAction::PropagateBeliefChange { root, delta } => {
@@ -1001,8 +1004,10 @@ impl MenteDb {
                     for (affected_id, new_conf) in affected {
                         if let Ok(mut affected_node) = self.get_memory(affected_id) {
                             affected_node.confidence = new_conf;
-                            if let Ok(pid) = self.storage.store_memory(&affected_node) {
-                                self.page_map.write().insert(affected_id, pid);
+                            if let Some(&pid) = self.page_map.read().get(&affected_id)
+                                && let Err(e) = self.storage.update_memory(pid, &affected_node)
+                            {
+                                warn!("Failed to persist belief update for {affected_id}: {e}");
                             }
                         }
                     }
@@ -1016,8 +1021,9 @@ impl MenteDb {
                 debug!("Updating content of {}: {}", memory, reason);
                 if let Ok(mut node) = self.get_memory(memory) {
                     node.content = new_content;
-                    let new_page_id = self.storage.store_memory(&node)?;
-                    self.page_map.write().insert(memory, new_page_id);
+                    if let Some(&pid) = self.page_map.read().get(&memory) {
+                        self.storage.update_memory(pid, &node)?;
+                    }
                     self.index.remove_memory(memory, &node);
                     self.index.index_memory(&node);
                 }
@@ -1066,15 +1072,10 @@ impl MenteDb {
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
             .as_micros() as u64;
-        let ids: Vec<(MemoryId, PageId)> = self
-            .page_map
-            .read()
-            .iter()
-            .map(|(mid, pid)| (*mid, *pid))
-            .collect();
+        let page_ids: Vec<PageId> = self.page_map.read().values().copied().collect();
 
         let mut updated = 0;
-        for (mid, pid) in &ids {
+        for pid in &page_ids {
             if let Ok(mut node) = self.storage.load_memory(*pid) {
                 let new_salience = self.decay.compute_decay(
                     node.salience,
@@ -1085,8 +1086,7 @@ impl MenteDb {
                 );
                 if (new_salience - node.salience).abs() > 0.001 {
                     node.salience = new_salience;
-                    let new_pid = self.storage.store_memory(&node)?;
-                    self.page_map.write().insert(*mid, new_pid);
+                    self.storage.update_memory(*pid, &node)?;
                     updated += 1;
                 }
             }
@@ -2215,7 +2215,7 @@ impl MenteDb {
                         .embed(summary)
                         .unwrap_or_else(|_| updated.embedding.clone());
                 }
-                self.storage.store_memory(&updated)?;
+                self.storage.update_memory(*pid, &updated)?;
                 existing_id = Some(updated.id);
                 break;
             }
@@ -2336,7 +2336,7 @@ impl MenteDb {
                         .embed(profile)
                         .unwrap_or_else(|_| updated.embedding.clone());
                 }
-                self.storage.store_memory(&updated)?;
+                self.storage.update_memory(*pid, &updated)?;
                 return Ok(updated.id);
             }
         }

--- a/crates/mentedb/src/lib.rs
+++ b/crates/mentedb/src/lib.rs
@@ -535,6 +535,14 @@ impl MenteDb {
         }
         drop(page_map);
 
+        // Batch inserts get the same auto-linking, contradiction detection,
+        // and invalidation as single stores.
+        if self.cognitive_config.write_inference {
+            for node in &nodes {
+                self.run_write_inference(node);
+            }
+        }
+
         Ok(ids)
     }
 

--- a/crates/mentedb/src/process_turn.rs
+++ b/crates/mentedb/src/process_turn.rs
@@ -483,7 +483,9 @@ impl MenteDb {
                         valid_until: None,
                         label: None,
                     };
-                    let _ = self.relate(edge);
+                    if let Err(e) = self.relate(edge) {
+                        tracing::warn!("failed to create inferred edge: {e}");
+                    }
                     applied += 1;
                 }
                 crate::InferredAction::MarkObsolete {
@@ -500,7 +502,9 @@ impl MenteDb {
                         valid_until: None,
                         label: None,
                     };
-                    let _ = self.relate(edge);
+                    if let Err(e) = self.relate(edge) {
+                        tracing::warn!("failed to create inferred edge: {e}");
+                    }
                     applied += 1;
                 }
                 crate::InferredAction::CreateEdge {
@@ -519,7 +523,9 @@ impl MenteDb {
                         valid_until: None,
                         label: None,
                     };
-                    let _ = self.relate(edge);
+                    if let Err(e) = self.relate(edge) {
+                        tracing::warn!("failed to create inferred edge: {e}");
+                    }
                     applied += 1;
                 }
                 crate::InferredAction::UpdateConfidence {
@@ -599,7 +605,9 @@ impl MenteDb {
                         valid_until: None,
                         label: None,
                     };
-                    let _ = self.relate(edge);
+                    if let Err(e) = self.relate(edge) {
+                        tracing::warn!("failed to create inferred edge: {e}");
+                    }
                     edges_created += 1;
                 }
             }

--- a/crates/mentedb/src/process_turn.rs
+++ b/crates/mentedb/src/process_turn.rs
@@ -227,9 +227,7 @@ impl MenteDb {
         );
 
         // §1: Embed query
-        let query_embedding = self
-            .embed_text(&input.user_message)?
-            .unwrap_or_else(|| vec![0.0; 384]);
+        let query_embedding = self.embed_or_empty(&input.user_message)?;
 
         // §1b: Try speculative cache, fall back to hybrid search
         let (context, current_ids, cache_hit) =
@@ -423,15 +421,36 @@ impl MenteDb {
             .collect()
     }
 
+    /// Embed text, or return an empty embedding when no provider is configured.
+    ///
+    /// An empty embedding degrades honestly: store() skips the vector index,
+    /// write inference skips similarity checks, and retrieval falls back to
+    /// keyword (BM25) matching. A zero vector would instead pollute the HNSW
+    /// index and silently make every cosine similarity zero.
+    fn embed_or_empty(&self, text: &str) -> crate::MenteResult<Vec<f32>> {
+        match self.embed_text(text)? {
+            Some(embedding) => Ok(embedding),
+            None => {
+                static NO_EMBEDDER_WARN: std::sync::Once = std::sync::Once::new();
+                NO_EMBEDDER_WARN.call_once(|| {
+                    warn!(
+                        "no embedding provider configured: semantic search, auto-linking, and \
+                         contradiction detection are DISABLED; retrieval falls back to keyword \
+                         (BM25) matching only. Configure a provider via open_with_embedder()."
+                    );
+                });
+                Ok(Vec::new())
+            }
+        }
+    }
+
     fn store_episodic(
         &self,
         conversation: &str,
         agent_id: AgentId,
         project_context: &Option<String>,
     ) -> crate::MenteResult<(Vec<MemoryId>, Option<MemoryId>)> {
-        let embedding = self
-            .embed_text(conversation)?
-            .unwrap_or_else(|| vec![0.0; 384]);
+        let embedding = self.embed_or_empty(conversation)?;
         let mut node = MemoryNode::new(
             agent_id,
             MemoryType::Episodic,
@@ -656,9 +675,7 @@ impl MenteDb {
         }
 
         let correction_content = format!("Correction: {}", user_message);
-        let embedding = self
-            .embed_text(&correction_content)?
-            .unwrap_or_else(|| vec![0.0; 384]);
+        let embedding = self.embed_or_empty(&correction_content)?;
         let mut node = MemoryNode::new(
             agent_id,
             MemoryType::Semantic,
@@ -737,9 +754,7 @@ impl MenteDb {
             input.user_message.clone()
         };
 
-        let topic_embedding = self
-            .embed_text(&raw_topic)?
-            .unwrap_or_else(|| vec![0.0; 384]);
+        let topic_embedding = self.embed_or_empty(&raw_topic)?;
 
         let node = TrajectoryNode {
             turn_id: input.turn_id,

--- a/crates/mentedb/tests/integration.rs
+++ b/crates/mentedb/tests/integration.rs
@@ -138,6 +138,114 @@ fn test_invalidation_updates_in_place_across_reopen() {
 }
 
 #[test]
+fn test_edges_survive_crash() {
+    let dir = tempfile::tempdir().unwrap();
+    let m1 = make_memory("cause", vec![1.0, 0.0, 0.0, 0.0]);
+    let m2 = make_memory("effect", vec![0.0, 1.0, 0.0, 0.0]);
+    let (id1, id2) = (m1.id, m2.id);
+
+    {
+        let db = MenteDb::open(dir.path()).unwrap();
+        db.store(m1).unwrap();
+        db.store(m2).unwrap();
+        db.relate(MemoryEdge {
+            source: id1,
+            target: id2,
+            edge_type: EdgeType::Caused,
+            weight: 0.9,
+            created_at: 0,
+            valid_from: None,
+            valid_until: None,
+            label: Some("crash-edge".into()),
+        })
+        .unwrap();
+        // Simulate crash: no close, no flush — the graph snapshot was never
+        // written, so the edge only exists in the edge log.
+        std::mem::forget(db);
+    }
+    {
+        let db = MenteDb::open(dir.path()).unwrap();
+        let g = db.graph().read_graph();
+        let out = g.outgoing(id1);
+        assert_eq!(out.len(), 1, "edge must survive a crash via the edge log");
+        assert_eq!(out[0].0, id2);
+        assert_eq!(out[0].1.label.as_deref(), Some("crash-edge"));
+        drop(g);
+        db.close().unwrap();
+    }
+}
+
+#[test]
+fn test_relate_works_after_crash() {
+    let dir = tempfile::tempdir().unwrap();
+    let m1 = make_memory("first", vec![1.0, 0.0, 0.0, 0.0]);
+    let m2 = make_memory("second", vec![0.0, 1.0, 0.0, 0.0]);
+    let (id1, id2) = (m1.id, m2.id);
+
+    {
+        let db = MenteDb::open(dir.path()).unwrap();
+        db.store(m1).unwrap();
+        db.store(m2).unwrap();
+        // Crash before any flush: no graph snapshot exists on disk.
+        std::mem::forget(db);
+    }
+    {
+        // Graph nodes must be rebuilt from storage so surviving memories can
+        // still be linked.
+        let db = MenteDb::open(dir.path()).unwrap();
+        db.relate(MemoryEdge {
+            source: id1,
+            target: id2,
+            edge_type: EdgeType::Supports,
+            weight: 0.5,
+            created_at: 0,
+            valid_from: None,
+            valid_until: None,
+            label: None,
+        })
+        .expect("relate must work on memories that survived a crash");
+        db.close().unwrap();
+    }
+}
+
+#[test]
+fn test_forgotten_memory_edges_do_not_resurrect() {
+    let dir = tempfile::tempdir().unwrap();
+    let m1 = make_memory("keep", vec![1.0, 0.0, 0.0, 0.0]);
+    let m2 = make_memory("forget", vec![0.0, 1.0, 0.0, 0.0]);
+    let (id1, id2) = (m1.id, m2.id);
+
+    {
+        let db = MenteDb::open(dir.path()).unwrap();
+        db.store(m1).unwrap();
+        db.store(m2).unwrap();
+        db.relate(MemoryEdge {
+            source: id1,
+            target: id2,
+            edge_type: EdgeType::Related,
+            weight: 0.5,
+            created_at: 0,
+            valid_from: None,
+            valid_until: None,
+            label: None,
+        })
+        .unwrap();
+        db.forget(id2).unwrap();
+        std::mem::forget(db); // crash: RemoveNode only in the edge log
+    }
+    {
+        let db = MenteDb::open(dir.path()).unwrap();
+        let g = db.graph().read_graph();
+        assert!(
+            g.outgoing(id1).is_empty(),
+            "edges to a forgotten memory must not survive the crash"
+        );
+        drop(g);
+        db.close().unwrap();
+    }
+}
+
+#[test]
 fn test_relate_memories() {
     let dir = tempfile::tempdir().unwrap();
     let db = MenteDb::open(dir.path()).unwrap();

--- a/crates/mentedb/tests/integration.rs
+++ b/crates/mentedb/tests/integration.rs
@@ -63,6 +63,81 @@ fn test_forget_memory() {
 }
 
 #[test]
+fn test_forget_survives_reopen() {
+    let dir = tempfile::tempdir().unwrap();
+    let kept = make_memory("keep me", vec![1.0, 0.0, 0.0, 0.0]);
+    let forgotten = make_memory("forget me", vec![0.0, 1.0, 0.0, 0.0]);
+    let (kept_id, forgotten_id) = (kept.id, forgotten.id);
+
+    {
+        let db = MenteDb::open(dir.path()).unwrap();
+        db.store(kept).unwrap();
+        db.store(forgotten).unwrap();
+        db.forget(forgotten_id).unwrap();
+        db.close().unwrap();
+    }
+    {
+        let db = MenteDb::open(dir.path()).unwrap();
+        assert_eq!(db.memory_count(), 1, "forgotten memory must not resurrect");
+        assert!(db.get_memory(kept_id).is_ok());
+        assert!(
+            db.get_memory(forgotten_id).is_err(),
+            "forgotten memory must stay forgotten after reopen"
+        );
+        db.close().unwrap();
+    }
+}
+
+#[test]
+fn test_forget_survives_crash() {
+    let dir = tempfile::tempdir().unwrap();
+    let node = make_memory("forget me before crash", vec![0.0, 1.0, 0.0, 0.0]);
+    let id = node.id;
+
+    {
+        let db = MenteDb::open(dir.path()).unwrap();
+        db.store(node).unwrap();
+        db.forget(id).unwrap();
+        // Simulate crash: no close, no flush.
+        std::mem::forget(db);
+    }
+    {
+        let db = MenteDb::open(dir.path()).unwrap();
+        assert!(
+            db.get_memory(id).is_err(),
+            "forget must be WAL-durable across a crash"
+        );
+        assert_eq!(db.memory_count(), 0);
+        db.close().unwrap();
+    }
+}
+
+#[test]
+fn test_invalidation_updates_in_place_across_reopen() {
+    let dir = tempfile::tempdir().unwrap();
+    let node = make_memory("versioned fact", vec![1.0, 0.0, 0.0, 0.0]);
+    let id = node.id;
+
+    {
+        let db = MenteDb::open(dir.path()).unwrap();
+        db.store(node).unwrap();
+        db.invalidate_memory(id, 12345).unwrap();
+        db.close().unwrap();
+    }
+    {
+        let db = MenteDb::open(dir.path()).unwrap();
+        assert_eq!(
+            db.memory_count(),
+            1,
+            "in-place update must not orphan a duplicate copy"
+        );
+        let loaded = db.get_memory(id).unwrap();
+        assert_eq!(loaded.valid_until, Some(12345));
+        db.close().unwrap();
+    }
+}
+
+#[test]
 fn test_relate_memories() {
     let dir = tempfile::tempdir().unwrap();
     let db = MenteDb::open(dir.path()).unwrap();

--- a/crates/mentedb/tests/integration.rs
+++ b/crates/mentedb/tests/integration.rs
@@ -485,13 +485,15 @@ fn test_write_inference_invalidates_superseded_memory() {
     let m1_id = m1.id;
     db.store(m1).unwrap();
 
-    // Very similar embedding (sim > 0.85) = should mark m1 as obsolete.
+    // Similarity in the supersede band (0.85 < sim <= 0.95) marks m1 obsolete.
+    // Above 0.95 the engine flags a contradiction instead of invalidating.
     let m2 = MemoryNode::new(
         agent,
         MemoryType::Semantic,
         "Project version is 3.0".to_string(),
-        vec![0.99, 0.05, 0.0, 0.0],
+        vec![0.90, 0.43589, 0.0, 0.0],
     );
+    let m2_id = m2.id;
     db.store(m2).unwrap();
 
     // m1 should now have valid_until set (invalidated).
@@ -500,6 +502,104 @@ fn test_write_inference_invalidates_superseded_memory() {
         m1_after.valid_until.is_some(),
         "Superseded memory should have valid_until set, got None"
     );
+
+    // Exactly one Supersedes edge, not parallel duplicates.
+    let g = db.graph().read_graph();
+    let supersedes: Vec<_> = g
+        .outgoing(m2_id)
+        .into_iter()
+        .filter(|(t, e)| *t == m1_id && e.edge_type == EdgeType::Supersedes)
+        .collect();
+    assert_eq!(
+        supersedes.len(),
+        1,
+        "supersede must create exactly one edge, got {}",
+        supersedes.len()
+    );
+    drop(g);
+
+    db.close().unwrap();
+}
+
+#[test]
+fn test_contradiction_does_not_invalidate() {
+    // Above 0.95 similarity with different content: flag the contradiction,
+    // keep both memories valid for review.
+    let dir = tempfile::tempdir().unwrap();
+    let db = MenteDb::open(dir.path()).unwrap();
+    let agent = AgentId::new();
+
+    let m1 = MemoryNode::new(
+        agent,
+        MemoryType::Semantic,
+        "User loves PostgreSQL".to_string(),
+        vec![1.0, 0.0, 0.0, 0.0],
+    );
+    let m1_id = m1.id;
+    db.store(m1).unwrap();
+
+    let m2 = MemoryNode::new(
+        agent,
+        MemoryType::Semantic,
+        "User hates PostgreSQL".to_string(),
+        vec![0.99, 0.14106736, 0.0, 0.0],
+    );
+    let m2_id = m2.id;
+    db.store(m2).unwrap();
+
+    let m1_after = db.get_memory(m1_id).unwrap();
+    assert!(
+        m1_after.valid_until.is_none(),
+        "a flagged contradiction must not silently invalidate the old memory"
+    );
+
+    let g = db.graph().read_graph();
+    let edges = g.outgoing(m2_id);
+    assert_eq!(edges.len(), 1, "exactly one edge expected, got {edges:?}");
+    assert_eq!(edges[0].1.edge_type, EdgeType::Contradicts);
+    drop(g);
+
+    db.close().unwrap();
+}
+
+#[test]
+fn test_store_batch_runs_write_inference() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = MenteDb::open(dir.path()).unwrap();
+    let agent = AgentId::new();
+
+    let m1 = MemoryNode::new(
+        agent,
+        MemoryType::Semantic,
+        "User works at Acme".to_string(),
+        vec![1.0, 0.0, 0.0, 0.0],
+    );
+    let m1_id = m1.id;
+    db.store(m1).unwrap();
+
+    // Batch-stored memory in the supersede band must invalidate + link like store().
+    let m2 = MemoryNode::new(
+        agent,
+        MemoryType::Semantic,
+        "User works at Globex now".to_string(),
+        vec![0.90, 0.43589, 0.0, 0.0],
+    );
+    let m2_id = m2.id;
+    db.store_batch(vec![m2]).unwrap();
+
+    let m1_after = db.get_memory(m1_id).unwrap();
+    assert!(
+        m1_after.valid_until.is_some(),
+        "store_batch must run write inference (supersede old memory)"
+    );
+    let g = db.graph().read_graph();
+    assert!(
+        g.outgoing(m2_id)
+            .iter()
+            .any(|(t, e)| *t == m1_id && e.edge_type == EdgeType::Supersedes),
+        "store_batch must create the Supersedes edge"
+    );
+    drop(g);
 
     db.close().unwrap();
 }


### PR DESCRIPTION
## Summary

Fixes the top findings from the 2026-07-03 deep-dive audit of the memory save/link path. All changes are root-cause fixes verified with new regression tests plus a live store/link/crash/reopen harness.

### Durability
- **`forget()` is now durable.** New `PageFree` WAL entry + `StorageEngine::delete_memory()`: the page is freed under the WAL flock, recovery replays deletions with last-op-wins semantics, and the free list is rebuilt from WAL-authoritative page types. Previously forgotten memories resurrected on reopen (the storage layer had no delete at all).
- **Graph edges survive crashes.** `GraphManager::open()` maintains an append-only `edges.jsonl` log (fsynced per record, truncated on snapshot save) and replays it on open. Previously all edges since the last `flush()`/`close()` were lost on crash while memories survived via the WAL.
- **Graph nodes are rebuilt from storage on open**, so `relate()` and write inference work on memories that survived a crash. Previously one crash permanently broke linking for all pre-existing memories (`MemoryNotFound`, silently swallowed).
- Graph snapshots are written atomically (temp + fsync + rename); in-place `update_memory()` replaces the store-new-page-and-orphan pattern in `invalidate_memory`, confidence/content updates, decay, and enrichment updates (a global decay pass used to orphan a duplicate page per memory).
- Buffer pool gained `invalidate()` so freed/reused pages can never serve stale cached data.

### Linking correctness
- **Write-inference similarity bands are mutually exclusive**: >0.95 flags a `Contradicts` edge for review (no more silent invalidation), 0.85-0.95 supersedes + invalidates, 0.6-0.85 relates. Previously a supersede emitted two identical edges and a contradiction additionally invalidated + double-edged.
- Single `InvalidateMemory` action per supersede across heuristic and LLM paths (was up to 3 overlapping actions per pair in the LLM path).
- `CsrGraph::add_edge` deduplicates identical valid edges; `strengthen_edge` updates in place instead of appending parallel duplicates.
- **`store_batch()` now runs write inference** like `store()`.

### Embedder defaults
- The server now wires an embedding provider (`--embedding-provider` / `MENTEDB_EMBEDDING_PROVIDER`; new `local-embeddings` feature bundles Candle, enabled in the Docker image) and warns loudly when running with hash/none. Previously the server ran with no embedder at all, silently disabling semantic search and all auto-linking.
- `process_turn` uses empty embeddings instead of zero vectors when no provider is configured: no more HNSW pollution, honest BM25-only fallback, one-time warning.

### Docs
- Entity-memory section now describes the real linking mechanism (`Derived` + labeled `Related` edges via enrichment; `PartOf` edges were never implemented) and retrieval story (hybrid search + explicit `TRAVERSE`), page size corrected to 64KB everywhere, write-inference table updated, embedding requirements documented, unimplemented `vscode` setup target removed.

## Test plan
- `cargo test --workspace`: 569 passed (17 new regression tests covering durable forget, crash-safe deletes, page reuse after crash, in-place updates, edge-log replay, post-crash relinking, exclusive bands, batch inference)
- `cargo clippy --workspace -- -D warnings` and `cargo fmt` clean
- Live harness: store/link at all three similarity bands, forget + reopen, kill-without-close + reopen, all verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)