### PR TITLE
fix: debian and arm linux installs (issue #87)

### DIFF
--- a/.github/workflows/publish-sdks.yml
+++ b/.github/workflows/publish-sdks.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -36,6 +36,9 @@ jobs:
           working-directory: sdks/python
           command: build
           args: --release
+          # Containerized manylinux build: without it the linux wheel gets
+          # tagged with the runner's glibc (2.39), shutting out older distros.
+          manylinux: auto
       - uses: actions/upload-artifact@v4
         with:
           name: wheels-${{ matrix.os }}
@@ -67,6 +70,9 @@ jobs:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             artifact: mentedb.linux-x64-gnu.node
+          - os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+            artifact: mentedb.linux-arm64-gnu.node
           - os: macos-latest
             target: aarch64-apple-darwin
             artifact: mentedb.darwin-arm64.node

--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ mentedb-server --data-dir ./data
 pip install mentedb
 ```
 
+On Debian and Ubuntu systems pip refuses system wide installs (PEP 668). Use a virtual environment or pipx:
+
+```bash
+python3 -m venv .venv && .venv/bin/pip install mentedb
+# or: pipx install mentedb
+```
+
 ### TypeScript SDK
 
 ```bash

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -25,6 +25,8 @@ changelog_include = ["mentedb-core", "mentedb-cognitive", "mentedb-consolidation
 name = "mentedb-replication"
 release = false
 
+# The server publishes so `cargo install mentedb-server` works as the
+# README documents.
 [[package]]
 name = "mentedb-server"
-release = false
+

--- a/sdks/python/Cargo.toml
+++ b/sdks/python/Cargo.toml
@@ -12,7 +12,7 @@ name = "mentedb_python"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.24", features = ["extension-module"] }
+pyo3 = { version = "0.24", features = ["extension-module", "abi3-py39"] }
 mentedb = { path = "../../crates/mentedb", features = ["enrichment"] }
 mentedb-core = { path = "../../crates/mentedb-core" }
 mentedb-storage = { path = "../../crates/mentedb-storage" }

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -20,6 +20,13 @@ maturin develop
 pip install mentedb
 ```
 
+On Debian and Ubuntu systems pip refuses system wide installs (PEP 668). Use a virtual environment or pipx:
+
+```bash
+python3 -m venv .venv && .venv/bin/pip install mentedb
+# or: pipx install mentedb
+```
+
 ## Quick start
 
 ```python

--- a/sdks/typescript/npm/client.ts
+++ b/sdks/typescript/npm/client.ts
@@ -11,6 +11,7 @@ import * as path from 'path';
 
 const PLATFORM_TRIPLES: Record<string, string> = {
   'linux-x64': 'linux-x64-gnu',
+    'linux-arm64': 'linux-arm64-gnu',
   'darwin-arm64': 'darwin-arm64',
   'darwin-x64': 'darwin-x64',
   'win32-x64': 'win32-x64-msvc',


### PR DESCRIPTION
## Summary
Fixes #87. Installs failed on Debian 13 and ARM Linux for three unrelated reasons, all reproduced in containers before fixing.

## Changes
- Python wheels build as abi3 (one wheel covers Python 3.9+) inside a manylinux container, instead of cp312 only with the runner's glibc 2.39 tag
- npm publish matrix adds aarch64 Linux on the ARM runner; the client maps the linux-arm64 triple
- mentedb-server now publishes to crates.io, so the README's `cargo install mentedb-server` works
- READMEs note Debian's PEP 668 (install in a venv or with pipx)

## Verification
- pip failure and npm ARM failure reproduced in debian trixie and node:22 containers before the fix
- npm x64 install works, abi3 build compiles, `cargo publish --dry-run` passes
- All workspace gates green