### PR TITLE
feat: engine-native injection attention with outcome learning

### DIFF
--- a/crates/mentedb/src/injection.rs
+++ b/crates/mentedb/src/injection.rs
@@ -1,0 +1,368 @@
+//! Engine-native injection attention: retrieval shaped for context
+//! injection rather than raw search.
+//!
+//! Plain top-k recall is the wrong contract for injecting memories into a
+//! model's context: the most similar memories to a conversation are echoes
+//! of that conversation, top-k always returns k items however weak the
+//! tail, and near-duplicates (a distilled fact and the turn it came from)
+//! co-rank. This module owns the selection policy that client hooks
+//! previously approximated with heuristics:
+//!
+//! - Session provenance: memories originating from the querying session are
+//!   never returned, they are in that context by construction.
+//! - A working-memory ledger (`exclude_ids`) supplied by the client, holding
+//!   what was already delivered within the current context lifetime.
+//! - A relevance knee instead of a fixed floor: the candidate list is cut at
+//!   the largest score gap, so weak tails vanish without a magic constant.
+//! - Maximal Marginal Relevance over embeddings, so each selected item adds
+//!   information the previous ones did not.
+//! - Type quotas: distilled knowledge first, verbatim episodic capped,
+//!   action notes never (they exist for distillation and session resume).
+//! - User-pinned `scope:always` memories bypass every quality gate.
+//! - Outcome learning: `record_injection_outcome` tracks shown vs used per
+//!   memory; chronically ignored memories are demoted at selection time and
+//!   used ones are reinforced.
+
+use std::collections::HashSet;
+
+use mentedb_core::error::MenteResult;
+use mentedb_core::memory::{AttributeValue, MemoryNode, MemoryType};
+use mentedb_core::types::MemoryId;
+
+use crate::MenteDb;
+
+/// Attribute key: how many times this memory was injected into a context.
+pub const ATTR_INJECTION_SHOWN: &str = "injection_shown";
+/// Attribute key: how many times an injected memory was drawn on by the
+/// reply that followed.
+pub const ATTR_INJECTION_USED: &str = "injection_used";
+
+/// Tunables for injection attention selection.
+#[derive(Debug, Clone)]
+pub struct InjectionConfig {
+    /// Retrieval pool fanned out before selection.
+    pub candidate_pool: usize,
+    /// MMR relevance weight; the remainder weighs redundancy.
+    pub mmr_lambda: f32,
+    /// Consecutive score ratio treated as the relevance knee.
+    pub knee_gap_ratio: f32,
+    /// Shown at least this often with zero uses = demoted at selection.
+    pub demotion_shown_min: i64,
+    /// Score multiplier applied to chronically ignored memories.
+    pub demotion_factor: f32,
+    /// Reply similarity above which a shown memory counts as used.
+    pub used_similarity: f32,
+    /// Salience reinforcement applied when a memory is actually used.
+    pub use_reinforcement: f32,
+}
+
+impl Default for InjectionConfig {
+    fn default() -> Self {
+        Self {
+            candidate_pool: 48,
+            mmr_lambda: 0.7,
+            knee_gap_ratio: 2.0,
+            demotion_shown_min: 5,
+            demotion_factor: 0.5,
+            used_similarity: 0.6,
+            use_reinforcement: 0.05,
+        }
+    }
+}
+
+/// A request for injection-ready context.
+pub struct InjectionQuery<'a> {
+    /// Embedding of the prompt (plus any conversational blend).
+    pub embedding: &'a [f32],
+    /// Raw query text for the lexical half of hybrid recall.
+    pub query_text: Option<&'a str>,
+    /// The session issuing the query. Memories tagged `session:<id>` with
+    /// this ID are excluded: they are already in that session's context.
+    pub session_id: Option<&'a str>,
+    /// Memory IDs already delivered within the current context lifetime.
+    pub exclude_ids: &'a [MemoryId],
+    /// Maximum items returned beyond pinned memories.
+    pub max_items: usize,
+    /// Maximum verbatim episodic items within `max_items`.
+    pub max_episodic: usize,
+}
+
+/// Why an item was selected, for introspection and client display.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SelectionReason {
+    /// User-pinned scope:always memory: bypasses every quality gate.
+    Pinned,
+    /// Survived the relevance knee, MMR, and quotas.
+    Relevant,
+}
+
+/// One injection-ready memory with its selection metadata.
+pub struct InjectionCandidate {
+    pub node: MemoryNode,
+    /// Retrieval score after demotion adjustment (0.0 for pinned items,
+    /// which are not score-ranked).
+    pub score: f32,
+    pub reason: SelectionReason,
+}
+
+fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
+    if a.len() != b.len() || a.is_empty() {
+        return 0.0;
+    }
+    let dot: f32 = a.iter().zip(b).map(|(x, y)| x * y).sum();
+    let na: f32 = a.iter().map(|x| x * x).sum::<f32>().sqrt();
+    let nb: f32 = b.iter().map(|x| x * x).sum::<f32>().sqrt();
+    if na == 0.0 || nb == 0.0 {
+        return 0.0;
+    }
+    dot / (na * nb)
+}
+
+fn attr_count(node: &MemoryNode, key: &str) -> i64 {
+    match node.attributes.get(key) {
+        Some(AttributeValue::Integer(n)) => *n,
+        _ => 0,
+    }
+}
+
+fn bump_attr(node: &mut MemoryNode, key: &str) {
+    let next = attr_count(node, key) + 1;
+    node.attributes
+        .insert(key.to_string(), AttributeValue::Integer(next));
+}
+
+fn has_tag(node: &MemoryNode, tag: &str) -> bool {
+    node.tags.iter().any(|t| t == tag)
+}
+
+fn now_us() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_micros() as u64
+}
+
+/// Cut a descending score list at its largest relative gap (the relevance
+/// knee), when that gap is decisive. Returns how many items to keep.
+fn knee_cutoff(scores: &[f32], gap_ratio: f32) -> usize {
+    if scores.len() <= 1 {
+        return scores.len();
+    }
+    let mut best_ratio = 0.0f32;
+    let mut cut = scores.len();
+    for i in 0..scores.len() - 1 {
+        let hi = scores[i];
+        let lo = scores[i + 1].max(f32::EPSILON);
+        let ratio = hi / lo;
+        if ratio > best_ratio {
+            best_ratio = ratio;
+            cut = i + 1;
+        }
+    }
+    if best_ratio >= gap_ratio {
+        cut
+    } else {
+        scores.len()
+    }
+}
+
+impl MenteDb {
+    /// Injection-ready context selection. See the module docs for the
+    /// policy; this is the API client hooks should prefer over raw recall.
+    pub fn recall_for_injection(
+        &self,
+        query: &InjectionQuery<'_>,
+    ) -> MenteResult<Vec<InjectionCandidate>> {
+        let cfg = self.cognitive_config.injection_config.clone();
+        let excluded: HashSet<MemoryId> = query.exclude_ids.iter().copied().collect();
+        let session_tag = query.session_id.map(|s| format!("session:{s}"));
+
+        // Candidate pool from hybrid recall.
+        let hits = self
+            .recall_hybrid_at(
+                query.embedding,
+                query.query_text,
+                cfg.candidate_pool,
+                now_us(),
+                None,
+                None,
+            )
+            .unwrap_or_default();
+
+        let mut scored: Vec<(MemoryNode, f32)> = Vec::new();
+        for (id, score) in hits {
+            if excluded.contains(&id) {
+                continue;
+            }
+            let Ok(node) = self.get_memory(id) else {
+                continue;
+            };
+            if has_tag(&node, "action") || has_tag(&node, "scope:always") {
+                // Actions never inject; pinned items are handled separately.
+                continue;
+            }
+            if let Some(ref st) = session_tag
+                && has_tag(&node, st)
+            {
+                continue;
+            }
+            // Chronically ignored memories fall back in the ranking until
+            // usage or decay resolves them.
+            let shown = attr_count(&node, ATTR_INJECTION_SHOWN);
+            let used = attr_count(&node, ATTR_INJECTION_USED);
+            let adjusted = if shown >= cfg.demotion_shown_min && used == 0 {
+                score * cfg.demotion_factor
+            } else {
+                score
+            };
+            scored.push((node, adjusted));
+        }
+
+        scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        let scores: Vec<f32> = scored.iter().map(|(_, s)| *s).collect();
+        scored.truncate(knee_cutoff(&scores, cfg.knee_gap_ratio));
+
+        // MMR selection with type quotas.
+        let top_score = scored
+            .first()
+            .map(|(_, s)| *s)
+            .unwrap_or(1.0)
+            .max(f32::EPSILON);
+        let mut remaining: Vec<(MemoryNode, f32)> = scored;
+        let mut selected: Vec<InjectionCandidate> = Vec::new();
+        let mut episodic_count = 0usize;
+
+        while selected.len() < query.max_items && !remaining.is_empty() {
+            let mut best_idx: Option<usize> = None;
+            let mut best_value = f32::NEG_INFINITY;
+            for (idx, (node, score)) in remaining.iter().enumerate() {
+                if node.memory_type == MemoryType::Episodic && episodic_count >= query.max_episodic
+                {
+                    continue;
+                }
+                let redundancy = selected
+                    .iter()
+                    .map(|s| cosine_similarity(&node.embedding, &s.node.embedding))
+                    .fold(0.0f32, f32::max);
+                let value =
+                    cfg.mmr_lambda * (score / top_score) - (1.0 - cfg.mmr_lambda) * redundancy;
+                if value > best_value {
+                    best_value = value;
+                    best_idx = Some(idx);
+                }
+            }
+            let Some(idx) = best_idx else {
+                break;
+            };
+            let (node, score) = remaining.remove(idx);
+            if node.memory_type == MemoryType::Episodic {
+                episodic_count += 1;
+            }
+            selected.push(InjectionCandidate {
+                node,
+                score,
+                reason: SelectionReason::Relevant,
+            });
+        }
+
+        // Pinned memories bypass every gate except the ledger, and lead the
+        // result. The client's ledger reset (at context loss) governs
+        // re-delivery.
+        let mut result: Vec<InjectionCandidate> = Vec::new();
+        let page_ids: Vec<_> = {
+            let pm = self.page_map.read();
+            pm.values().copied().collect()
+        };
+        for pid in page_ids {
+            if let Ok(node) = self.storage.load_memory(pid)
+                && has_tag(&node, "scope:always")
+                && !excluded.contains(&node.id)
+            {
+                result.push(InjectionCandidate {
+                    node,
+                    score: 0.0,
+                    reason: SelectionReason::Pinned,
+                });
+            }
+        }
+        result.extend(selected);
+        Ok(result)
+    }
+
+    /// Record the outcome of an injection: every shown memory's exposure
+    /// count rises, and memories the reply actually drew on (embedding
+    /// similarity against the reply) are counted as used and reinforced.
+    /// Returns (shown_updated, used_count).
+    pub fn record_injection_outcome(
+        &self,
+        shown: &[MemoryId],
+        reply_embedding: Option<&[f32]>,
+    ) -> MenteResult<(usize, usize)> {
+        let cfg = self.cognitive_config.injection_config.clone();
+        let mut updated = 0usize;
+        let mut used_total = 0usize;
+        let now = now_us();
+
+        for id in shown {
+            let pid = {
+                let pm = self.page_map.read();
+                match pm.get(id) {
+                    Some(p) => *p,
+                    None => continue,
+                }
+            };
+            let Ok(mut node) = self.storage.load_memory(pid) else {
+                continue;
+            };
+            bump_attr(&mut node, ATTR_INJECTION_SHOWN);
+
+            let used = reply_embedding
+                .map(|re| cosine_similarity(&node.embedding, re) >= cfg.used_similarity)
+                .unwrap_or(false);
+            if used {
+                bump_attr(&mut node, ATTR_INJECTION_USED);
+                node.access_count = node.access_count.saturating_add(1);
+                node.accessed_at = now;
+                node.salience = (node.salience + cfg.use_reinforcement).min(1.0);
+                used_total += 1;
+            }
+
+            // Counter updates must not re-run write inference; write the
+            // node in place.
+            self.storage.update_memory(pid, &node)?;
+            updated += 1;
+        }
+        Ok((updated, used_total))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mentedb_core::types::AgentId;
+    use uuid::Uuid;
+
+    #[test]
+    fn knee_cuts_at_largest_gap() {
+        let ratio = InjectionConfig::default().knee_gap_ratio;
+        assert_eq!(knee_cutoff(&[1.0, 0.9, 0.8, 0.1, 0.09], ratio), 3);
+        // No decisive gap: keep everything.
+        assert_eq!(knee_cutoff(&[1.0, 0.9, 0.8, 0.7], ratio), 4);
+        assert_eq!(knee_cutoff(&[1.0], ratio), 1);
+        assert_eq!(knee_cutoff(&[], ratio), 0);
+    }
+
+    #[test]
+    fn attr_counters_roundtrip() {
+        let mut node = MemoryNode::new(
+            AgentId(Uuid::nil()),
+            MemoryType::Semantic,
+            "x".into(),
+            vec![0.0; 4],
+        );
+        assert_eq!(attr_count(&node, ATTR_INJECTION_SHOWN), 0);
+        bump_attr(&mut node, ATTR_INJECTION_SHOWN);
+        bump_attr(&mut node, ATTR_INJECTION_SHOWN);
+        assert_eq!(attr_count(&node, ATTR_INJECTION_SHOWN), 2);
+    }
+}

--- a/crates/mentedb/src/lib.rs
+++ b/crates/mentedb/src/lib.rs
@@ -98,6 +98,9 @@ pub use mentedb_storage as storage;
 /// Unified process_turn orchestration.
 pub mod process_turn;
 
+/// Engine-native injection attention (selection policy for context injection).
+pub mod injection;
+
 /// Sleeptime enrichment pipeline (requires `enrichment` feature).
 #[cfg(feature = "enrichment")]
 pub mod enrichment;
@@ -244,6 +247,8 @@ pub struct CognitiveConfig {
     pub speculative_cache_size: usize,
     /// Maximum pain signals to retain.
     pub pain_max_warnings: usize,
+    /// Configuration for injection attention selection.
+    pub injection_config: injection::InjectionConfig,
 }
 
 impl Default for CognitiveConfig {
@@ -266,6 +271,7 @@ impl Default for CognitiveConfig {
             trajectory_max_turns: 100,
             speculative_cache_size: 10,
             pain_max_warnings: 5,
+            injection_config: injection::InjectionConfig::default(),
         }
     }
 }

