### PR TITLE
fix: vendored openssl for manylinux wheels

### DIFF
--- a/.github/workflows/publish-sdks.yml
+++ b/.github/workflows/publish-sdks.yml
@@ -39,12 +39,12 @@ jobs:
           # Containerized manylinux build: without it the linux wheel gets
           # tagged with the runner's glibc (2.39), shutting out older distros.
           manylinux: auto
-          # The manylinux image ships without OpenSSL headers, which
-          # openssl-sys needs (pulled in by the SDK's HTTP client).
+          # Vendored OpenSSL builds from source inside the container and
+          # needs perl with IPC::Cmd; system OpenSSL there is 1.0.2, too old.
           before-script-linux: |
-            if command -v dnf >/dev/null 2>&1; then dnf install -y openssl-devel perl-core
-            elif command -v yum >/dev/null 2>&1; then yum install -y openssl-devel perl-core
-            else apt-get update && apt-get install -y libssl-dev pkg-config
+            if command -v dnf >/dev/null 2>&1; then dnf install -y perl-core perl-IPC-Cmd
+            elif command -v yum >/dev/null 2>&1; then yum install -y perl-core perl-IPC-Cmd
+            else apt-get update && apt-get install -y perl make
             fi
       - uses: actions/upload-artifact@v4
         with:

--- a/sdks/python/Cargo.lock
+++ b/sdks/python/Cargo.lock
@@ -1439,7 +1439,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "mentedb-cognitive",
  "mentedb-consolidation",
@@ -1459,7 +1459,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-cognitive"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "ahash",
  "crossbeam",
@@ -1474,7 +1474,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-consolidation"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "ahash",
  "mentedb-core",
@@ -1485,7 +1485,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-context"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "ahash",
  "mentedb-core",
@@ -1497,7 +1497,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-core"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1512,7 +1512,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-embedding"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -1530,7 +1530,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-extraction"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "mentedb-cognitive",
  "mentedb-core",
@@ -1546,7 +1546,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-graph"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "ahash",
  "bincode",
@@ -1561,7 +1561,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-index"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "ahash",
  "bincode",
@@ -1590,6 +1590,7 @@ dependencies = [
  "mentedb-graph",
  "mentedb-index",
  "mentedb-storage",
+ "openssl-sys",
  "pyo3",
  "serde_json",
  "tokio",
@@ -1598,7 +1599,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-query"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "mentedb-core",
  "serde",
@@ -1609,7 +1610,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-storage"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "ahash",
  "bincode",
@@ -1812,6 +1813,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "openssl-src"
+version = "300.6.1+3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46eb8fb9fb3b61ce1c0f8a026c4c1a0714d3a9e138e7fbde78753ce2babc3846"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1819,6 +1829,7 @@ checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/sdks/python/Cargo.toml
+++ b/sdks/python/Cargo.toml
@@ -13,6 +13,9 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3 = { version = "0.24", features = ["extension-module", "abi3-py39"] }
+# Vendored so the manylinux wheel build never depends on the container's
+# system OpenSSL (manylinux2014 ships 1.0.2, too old for openssl-sys).
+openssl-sys = { version = "0.9", features = ["vendored"] }
 mentedb = { path = "../../crates/mentedb", features = ["enrichment"] }
 mentedb-core = { path = "../../crates/mentedb-core" }
 mentedb-storage = { path = "../../crates/mentedb-storage" }


### PR DESCRIPTION
## Summary
The wheel build still failed after installing openssl-devel: manylinux2014 ships OpenSSL 1.0.2, which openssl-sys cannot use.

## Changes
- openssl-sys builds vendored in the Python SDK, so the wheel never depends on the container's system OpenSSL
- The before script installs perl-core and perl-IPC-Cmd, which the vendored build needs

## Verification
- SDK compiles locally with the vendored feature
- The failed run's log confirmed openssl-devel installed successfully and was still too old, so vendoring is the durable fix