### PR TITLE
fix: SDK bindings expose session_id on process_turn

### DIFF
--- a/sdks/python/Cargo.lock
+++ b/sdks/python/Cargo.lock
@@ -1439,7 +1439,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb"
-version = "0.9.1"
+version = "0.10.4"
 dependencies = [
  "mentedb-cognitive",
  "mentedb-consolidation",
@@ -1459,7 +1459,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-cognitive"
-version = "0.9.1"
+version = "0.10.4"
 dependencies = [
  "ahash",
  "crossbeam",
@@ -1474,7 +1474,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-consolidation"
-version = "0.9.1"
+version = "0.10.4"
 dependencies = [
  "ahash",
  "mentedb-core",
@@ -1485,7 +1485,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-context"
-version = "0.9.1"
+version = "0.10.4"
 dependencies = [
  "ahash",
  "mentedb-core",
@@ -1497,7 +1497,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-core"
-version = "0.9.1"
+version = "0.10.4"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1512,7 +1512,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-embedding"
-version = "0.9.1"
+version = "0.10.4"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -1530,7 +1530,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-extraction"
-version = "0.9.1"
+version = "0.10.4"
 dependencies = [
  "mentedb-cognitive",
  "mentedb-core",
@@ -1546,7 +1546,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-graph"
-version = "0.9.1"
+version = "0.10.4"
 dependencies = [
  "ahash",
  "bincode",
@@ -1561,7 +1561,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-index"
-version = "0.9.1"
+version = "0.10.4"
 dependencies = [
  "ahash",
  "bincode",
@@ -1598,7 +1598,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-query"
-version = "0.9.1"
+version = "0.10.4"
 dependencies = [
  "mentedb-core",
  "serde",
@@ -1609,7 +1609,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-storage"
-version = "0.9.1"
+version = "0.10.4"
 dependencies = [
  "ahash",
  "bincode",

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -35,6 +35,8 @@ with MenteDB("./agent-memory") as db:
     # result.context — relevant memories for your prompt
     # result.facts_extracted — what was learned this turn
     # result.contradiction_count — conflicting beliefs detected
+    # Optional kwargs: project_context, agent_id, session_id (tags stored
+    # turns so injection recall can exclude the requesting session)
 
     # Sleeptime enrichment runs automatically after process_turn:
     # - Extracts semantic facts from conversations

--- a/sdks/python/src/lib.rs
+++ b/sdks/python/src/lib.rs
@@ -2305,7 +2305,9 @@ impl MenteDB {
                 } else {
                     // Fallback: flat evidence (no graph structure available)
                     // Build temporal context header if we have temporal info
-                    let temporal_context = if let Some(ref_us) = temporal_reference.filter(|_| is_temporal) {
+                    let temporal_context = if let Some(ref_us) =
+                        temporal_reference.filter(|_| is_temporal)
+                    {
                         let ref_secs = (ref_us / 1_000_000) as i64;
                         let ref_days = ref_secs / 86400;
                         let (ry, rm, rd) = {
@@ -2514,195 +2516,191 @@ impl MenteDB {
                                     && let Some(events) =
                                         date_json.get("events").and_then(|v| v.as_array())
                                 {
-                                        // Parse dates and compute differences
-                                        let mut parsed_dates: Vec<(String, i64)> = Vec::new(); // (description, days_since_epoch)
-                                        for event in events {
-                                            if let (Some(desc), Some(date_str)) = (
-                                                event.get("description").and_then(|v| v.as_str()),
-                                                event.get("date").and_then(|v| v.as_str()),
-                                            ) {
-                                                // Parse YYYY-MM-DD to days since epoch
-                                                let parts: Vec<&str> =
-                                                    date_str.split('-').collect();
-                                                if parts.len() == 3
-                                                    && let (Ok(y), Ok(m), Ok(d)) = (
-                                                        parts[0].parse::<i64>(),
-                                                        parts[1].parse::<i64>(),
-                                                        parts[2].parse::<i64>(),
-                                                    )
-                                                {
-                                                        // Days since epoch (approximate but accurate enough for differences)
-                                                        let days = (y - 1970) * 365
-                                                            + (y - 1969) / 4
-                                                            - (y - 1901) / 100
-                                                            + (y - 1601) / 400
-                                                            + (367 * m - 362) / 12
-                                                            + d
-                                                            - 1
-                                                            + if m > 2 {
-                                                                if y % 4 == 0
-                                                                    && (y % 100 != 0
-                                                                        || y % 400 == 0)
-                                                                {
-                                                                    -1
-                                                                } else {
-                                                                    -2
-                                                                }
-                                                            } else {
-                                                                0
-                                                            };
-                                                        parsed_dates.push((desc.to_string(), days));
-                                                    }
-                                                }
-                                        }
-                                        if parsed_dates.len() >= 2 {
-                                            // Compute difference between first two events
-                                            let diff_days = (parsed_dates[1].1 - parsed_dates[0].1)
-                                                .unsigned_abs();
-                                            let diff_weeks = diff_days / 7;
-                                            let diff_months = diff_days / 30; // approximate
-
-                                            let computed_answer = if query_lower
-                                                .contains("how many days")
+                                    // Parse dates and compute differences
+                                    let mut parsed_dates: Vec<(String, i64)> = Vec::new(); // (description, days_since_epoch)
+                                    for event in events {
+                                        if let (Some(desc), Some(date_str)) = (
+                                            event.get("description").and_then(|v| v.as_str()),
+                                            event.get("date").and_then(|v| v.as_str()),
+                                        ) {
+                                            // Parse YYYY-MM-DD to days since epoch
+                                            let parts: Vec<&str> = date_str.split('-').collect();
+                                            if parts.len() == 3
+                                                && let (Ok(y), Ok(m), Ok(d)) = (
+                                                    parts[0].parse::<i64>(),
+                                                    parts[1].parse::<i64>(),
+                                                    parts[2].parse::<i64>(),
+                                                )
                                             {
-                                                format!(
-                                                    "[VERIFIED COMPUTATION]\n\
+                                                // Days since epoch (approximate but accurate enough for differences)
+                                                let days = (y - 1970) * 365 + (y - 1969) / 4
+                                                    - (y - 1901) / 100
+                                                    + (y - 1601) / 400
+                                                    + (367 * m - 362) / 12
+                                                    + d
+                                                    - 1
+                                                    + if m > 2 {
+                                                        if y % 4 == 0
+                                                            && (y % 100 != 0 || y % 400 == 0)
+                                                        {
+                                                            -1
+                                                        } else {
+                                                            -2
+                                                        }
+                                                    } else {
+                                                        0
+                                                    };
+                                                parsed_dates.push((desc.to_string(), days));
+                                            }
+                                        }
+                                    }
+                                    if parsed_dates.len() >= 2 {
+                                        // Compute difference between first two events
+                                        let diff_days =
+                                            (parsed_dates[1].1 - parsed_dates[0].1).unsigned_abs();
+                                        let diff_weeks = diff_days / 7;
+                                        let diff_months = diff_days / 30; // approximate
+
+                                        let computed_answer = if query_lower
+                                            .contains("how many days")
+                                        {
+                                            format!(
+                                                "[VERIFIED COMPUTATION]\n\
                                                      Event 1: {}\n\
                                                      Event 2: {}\n\
                                                      Date arithmetic: {} days between the two events.\n\
                                                      ANSWER: {} days.",
-                                                    parsed_dates[0].0,
-                                                    parsed_dates[1].0,
-                                                    diff_days,
-                                                    diff_days
-                                                )
-                                            } else if query_lower.contains("how many weeks") {
-                                                format!(
-                                                    "[VERIFIED COMPUTATION]\n\
+                                                parsed_dates[0].0,
+                                                parsed_dates[1].0,
+                                                diff_days,
+                                                diff_days
+                                            )
+                                        } else if query_lower.contains("how many weeks") {
+                                            format!(
+                                                "[VERIFIED COMPUTATION]\n\
                                                      Event 1: {}\n\
                                                      Event 2: {}\n\
                                                      Date arithmetic: {} days = {} weeks between the two events.\n\
                                                      ANSWER: {} weeks.",
-                                                    parsed_dates[0].0,
-                                                    parsed_dates[1].0,
-                                                    diff_days,
-                                                    diff_weeks,
-                                                    diff_weeks
-                                                )
-                                            } else if query_lower.contains("how many months") || query_lower.contains("how long") {
-                                                format!(
-                                                    "[VERIFIED COMPUTATION]\n\
+                                                parsed_dates[0].0,
+                                                parsed_dates[1].0,
+                                                diff_days,
+                                                diff_weeks,
+                                                diff_weeks
+                                            )
+                                        } else if query_lower.contains("how many months")
+                                            || query_lower.contains("how long")
+                                        {
+                                            format!(
+                                                "[VERIFIED COMPUTATION]\n\
                                                      Event 1: {}\n\
                                                      Event 2: {}\n\
                                                      Date arithmetic: {} days = approximately {} months between the two events.\n\
                                                      ANSWER: {} months.",
-                                                    parsed_dates[0].0,
-                                                    parsed_dates[1].0,
-                                                    diff_days,
-                                                    diff_months,
-                                                    diff_months
-                                                )
-                                            } else {
-                                                format!(
-                                                    "[VERIFIED COMPUTATION]\n\
+                                                parsed_dates[0].0,
+                                                parsed_dates[1].0,
+                                                diff_days,
+                                                diff_months,
+                                                diff_months
+                                            )
+                                        } else {
+                                            format!(
+                                                "[VERIFIED COMPUTATION]\n\
                                                      Event 1: {}\n\
                                                      Event 2: {}\n\
                                                      Date arithmetic: {} days ({} weeks, ~{} months) between the two events.\n\
                                                      ANSWER: {} days.",
-                                                    parsed_dates[0].0,
-                                                    parsed_dates[1].0,
-                                                    diff_days,
-                                                    diff_weeks,
-                                                    diff_months,
-                                                    diff_days
-                                                )
-                                            };
-                                            if debug {
-                                                eprintln!(
-                                                    "[temporal-compute] Computed date difference: {} days between '{}' and '{}'",
-                                                    diff_days, parsed_dates[0].0, parsed_dates[1].0
-                                                );
-                                            }
-                                            final_synthesis = computed_answer;
-                                            temporal_math_succeeded = true;
-                                        } else if parsed_dates.len() == 1
-                                            && query_lower.contains("ago")
-                                        {
-                                            // "How many weeks ago did X happen?"
-                                            // Compute from reference date
-                                            let event_days = parsed_dates[0].1;
-                                            let local_day_us: u64 = 86_400_000_000;
-                                            let local_before_us = temporal_reference.unwrap_or(
-                                                std::time::SystemTime::now()
-                                                    .duration_since(std::time::UNIX_EPOCH)
-                                                    .unwrap_or_default()
-                                                    .as_micros()
-                                                    as u64,
+                                                parsed_dates[0].0,
+                                                parsed_dates[1].0,
+                                                diff_days,
+                                                diff_weeks,
+                                                diff_months,
+                                                diff_days
+                                            )
+                                        };
+                                        if debug {
+                                            eprintln!(
+                                                "[temporal-compute] Computed date difference: {} days between '{}' and '{}'",
+                                                diff_days, parsed_dates[0].0, parsed_dates[1].0
                                             );
-                                            let ref_days = (local_before_us / local_day_us) as i64;
-                                            let diff_days = (ref_days - event_days).unsigned_abs();
-                                            let diff_weeks = diff_days / 7;
+                                        }
+                                        final_synthesis = computed_answer;
+                                        temporal_math_succeeded = true;
+                                    } else if parsed_dates.len() == 1 && query_lower.contains("ago")
+                                    {
+                                        // "How many weeks ago did X happen?"
+                                        // Compute from reference date
+                                        let event_days = parsed_dates[0].1;
+                                        let local_day_us: u64 = 86_400_000_000;
+                                        let local_before_us = temporal_reference.unwrap_or(
+                                            std::time::SystemTime::now()
+                                                .duration_since(std::time::UNIX_EPOCH)
+                                                .unwrap_or_default()
+                                                .as_micros()
+                                                as u64,
+                                        );
+                                        let ref_days = (local_before_us / local_day_us) as i64;
+                                        let diff_days = (ref_days - event_days).unsigned_abs();
+                                        let diff_weeks = diff_days / 7;
 
-                                            let diff_months = diff_days / 30;
-                                            let computed_answer = if query_lower
-                                                .contains("how many weeks")
-                                            {
-                                                format!(
-                                                    "[VERIFIED COMPUTATION]\n\
+                                        let diff_months = diff_days / 30;
+                                        let computed_answer = if query_lower
+                                            .contains("how many weeks")
+                                        {
+                                            format!(
+                                                "[VERIFIED COMPUTATION]\n\
                                                      Event: {}\n\
                                                      Date arithmetic: {} days = {} weeks ago from reference date.\n\
                                                      ANSWER: {} weeks ago.",
-                                                    parsed_dates[0].0,
-                                                    diff_days,
-                                                    diff_weeks,
-                                                    diff_weeks
-                                                )
-                                            } else if query_lower.contains("how many months") {
-                                                format!(
-                                                    "[VERIFIED COMPUTATION]\n\
+                                                parsed_dates[0].0,
+                                                diff_days,
+                                                diff_weeks,
+                                                diff_weeks
+                                            )
+                                        } else if query_lower.contains("how many months") {
+                                            format!(
+                                                "[VERIFIED COMPUTATION]\n\
                                                      Event: {}\n\
                                                      Date arithmetic: {} days = approximately {} months ago from reference date.\n\
                                                      ANSWER: {} months ago.",
-                                                    parsed_dates[0].0,
-                                                    diff_days,
-                                                    diff_months,
-                                                    diff_months
-                                                )
-                                            } else if query_lower.contains("how many days") {
-                                                format!(
-                                                    "[VERIFIED COMPUTATION]\n\
+                                                parsed_dates[0].0,
+                                                diff_days,
+                                                diff_months,
+                                                diff_months
+                                            )
+                                        } else if query_lower.contains("how many days") {
+                                            format!(
+                                                "[VERIFIED COMPUTATION]\n\
                                                      Event: {}\n\
                                                      Date arithmetic: {} days ago from reference date.\n\
                                                      ANSWER: {} days ago.",
-                                                    parsed_dates[0].0,
-                                                    diff_days,
-                                                    diff_days
-                                                )
-                                            } else {
-                                                format!(
-                                                    "[VERIFIED COMPUTATION]\n\
+                                                parsed_dates[0].0, diff_days, diff_days
+                                            )
+                                        } else {
+                                            format!(
+                                                "[VERIFIED COMPUTATION]\n\
                                                      Event: {}\n\
                                                      Date arithmetic: {} days (~{} months, ~{} weeks) ago from reference date.\n\
                                                      ANSWER: {} days ago.",
-                                                    parsed_dates[0].0,
-                                                    diff_days,
-                                                    diff_months,
-                                                    diff_weeks,
-                                                    diff_days
-                                                )
-                                            };
-                                            if debug {
-                                                eprintln!(
-                                                    "[temporal-compute] Event '{}' was {} days ago",
-                                                    parsed_dates[0].0, diff_days
-                                                );
-                                            }
-                                            final_synthesis = computed_answer;
-                                            temporal_math_succeeded = true;
+                                                parsed_dates[0].0,
+                                                diff_days,
+                                                diff_months,
+                                                diff_weeks,
+                                                diff_days
+                                            )
+                                        };
+                                        if debug {
+                                            eprintln!(
+                                                "[temporal-compute] Event '{}' was {} days ago",
+                                                parsed_dates[0].0, diff_days
+                                            );
                                         }
+                                        final_synthesis = computed_answer;
+                                        temporal_math_succeeded = true;
                                     }
                                 }
                             }
+                        }
 
                         // --- Temporal ordering engine ---
                         // For "what is the order of X from earliest to latest" questions,
@@ -2725,7 +2723,8 @@ impl MenteDB {
                             let ordering_system = "You extract events with dates from evidence for chronological ordering. Return only valid JSON.";
 
                             if let Ok(ordering_response) = rt.block_on(
-                                synth_provider.call_text_with_retry(&ordering_prompt, ordering_system),
+                                synth_provider
+                                    .call_text_with_retry(&ordering_prompt, ordering_system),
                             ) {
                                 let cleaned = ordering_response
                                     .trim()
@@ -2751,8 +2750,7 @@ impl MenteDB {
                                                     parts[2].parse::<i64>(),
                                                 )
                                             {
-                                                let days = (y - 1970) * 365
-                                                    + (y - 1969) / 4
+                                                let days = (y - 1970) * 365 + (y - 1969) / 4
                                                     - (y - 1901) / 100
                                                     + (y - 1601) / 400
                                                     + (367 * m - 362) / 12
@@ -2780,7 +2778,11 @@ impl MenteDB {
 
                                         let mut ordered_list = String::new();
                                         for (i, (desc, _)) in dated_events.iter().enumerate() {
-                                            ordered_list.push_str(&format!("{}. {}\n", i + 1, desc));
+                                            ordered_list.push_str(&format!(
+                                                "{}. {}\n",
+                                                i + 1,
+                                                desc
+                                            ));
                                         }
 
                                         let computed_answer = format!(
@@ -2789,7 +2791,11 @@ impl MenteDB {
                                              {}\n\
                                              ANSWER: The order from earliest to latest is: {}",
                                             ordered_list,
-                                            dated_events.iter().map(|(d, _)| d.as_str()).collect::<Vec<_>>().join(", then ")
+                                            dated_events
+                                                .iter()
+                                                .map(|(d, _)| d.as_str())
+                                                .collect::<Vec<_>>()
+                                                .join(", then ")
                                         );
 
                                         if debug {
@@ -2830,7 +2836,8 @@ impl MenteDB {
                                     || query_lower.contains("miles")
                                     || query_lower.contains("raised")))
                             || (query_lower.contains("how many")
-                                && (query_lower.contains("spend") || query_lower.contains("spent"))
+                                && (query_lower.contains("spend")
+                                    || query_lower.contains("spent"))
                                 && (query_lower.contains("hours")
                                     || query_lower.contains("days")
                                     || query_lower.contains("miles")));
@@ -3058,15 +3065,14 @@ impl MenteDB {
                                                     .join("\n");
 
                                                 if found_any {
-                                                    let is_money =
-                                                        query_lower.contains("money")
-                                                            || query_lower.contains("spend")
-                                                            || query_lower.contains("spent")
-                                                            || query_lower.contains("cost")
-                                                            || query_lower.contains("paid")
-                                                            || query_lower.contains("save")
-                                                            || query_lower.contains("earn")
-                                                            || query_lower.contains("raised");
+                                                    let is_money = query_lower.contains("money")
+                                                        || query_lower.contains("spend")
+                                                        || query_lower.contains("spent")
+                                                        || query_lower.contains("cost")
+                                                        || query_lower.contains("paid")
+                                                        || query_lower.contains("save")
+                                                        || query_lower.contains("earn")
+                                                        || query_lower.contains("raised");
                                                     let formatted_total = if is_money {
                                                         if total == total.floor() {
                                                             format!("${}", total as i64)
@@ -4577,7 +4583,8 @@ impl MenteDB {
     /// cache_hit, inference_actions, detected_actions, proactive_recalls,
     /// correction_id, sentiment, phantom_count, contradiction_count,
     /// predicted_topics, facts_extracted, edges_created.
-    #[pyo3(signature = (user_message, assistant_response=None, turn_id=0, project_context=None, agent_id=None))]
+    #[pyo3(signature = (user_message, assistant_response=None, turn_id=0, project_context=None, agent_id=None, session_id=None))]
+    #[allow(clippy::too_many_arguments)]
     fn process_turn(
         &self,
         py: Python<'_>,
@@ -4586,6 +4593,7 @@ impl MenteDB {
         turn_id: u64,
         project_context: Option<String>,
         agent_id: Option<&str>,
+        session_id: Option<String>,
     ) -> PyResult<PyObject> {
         let db = self
             .db
@@ -4603,6 +4611,7 @@ impl MenteDB {
             turn_id,
             project_context,
             agent_id: aid,
+            session_id,
         };
 
         let mut delta = self

--- a/sdks/typescript/Cargo.lock
+++ b/sdks/typescript/Cargo.lock
@@ -672,7 +672,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mentedb"
-version = "0.7.2"
+version = "0.10.4"
 dependencies = [
  "mentedb-cognitive",
  "mentedb-consolidation",
@@ -691,7 +691,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-cognitive"
-version = "0.7.2"
+version = "0.10.4"
 dependencies = [
  "ahash",
  "crossbeam",
@@ -706,7 +706,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-consolidation"
-version = "0.7.2"
+version = "0.10.4"
 dependencies = [
  "ahash",
  "mentedb-core",
@@ -717,7 +717,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-context"
-version = "0.7.2"
+version = "0.10.4"
 dependencies = [
  "ahash",
  "mentedb-core",
@@ -729,7 +729,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-core"
-version = "0.7.2"
+version = "0.10.4"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-embedding"
-version = "0.7.2"
+version = "0.10.4"
 dependencies = [
  "mentedb-core",
  "serde",
@@ -756,7 +756,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-extraction"
-version = "0.7.2"
+version = "0.10.4"
 dependencies = [
  "mentedb-cognitive",
  "mentedb-core",
@@ -772,7 +772,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-graph"
-version = "0.7.2"
+version = "0.10.4"
 dependencies = [
  "ahash",
  "bincode",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-index"
-version = "0.7.2"
+version = "0.10.4"
 dependencies = [
  "ahash",
  "bincode",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-query"
-version = "0.7.2"
+version = "0.10.4"
 dependencies = [
  "mentedb-core",
  "serde",
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-storage"
-version = "0.7.2"
+version = "0.10.4"
 dependencies = [
  "ahash",
  "bincode",

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -30,6 +30,8 @@ const result = await db.processTurn(
   "I prefer using TypeScript for backend services",
   "Noted! TypeScript is great for type-safe backends.",
   0 // turn_id
+  // optional: projectContext, agentId, sessionId (tags stored turns so
+  // injection recall can exclude the requesting session)
 );
 
 console.log(result.context);     // relevant memories

--- a/sdks/typescript/src/lib.rs
+++ b/sdks/typescript/src/lib.rs
@@ -1,9 +1,9 @@
 use std::path::Path;
 use std::sync::Mutex;
 
+use mentedb::CognitiveConfig;
 use mentedb::MenteDb;
 use mentedb::process_turn::ProcessTurnInput;
-use mentedb::CognitiveConfig;
 use mentedb_cognitive::stream::CognitionStream as RustCognitionStream;
 use mentedb_cognitive::trajectory::{
     DecisionState, TrajectoryNode, TrajectoryTracker as RustTrajectoryTracker,
@@ -345,6 +345,7 @@ impl MenteDB {
         turn_id: u32,
         project_context: Option<String>,
         agent_id: Option<String>,
+        session_id: Option<String>,
     ) -> Result<JsProcessTurnResult> {
         let aid = match agent_id {
             Some(ref s) => Some(parse_uuid(s)?),
@@ -357,6 +358,7 @@ impl MenteDB {
             turn_id: turn_id as u64,
             project_context,
             agent_id: aid,
+            session_id,
         };
 
         let mut delta = self
@@ -364,7 +366,10 @@ impl MenteDB {
             .lock()
             .map_err(|e| Error::from_reason(format!("lock poisoned: {e}")))?;
 
-        let result = self.inner.process_turn(&input, &mut delta).map_err(mente_err)?;
+        let result = self
+            .inner
+            .process_turn(&input, &mut delta)
+            .map_err(mente_err)?;
 
         Ok(JsProcessTurnResult {
             context: result
@@ -416,7 +421,11 @@ impl MenteDB {
             edges_created: result.edges_created,
             enrichment_pending: result.enrichment_pending,
             delta_added: result.delta_added.iter().map(|id| id.to_string()).collect(),
-            delta_removed: result.delta_removed.iter().map(|id| id.to_string()).collect(),
+            delta_removed: result
+                .delta_removed
+                .iter()
+                .map(|id| id.to_string())
+                .collect(),
         })
     }
 


### PR DESCRIPTION
## Summary
The Publish SDKs workflow failed to compile since ProcessTurnInput gained session_id: the PyO3 and napi bindings construct the struct directly and only compile in that workflow.

## Changes
- Both bindings accept an optional session_id and pass it through, exposing session provenance instead of defaulting it away
- READMEs note the new parameter

## Verification
- Both SDK crates compile with the new field
- Workflow rerun green after merge