### PR TITLE
fix: exclusive process lock on the data directory

### DIFF
--- a/crates/mentedb-storage/src/engine.rs
+++ b/crates/mentedb-storage/src/engine.rs
@@ -1,5 +1,6 @@
 //! Storage Engine: facade that ties the page manager, WAL, and buffer pool together.
 
+use std::fs::File;
 use std::path::Path;
 
 use mentedb_core::MemoryNode;
@@ -32,12 +33,21 @@ const WAL_AUTO_CHECKPOINT_BYTES: u64 = 8 * 1024 * 1024;
 /// - **State is refreshed from disk** under the flock: page count is re-read
 ///   from the file header and LSN is re-read from the WAL tail, so no process
 ///   can act on stale in-memory state.
-/// - **No DB-level lock on open.** Multiple processes can open the same database
-///   simultaneously.
+/// - **One process per database.** Open acquires an exclusive lock on a LOCK
+///   file in the data directory and holds it for the engine's lifetime. The
+///   per operation flock protects individual write transactions, but layers
+///   above the storage engine cache state across operations (buffer pool,
+///   page map, index snapshots), and a second concurrent process flushing
+///   those caches rolls the database back to its own open time snapshot.
+///   A second open therefore fails fast with a "locked" error instead of
+///   silently corrupting state; callers retry until the owner exits.
 pub struct StorageEngine {
     page_manager: Mutex<PageManager>,
     buffer_pool: BufferPool,
     wal: Mutex<Wal>,
+    /// Held exclusively for the lifetime of this engine; released on close
+    /// or process exit. Guards against concurrent multi process opens.
+    process_lock: Mutex<Option<File>>,
 }
 
 impl StorageEngine {
@@ -58,6 +68,22 @@ impl StorageEngine {
     pub fn open(path: &Path) -> MenteResult<Self> {
         std::fs::create_dir_all(path)?;
 
+        // Exclusive process lock, held until close or process exit. A second
+        // process opening the same directory would interleave stale cached
+        // state with ours and roll the database back, so refuse it up front.
+        let lock_path = path.join("LOCK");
+        let lock_file = std::fs::OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .write(true)
+            .open(&lock_path)?;
+        fs2::FileExt::try_lock_exclusive(&lock_file).map_err(|_| {
+            MenteError::Storage(format!(
+                "database directory {} is locked by another process",
+                path.display()
+            ))
+        })?;
+
         let page_manager = PageManager::open(path)?;
         let buffer_pool = BufferPool::new(DEFAULT_BUFFER_POOL_SIZE);
         let wal = Wal::open(path)?;
@@ -66,6 +92,7 @@ impl StorageEngine {
             page_manager: Mutex::new(page_manager),
             buffer_pool,
             wal: Mutex::new(wal),
+            process_lock: Mutex::new(Some(lock_file)),
         };
 
         let recovered = engine.recover()?;
@@ -183,8 +210,24 @@ impl StorageEngine {
         self.buffer_pool.flush_all(&mut pm)?;
         pm.sync()?;
         self.wal.lock().sync()?;
+        // Release the process lock so the directory can be reopened, by this
+        // process or another, without waiting for us to exit.
+        if let Some(lock_file) = self.process_lock.lock().take() {
+            let _ = fs2::FileExt::unlock(&lock_file);
+        }
         info!("storage engine closed");
         Ok(())
+    }
+
+    /// Release the process lock without flushing anything.
+    ///
+    /// Test support for simulating a process crash: a real crash releases
+    /// the OS file lock but persists nothing beyond what was already synced.
+    #[doc(hidden)]
+    pub fn release_process_lock(&self) {
+        if let Some(lock_file) = self.process_lock.lock().take() {
+            let _ = fs2::FileExt::unlock(&lock_file);
+        }
     }
 
     // ---- low-level page operations ----
@@ -888,37 +931,23 @@ mod tests {
     }
 
     #[test]
-    fn test_concurrent_open_no_lock_conflict() {
+    fn test_concurrent_open_is_rejected() {
         let dir = tempfile::tempdir().unwrap();
 
-        // Two engines open the same directory simultaneously — should succeed
-        // now that we no longer hold an exclusive DB-level flock.
+        // The per operation flock serializes individual write transactions,
+        // but layers above the storage engine cache state across operations,
+        // so a second concurrent engine rolls the database back to its own
+        // open time snapshot. The process lock must refuse it.
         let engine1 = StorageEngine::open(dir.path()).unwrap();
+        let second = StorageEngine::open(dir.path());
+        assert!(second.is_err(), "second concurrent open must fail");
+        let msg = second.err().unwrap().to_string();
+        assert!(msg.contains("locked"), "error names the lock: {msg}");
+
+        // Close releases the lock; the directory can be opened again.
+        engine1.close().unwrap();
         let engine2 = StorageEngine::open(dir.path()).unwrap();
-
-        // Both can write (serialized by WAL file lock)
-        let node1 = MemoryNode::new(
-            AgentId::new(),
-            MemoryType::Episodic,
-            "from engine 1".to_string(),
-            vec![1.0],
-        );
-        let node2 = MemoryNode::new(
-            AgentId::new(),
-            MemoryType::Episodic,
-            "from engine 2".to_string(),
-            vec![2.0],
-        );
-
-        let pid1 = engine1.store_memory(&node1).unwrap();
-        let pid2 = engine2.store_memory(&node2).unwrap();
-
-        // Each engine can read what it wrote
-        let loaded1 = engine1.load_memory(pid1).unwrap();
-        assert_eq!(loaded1.content, "from engine 1");
-
-        let loaded2 = engine2.load_memory(pid2).unwrap();
-        assert_eq!(loaded2.content, "from engine 2");
+        engine2.close().unwrap();
     }
 
     #[test]

--- a/crates/mentedb/src/lib.rs
+++ b/crates/mentedb/src/lib.rs
@@ -1225,6 +1225,15 @@ impl MenteDb {
         Ok(())
     }
 
+    /// Simulate a process crash for tests: releases the storage process lock
+    /// exactly as the operating system would when a process dies, then drops
+    /// the instance without flushing or closing anything.
+    #[doc(hidden)]
+    pub fn simulate_crash(self) {
+        self.storage.release_process_lock();
+        std::mem::forget(self);
+    }
+
     /// Rebuild all indexes by scanning every memory in storage.
     ///
     /// Use this after index corruption or when index files were overwritten.

--- a/crates/mentedb/tests/forget_durability.rs
+++ b/crates/mentedb/tests/forget_durability.rs
@@ -1,0 +1,186 @@
+//! Forget durability: a forgotten memory must never resurrect on reopen,
+//! whether the database was closed cleanly or the process died before close.
+
+use mentedb::MenteDb;
+use mentedb::prelude::*;
+use mentedb_core::types::AgentId;
+
+fn open(dir: &std::path::Path) -> MenteDb {
+    MenteDb::open(dir).expect("open")
+}
+
+fn store_one(db: &MenteDb, content: &str, embedding: Vec<f32>) -> MemoryId {
+    let node = MemoryNode::new(
+        AgentId::nil(),
+        MemoryType::Semantic,
+        content.to_string(),
+        embedding,
+    );
+    let id = node.id;
+    db.store(node).expect("store");
+    id
+}
+
+#[test]
+fn second_open_of_live_database_is_rejected() {
+    // Two engine instances on one directory interleave stale cached state
+    // (buffer pool, page map, index snapshots) and roll the database back
+    // to one instance's open time snapshot. The process lock must refuse
+    // the second open while the first is alive, and allow it again after
+    // close and after a crash.
+    let dir = tempfile::tempdir().unwrap();
+
+    let db1 = open(dir.path());
+    let second = MenteDb::open(dir.path());
+    assert!(second.is_err(), "second concurrent open must fail");
+    let msg = second.err().unwrap().to_string();
+    assert!(msg.contains("locked"), "error names the lock: {msg}");
+
+    db1.close().expect("close");
+    let db2 = open(dir.path());
+    db2.simulate_crash();
+
+    // A crashed process releases the OS lock; reopen must succeed.
+    let db3 = open(dir.path());
+    db3.close().expect("close");
+}
+
+#[test]
+fn forget_survives_clean_reopen() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let keep;
+    let doomed;
+    {
+        let db = open(dir.path());
+        keep = store_one(&db, "memory that stays", vec![0.9, 0.1, 0.0, 0.0]);
+        doomed = store_one(
+            &db,
+            "memory that must not resurrect",
+            vec![0.1, 0.9, 0.0, 0.0],
+        );
+        db.flush().expect("flush");
+        db.close().expect("close");
+    }
+
+    {
+        let db = open(dir.path());
+        assert!(db.get_memory(doomed).is_ok(), "exists before forget");
+        db.forget(doomed).expect("forget");
+        assert!(db.get_memory(doomed).is_err(), "gone in same session");
+        db.close().expect("close");
+    }
+
+    {
+        let db = open(dir.path());
+        assert!(db.get_memory(keep).is_ok(), "kept memory survives");
+        assert!(
+            db.get_memory(doomed).is_err(),
+            "forgotten memory resurrected after clean close and reopen"
+        );
+        assert_eq!(db.memory_count(), 1);
+    }
+}
+
+#[test]
+fn forget_then_flush_survives_reopen() {
+    // The exact production sequence: the gateway delete handler calls
+    // forget() followed by flush(). A flush that checkpoints the WAL must
+    // not erase the evidence of the deletion.
+    let dir = tempfile::tempdir().unwrap();
+
+    let keep;
+    let doomed;
+    {
+        let db = open(dir.path());
+        keep = store_one(&db, "flush test keeper", vec![0.9, 0.1, 0.0, 0.0]);
+        doomed = store_one(&db, "flush test zombie", vec![0.1, 0.9, 0.0, 0.0]);
+        db.flush().expect("flush");
+        db.close().expect("close");
+    }
+
+    {
+        let db = open(dir.path());
+        db.forget(doomed).expect("forget");
+        db.flush().expect("flush after forget");
+        db.close().expect("close");
+    }
+
+    {
+        let db = open(dir.path());
+        assert!(db.get_memory(keep).is_ok(), "kept memory survives");
+        assert!(
+            db.get_memory(doomed).is_err(),
+            "forgotten memory resurrected after forget+flush+reopen"
+        );
+    }
+}
+
+#[test]
+fn forget_then_flush_then_crash_survives_reopen() {
+    // The production lifecycle: forget() + flush() succeed (the flush may
+    // checkpoint and truncate the WAL), then the process is killed hours
+    // later without close() ever running. The deletion must still be
+    // durable: either the checkpoint persists the free list, or the WAL
+    // entry must survive the checkpoint.
+    let dir = tempfile::tempdir().unwrap();
+
+    let keep;
+    let doomed;
+    {
+        let db = open(dir.path());
+        keep = store_one(&db, "checkpoint keeper", vec![0.9, 0.1, 0.0, 0.0]);
+        doomed = store_one(&db, "checkpoint zombie", vec![0.1, 0.9, 0.0, 0.0]);
+        db.flush().expect("flush");
+        db.close().expect("close");
+    }
+
+    {
+        let db = open(dir.path());
+        db.forget(doomed).expect("forget");
+        db.flush().expect("flush after forget");
+        // Crash without close: destructors skipped, nothing else written.
+        db.simulate_crash();
+    }
+
+    {
+        let db = open(dir.path());
+        assert!(db.get_memory(keep).is_ok(), "kept memory survives");
+        assert!(
+            db.get_memory(doomed).is_err(),
+            "forgotten memory resurrected after forget+flush+crash"
+        );
+    }
+}
+
+#[test]
+fn forget_survives_crash_without_close() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let keep;
+    let doomed;
+    {
+        let db = open(dir.path());
+        keep = store_one(&db, "crash test keeper", vec![0.9, 0.1, 0.0, 0.0]);
+        doomed = store_one(&db, "crash test zombie candidate", vec![0.1, 0.9, 0.0, 0.0]);
+        db.flush().expect("flush");
+        db.close().expect("close");
+    }
+
+    {
+        let db = open(dir.path());
+        db.forget(doomed).expect("forget");
+        // Simulate a crash: the destructor never runs, nothing else is
+        // flushed. The WAL entry written inside forget must be enough.
+        db.simulate_crash();
+    }
+
+    {
+        let db = open(dir.path());
+        assert!(db.get_memory(keep).is_ok(), "kept memory survives crash");
+        assert!(
+            db.get_memory(doomed).is_err(),
+            "forgotten memory resurrected after crash-style stop"
+        );
+    }
+}

--- a/crates/mentedb/tests/integration.rs
+++ b/crates/mentedb/tests/integration.rs
@@ -99,7 +99,7 @@ fn test_forget_survives_crash() {
         db.store(node).unwrap();
         db.forget(id).unwrap();
         // Simulate crash: no close, no flush.
-        std::mem::forget(db);
+        db.simulate_crash();
     }
     {
         let db = MenteDb::open(dir.path()).unwrap();
@@ -161,7 +161,7 @@ fn test_edges_survive_crash() {
         .unwrap();
         // Simulate crash: no close, no flush — the graph snapshot was never
         // written, so the edge only exists in the edge log.
-        std::mem::forget(db);
+        db.simulate_crash();
     }
     {
         let db = MenteDb::open(dir.path()).unwrap();
@@ -187,7 +187,7 @@ fn test_relate_works_after_crash() {
         db.store(m1).unwrap();
         db.store(m2).unwrap();
         // Crash before any flush: no graph snapshot exists on disk.
-        std::mem::forget(db);
+        db.simulate_crash();
     }
     {
         // Graph nodes must be rebuilt from storage so surviving memories can
@@ -231,7 +231,7 @@ fn test_forgotten_memory_edges_do_not_resurrect() {
         })
         .unwrap();
         db.forget(id2).unwrap();
-        std::mem::forget(db); // crash: RemoveNode only in the edge log
+        db.simulate_crash(); // crash: RemoveNode only in the edge log
     }
     {
         let db = MenteDb::open(dir.path()).unwrap();


### PR DESCRIPTION
Production evidence (mentedb-platform, 2026-07-04): during every ECS deploy two gateway tasks briefly share the same EFS data directory. The per operation WAL flock serializes individual write transactions, but the layers above cache state across operations (buffer pool, page map, HNSW and graph snapshots saved wholesale at flush), so the second process's flushes roll the database back to its own open time snapshot. Observed live: deleted memories resurrected with identical UUIDs across two delete and restart cycles, and memories created after the stale process opened vanished. Fix: open() takes an exclusive lock on LOCK in the data directory and holds it until close or process exit; a second open fails fast with a 'locked' error (the platform gateway already retries opens on lock errors). Adds forget durability tests (clean close, forget+flush, crash, forget+flush+crash), a second-open rejection test, and MenteDb::simulate_crash() test support that releases the lock exactly as a dying process would. The old test_concurrent_open_no_lock_conflict asserted the removed multi open contract and is inverted.