--- a/crates/mentedb/src/process_turn.rs
+++ b/crates/mentedb/src/process_turn.rs
@@ -45,6 +45,9 @@ pub struct ProcessTurnInput {
     pub project_context: Option<String>,
     /// Agent UUID (defaults to nil if not provided).
     pub agent_id: Option<Uuid>,
+    /// Originating session, tagged onto stored turns so injection recall
+    /// can exclude memories already present in that session's context.
+    pub session_id: Option<String>,
 }
 
 /// A detected action from the conversation.
@@ -241,8 +244,12 @@ impl MenteDb {
         delta_tracker.update(&current_ids);
 
         // §3: Store episodic turn (write inference runs automatically inside store)
-        let (stored_ids, episodic_id) =
-            self.store_episodic(&conversation, agent_id, &input.project_context)?;
+        let (stored_ids, episodic_id) = self.store_episodic(
+            &conversation,
+            agent_id,
+            &input.project_context,
+            &input.session_id,
+        )?;
 
         // §4: Write inference on the episodic memory
         let inference_actions = if let Some(eid) = episodic_id {
@@ -449,6 +456,7 @@ impl MenteDb {
         conversation: &str,
         agent_id: AgentId,
         project_context: &Option<String>,
+        session_id: &Option<String>,
     ) -> crate::MenteResult<(Vec<MemoryId>, Option<MemoryId>)> {
         let embedding = self.embed_or_empty(conversation)?;
         let mut node = MemoryNode::new(
@@ -460,6 +468,9 @@ impl MenteDb {
         node.tags.push("turn".to_string());
         if let Some(ctx) = project_context {
             node.tags.push(format!("scope:project:{}", ctx));
+        }
+        if let Some(session) = session_id {
+            node.tags.push(format!("session:{}", session));
         }
         let id = node.id;
         self.store(node)?;

--- a/crates/mentedb/tests/integration.rs
+++ b/crates/mentedb/tests/integration.rs
@@ -1427,3 +1427,158 @@ fn test_entity_resolver_persists_across_flush() {
         );
     }
 }
+
+// ---------------------------------------------------------------------------
+// Injection attention
+// ---------------------------------------------------------------------------
+
+mod injection_attention {
+    use super::*;
+    use mentedb::injection::{
+        ATTR_INJECTION_SHOWN, ATTR_INJECTION_USED, InjectionQuery, SelectionReason,
+    };
+
+    fn semantic(embedding: Vec<f32>, content: &str, tags: Vec<String>) -> MemoryNode {
+        let mut node = MemoryNode::new(
+            AgentId::new(),
+            MemoryType::Semantic,
+            content.into(),
+            embedding,
+        );
+        node.tags = tags;
+        node
+    }
+
+    #[test]
+    fn injection_excludes_session_actions_and_ledger_and_pins_always() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = MenteDb::open(dir.path()).unwrap();
+
+        let relevant = semantic(vec![1.0, 0.0, 0.0, 0.0], "prefers rust", vec![]);
+        let relevant_id = relevant.id;
+        let ledgered = semantic(vec![0.8, 0.6, 0.0, 0.0], "ledgered fact", vec![]);
+        let ledgered_id = ledgered.id;
+        let same_session = semantic(
+            vec![0.8, 0.0, 0.6, 0.0],
+            "from this session",
+            vec!["turn".into(), "session:sess-a".into()],
+        );
+        let action = semantic(
+            vec![0.8, 0.0, 0.0, 0.6],
+            "Edited file: x.rs",
+            vec!["action".into()],
+        );
+        let pinned = semantic(
+            vec![0.0, 1.0, 0.0, 0.0],
+            "never deploy fridays",
+            vec!["scope:always".into()],
+        );
+        let pinned_id = pinned.id;
+
+        for node in [relevant, ledgered, same_session, action, pinned] {
+            db.store(node).unwrap();
+        }
+
+        let query = InjectionQuery {
+            embedding: &[1.0, 0.0, 0.0, 0.0],
+            query_text: None,
+            session_id: Some("sess-a"),
+            exclude_ids: &[ledgered_id],
+            max_items: 6,
+            max_episodic: 2,
+        };
+        let out = db.recall_for_injection(&query).unwrap();
+
+        let ids: Vec<_> = out.iter().map(|c| c.node.id).collect();
+        assert!(ids.contains(&relevant_id), "relevant fact selected");
+        assert!(ids.contains(&pinned_id), "pinned memory always included");
+        assert!(!ids.contains(&ledgered_id), "ledger exclusion respected");
+        assert!(
+            !out.iter().any(|c| c.node.content == "from this session"),
+            "same-session memory excluded"
+        );
+        assert!(
+            !out.iter()
+                .any(|c| c.node.content.starts_with("Edited file")),
+            "action notes never inject"
+        );
+        assert_eq!(
+            out.iter().find(|c| c.node.id == pinned_id).unwrap().reason,
+            SelectionReason::Pinned
+        );
+    }
+
+    #[test]
+    fn outcome_recording_tracks_shown_and_used() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = MenteDb::open(dir.path()).unwrap();
+
+        let mut used = semantic(vec![1.0, 0.0, 0.0, 0.0], "drawn on by reply", vec![]);
+        used.salience = 0.5;
+        let used_id = used.id;
+        let ignored = semantic(vec![0.0, 1.0, 0.0, 0.0], "ignored fact", vec![]);
+        let ignored_id = ignored.id;
+        let before_salience = used.salience;
+        db.store(used).unwrap();
+        db.store(ignored).unwrap();
+
+        // The reply embedding matches the first memory only.
+        let (updated, used_count) = db
+            .record_injection_outcome(&[used_id, ignored_id], Some(&[1.0, 0.0, 0.0, 0.0]))
+            .unwrap();
+        assert_eq!(updated, 2);
+        assert_eq!(used_count, 1);
+
+        let used_node = db.get_memory(used_id).unwrap();
+        let ignored_node = db.get_memory(ignored_id).unwrap();
+        let count = |n: &MemoryNode, k: &str| match n.attributes.get(k) {
+            Some(mentedb_core::memory::AttributeValue::Integer(v)) => *v,
+            _ => 0,
+        };
+        assert_eq!(count(&used_node, ATTR_INJECTION_SHOWN), 1);
+        assert_eq!(count(&used_node, ATTR_INJECTION_USED), 1);
+        assert_eq!(count(&ignored_node, ATTR_INJECTION_SHOWN), 1);
+        assert_eq!(count(&ignored_node, ATTR_INJECTION_USED), 0);
+        assert!(
+            used_node.salience > before_salience,
+            "used memory reinforced"
+        );
+    }
+
+    #[test]
+    fn chronically_ignored_memories_are_demoted() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = MenteDb::open(dir.path()).unwrap();
+
+        let stale = semantic(vec![1.0, 0.0, 0.0, 0.0], "always shown never used", vec![]);
+        let stale_id = stale.id;
+        let fresh = semantic(vec![0.9, 0.3, 0.0, 0.0], "newcomer fact", vec![]);
+        let fresh_id = fresh.id;
+        db.store(stale).unwrap();
+        db.store(fresh).unwrap();
+
+        // Show the stale memory five times with no matching reply.
+        for _ in 0..5 {
+            db.record_injection_outcome(&[stale_id], None).unwrap();
+        }
+
+        let query = InjectionQuery {
+            embedding: &[1.0, 0.0, 0.0, 0.0],
+            query_text: None,
+            session_id: None,
+            exclude_ids: &[],
+            max_items: 1,
+            max_episodic: 0,
+        };
+        let out = db.recall_for_injection(&query).unwrap();
+        let relevant: Vec<_> = out
+            .iter()
+            .filter(|c| c.reason == SelectionReason::Relevant)
+            .collect();
+        assert_eq!(relevant.len(), 1);
+        assert_eq!(
+            relevant[0].node.id, fresh_id,
+            "demoted memory loses its top slot to the fresh one"
+        );
+    }
+}

