### PR TITLE
fix: resolve all open security alerts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2068,7 +2068,7 @@ dependencies = [
  "p256",
  "p384",
  "pem",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rsa",
  "serde",
  "serde_json",
@@ -2567,7 +2567,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "smallvec",
  "zeroize",
 ]
@@ -2737,15 +2737,14 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.78"
+version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
  "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -2769,9 +2768,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.114"
+version = "0.9.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
  "cc",
  "libc",
@@ -3206,9 +3205,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -3537,7 +3536,7 @@ dependencies = [
  "borsh",
  "bytes",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rkyv",
  "serde",
  "serde_json",

--- a/sdks/python/Cargo.lock
+++ b/sdks/python/Cargo.lock
@@ -1270,15 +1270,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indoc"
-version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1426,15 +1417,6 @@ checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
 dependencies = [
  "libc",
  "stable_deref_trait",
-]
-
-[[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
 ]
 
 [[package]]
@@ -1782,15 +1764,14 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.78"
+version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
  "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -1823,9 +1804,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.114"
+version = "0.9.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
  "cc",
  "libc",
@@ -1961,37 +1942,32 @@ checksum = "40e24eee682d89fb193496edf918a7f407d30175b2e785fe057e4392dfd182e0"
 
 [[package]]
 name = "pyo3"
-version = "0.24.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17da310086b068fbdcefbba30aeb3721d5bb9af8db4987d6735b2183ca567229"
+checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
 dependencies = [
- "cfg-if",
- "indoc",
  "libc",
- "memoffset",
  "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent",
 ]
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.24.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e27165889bd793000a098bb966adc4300c312497ea25cf7a690a9f0ac5aa5fc1"
+checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
 dependencies = [
- "once_cell",
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.24.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05280526e1dbf6b420062f3ef228b78c0c54ba94e157f5cb724a609d0f2faabc"
+checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1999,9 +1975,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.24.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c3ce5686aa4d3f63359a5100c62a127c9f15e8398e5fdeb5deef1fed5cd5f44"
+checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -2011,13 +1987,12 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.24.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4cf6faa0cbfb0ed08e89beb8103ae9724eb4750e3a78084ba4017cbe94f3855"
+checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn",
 ]
@@ -3035,12 +3010,6 @@ name = "unicode_categories"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
-
-[[package]]
-name = "unindent"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "untrusted"

--- a/sdks/python/Cargo.toml
+++ b/sdks/python/Cargo.toml
@@ -12,7 +12,7 @@ name = "mentedb_python"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.24", features = ["extension-module", "abi3-py39"] }
+pyo3 = { version = "0.29", features = ["extension-module", "abi3-py39"] }
 # Vendored so the manylinux wheel build never depends on the container's
 # system OpenSSL (manylinux2014 ships 1.0.2, too old for openssl-sys).
 openssl-sys = { version = "0.9", features = ["vendored"] }

--- a/sdks/typescript/Cargo.lock
+++ b/sdks/typescript/Cargo.lock
@@ -672,7 +672,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mentedb"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "mentedb-cognitive",
  "mentedb-consolidation",
@@ -691,7 +691,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-cognitive"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "ahash",
  "crossbeam",
@@ -706,7 +706,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-consolidation"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "ahash",
  "mentedb-core",
@@ -717,7 +717,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-context"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "ahash",
  "mentedb-core",
@@ -729,7 +729,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-core"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-embedding"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "mentedb-core",
  "serde",
@@ -756,7 +756,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-extraction"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "mentedb-cognitive",
  "mentedb-core",
@@ -772,7 +772,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-graph"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "ahash",
  "bincode",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-index"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "ahash",
  "bincode",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-query"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "mentedb-core",
  "serde",
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-storage"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "ahash",
  "bincode",


### PR DESCRIPTION
## Summary
Clears all nine open Dependabot security alerts: openssl (1 high, 4 medium across both lockfiles), pyo3 (1 high, 1 medium), and rand (1 low).

## Changes
- openssl 0.10.78 to 0.10.81 in the workspace, Python SDK, and TypeScript SDK lockfiles (X509 undefined behavior, AES heap overflow, cipher_update out of bounds write)
- pyo3 0.24 to 0.29 in the Python SDK (PyList out of bounds read, missing Sync bound on new_closure); the migration was mechanical: PyObject to Py<PyAny>, with_gil to attach, allow_threads to detach
- rand 0.8.5 to 0.8.6 (unsound custom logger interaction)

## Verification
- Workspace gates green (580 tests), both SDKs compile and pass clippy with the new versions, abi3 wheel build unaffected