--- a/crates/mentedb/tests/process_turn.rs
+++ b/crates/mentedb/tests/process_turn.rs
@@ -35,6 +35,7 @@ fn test_process_turn_basic() {
         turn_id: 0,
         project_context: Some("test-project".to_string()),
         agent_id: None,
+        session_id: None,
     };
 
     let result = db.process_turn(&input, &mut delta).unwrap();
@@ -60,6 +61,7 @@ fn test_process_turn_detects_actions() {
         turn_id: 1,
         project_context: None,
         agent_id: None,
+        session_id: None,
     };
 
     let result = db.process_turn(&input, &mut delta).unwrap();
@@ -85,6 +87,7 @@ fn test_process_turn_detects_corrections() {
         turn_id: 1,
         project_context: None,
         agent_id: None,
+        session_id: None,
     };
 
     let result = db.process_turn(&input, &mut delta).unwrap();
@@ -104,6 +107,7 @@ fn test_process_turn_sentiment() {
         turn_id: 0,
         project_context: None,
         agent_id: None,
+        session_id: None,
     };
 
     let result = db.process_turn(&positive_input, &mut delta).unwrap();
@@ -119,6 +123,7 @@ fn test_process_turn_sentiment() {
         turn_id: 1,
         project_context: None,
         agent_id: None,
+        session_id: None,
     };
 
     let result = db.process_turn(&negative_input, &mut delta).unwrap();
@@ -141,6 +146,7 @@ fn test_process_turn_multi_turn_context() {
         turn_id: 0,
         project_context: Some("shopflow".to_string()),
         agent_id: None,
+        session_id: None,
     };
     let r0 = db.process_turn(&input0, &mut delta).unwrap();
     assert!(r0.episodic_id.is_some());
@@ -152,6 +158,7 @@ fn test_process_turn_multi_turn_context() {
         turn_id: 1,
         project_context: Some("shopflow".to_string()),
         agent_id: None,
+        session_id: None,
     };
     let r1 = db.process_turn(&input1, &mut delta).unwrap();
 
@@ -187,6 +194,7 @@ fn test_process_turn_pain_signals() {
         turn_id: 0,
         project_context: None,
         agent_id: None,
+        session_id: None,
     };
 
     let result = db.process_turn(&input, &mut delta).unwrap();
@@ -210,6 +218,7 @@ fn test_process_turn_delta_tracking() {
         turn_id: 0,
         project_context: None,
         agent_id: None,
+        session_id: None,
     };
     let r0 = db.process_turn(&input0, &mut delta).unwrap();
 
@@ -223,6 +232,7 @@ fn test_process_turn_delta_tracking() {
         turn_id: 1,
         project_context: None,
         agent_id: None,
+        session_id: None,
     };
     let _r1 = db.process_turn(&input1, &mut delta).unwrap();
     // Just verify it doesn't panic — delta computation runs
@@ -240,6 +250,7 @@ fn test_process_turn_maintenance_intervals() {
         turn_id: 0,
         project_context: None,
         agent_id: None,
+        session_id: None,
     };
     let _ = db.process_turn(&input, &mut delta).unwrap();
 
@@ -250,6 +261,7 @@ fn test_process_turn_maintenance_intervals() {
         turn_id: 50,
         project_context: None,
         agent_id: None,
+        session_id: None,
     };
     let _ = db.process_turn(&input50, &mut delta).unwrap();
 
@@ -260,6 +272,7 @@ fn test_process_turn_maintenance_intervals() {
         turn_id: 200,
         project_context: None,
         agent_id: None,
+        session_id: None,
     };
     let _ = db.process_turn(&input200, &mut delta).unwrap();
 }
@@ -285,6 +298,7 @@ fn test_enrichment_trigger_after_interval() {
             turn_id: i,
             project_context: None,
             agent_id: None,
+            session_id: None,
         };
         let result = db.process_turn(&input, &mut delta).unwrap();
         assert!(!result.enrichment_pending, "turn {} should not trigger", i);
@@ -297,6 +311,7 @@ fn test_enrichment_trigger_after_interval() {
         turn_id: 5,
         project_context: None,
         agent_id: None,
+        session_id: None,
     };
     let result = db.process_turn(&input5, &mut delta).unwrap();
     assert!(result.enrichment_pending);
@@ -316,6 +331,7 @@ fn test_enrichment_candidates_returns_episodics() {
             turn_id: i as u64,
             project_context: None,
             agent_id: None,
+            session_id: None,
         };
         db.process_turn(&input, &mut delta).unwrap();
     }
@@ -344,6 +360,7 @@ fn test_enrichment_store_results() {
         turn_id: 1,
         project_context: None,
         agent_id: None,
+        session_id: None,
     };
     let result = db.process_turn(&input, &mut delta).unwrap();
     let source_id = result.episodic_id.unwrap();
@@ -387,6 +404,7 @@ fn test_enrichment_mark_complete_resets_pending() {
             turn_id: i,
             project_context: None,
             agent_id: None,
+            session_id: None,
         };
         db.process_turn(&input, &mut delta).unwrap();
     }
@@ -405,6 +423,7 @@ fn test_enrichment_mark_complete_resets_pending() {
             turn_id: i,
             project_context: None,
             agent_id: None,
+            session_id: None,
         };
         let result = db.process_turn(&input, &mut delta).unwrap();
         assert!(!result.enrichment_pending);
@@ -417,6 +436,7 @@ fn test_enrichment_mark_complete_resets_pending() {
         turn_id: 6,
         project_context: None,
         agent_id: None,
+        session_id: None,
     };
     let result = db.process_turn(&input6, &mut delta).unwrap();
     assert!(result.enrichment_pending);
@@ -444,6 +464,7 @@ fn test_always_scope_in_retrieve_context() {
         turn_id: 1,
         project_context: None,
         agent_id: None,
+        session_id: None,
     };
     let result = db.process_turn(&input, &mut delta).unwrap();
 


### PR DESCRIPTION
Adds the injection module: retrieval shaped for context injection rather than raw search, moving the selection policy that client hooks approximated with heuristics into the engine where it belongs.

recall_for_injection(InjectionQuery):
- Session provenance: process_turn now accepts session_id and tags stored turns session:<id>; injection recall excludes memories originating from the querying session, they are in that context by construction. Replaces the client-side 12 hour freshness heuristic.
- exclude_ids: the client working-memory ledger (what was already delivered this context lifetime) is honored inside retrieval, so every returned slot is useful.
- Relevance knee instead of a fixed floor: the candidate list is cut at its largest score gap when decisive, no magic threshold against uncalibrated scores.
- Maximal Marginal Relevance over embeddings with type quotas: distilled knowledge first, verbatim episodic capped, action notes never inject.
- scope:always memories bypass every quality gate and lead the result, with SelectionReason::Pinned for introspection.

record_injection_outcome(shown, reply_embedding):
- Every shown memory has injection_shown bumped (attributes map, zero schema change); memories the reply drew on (embedding similarity) get injection_used, an access touch, and salience reinforcement. Chronically ignored memories (shown 5+, used 0) are demoted at selection time. Attention that learns.

All tunables live in InjectionConfig on CognitiveConfig per the no-magic-numbers convention. Unit tests for the knee and counters, integration tests for session/ledger/action exclusion, pinning, outcome tracking, and demotion.

Found during testing, filed for follow-up rather than this PR: HNSW returns only 2 of 5 near-coincident vectors (pairwise similarity ~0.99), the neighbor pruning heuristic appears to orphan near-duplicate points.

🤖 Generated with [Claude Code](https://claude.com/claude-code)