### PR TITLE
feat: agent scoped retrieval (issue #88)

### DIFF
--- a/crates/mentedb-core/src/types.rs
+++ b/crates/mentedb-core/src/types.rs
@@ -23,6 +23,11 @@ macro_rules! define_id {
             pub fn nil() -> Self {
                 Self(Uuid::nil())
             }
+
+            /// True for the nil (all-zeros) identifier.
+            pub fn is_nil(&self) -> bool {
+                self.0.is_nil()
+            }
         }
 
         impl Default for $name {

--- a/crates/mentedb/src/injection.rs
+++ b/crates/mentedb/src/injection.rs
@@ -27,7 +27,7 @@ use std::collections::HashSet;
 
 use mentedb_core::error::MenteResult;
 use mentedb_core::memory::{AttributeValue, MemoryNode, MemoryType};
-use mentedb_core::types::MemoryId;
+use mentedb_core::types::{AgentId, MemoryId};
 
 use crate::MenteDb;
 
@@ -85,6 +85,9 @@ pub struct InjectionQuery<'a> {
     pub max_items: usize,
     /// Maximum verbatim episodic items within `max_items`.
     pub max_episodic: usize,
+    /// Restrict recall to this agent's memories plus shared (nil owned)
+    /// knowledge. None recalls globally.
+    pub agent_id: Option<AgentId>,
 }
 
 /// Why an item was selected, for introspection and client display.
@@ -179,13 +182,15 @@ impl MenteDb {
 
         // Candidate pool from hybrid recall.
         let hits = self
-            .recall_hybrid_at(
+            .recall_hybrid_scoped_at_mode(
                 query.embedding,
                 query.query_text,
                 cfg.candidate_pool,
                 now_us(),
                 None,
+                false,
                 None,
+                query.agent_id,
             )
             .unwrap_or_default();
 
@@ -277,6 +282,7 @@ impl MenteDb {
             if let Ok(node) = self.storage.load_memory(pid)
                 && has_tag(&node, "scope:always")
                 && !excluded.contains(&node.id)
+                && crate::agent_visible(node.agent_id, query.agent_id)
             {
                 result.push(InjectionCandidate {
                     node,

--- a/crates/mentedb/src/lib.rs
+++ b/crates/mentedb/src/lib.rs
@@ -63,7 +63,7 @@ use mentedb_context::{AssemblyConfig, ContextAssembler, ContextWindow, ScoredMem
 use mentedb_core::edge::EdgeType;
 use mentedb_core::error::MenteResult;
 use mentedb_core::memory::MemoryType;
-use mentedb_core::types::{MemoryId, Timestamp};
+use mentedb_core::types::{AgentId, MemoryId, Timestamp};
 use mentedb_core::{MemoryEdge, MemoryNode, MenteError};
 use mentedb_embedding::provider::EmbeddingProvider;
 use mentedb_graph::GraphManager;
@@ -326,6 +326,16 @@ pub struct MenteDb {
     last_enrichment_turn: RwLock<u64>,
     /// Whether enrichment is currently pending (set by maintenance trigger).
     enrichment_pending: RwLock<bool>,
+}
+
+/// Agent visibility rule for scoped retrieval: a node is visible to an agent
+/// when it is owned by that agent or owned by no agent (nil, shared
+/// knowledge). No scope means global visibility.
+pub(crate) fn agent_visible(owner: AgentId, scope: Option<AgentId>) -> bool {
+    match scope {
+        None => true,
+        Some(a) => owner == a || owner.is_nil(),
+    }
 }
 
 impl MenteDb {
@@ -650,6 +660,27 @@ impl MenteDb {
         tags_or: bool,
         time_range: Option<(Timestamp, Timestamp)>,
     ) -> MenteResult<Vec<(MemoryId, f32)>> {
+        self.recall_hybrid_scoped_at_mode(
+            embedding, query_text, k, at, tags, tags_or, time_range, None,
+        )
+    }
+
+    /// Hybrid recall visible to one agent: nodes owned by `agent` or owned
+    /// by no agent (nil, shared knowledge) pass; other agents' memories are
+    /// invisible. `agent: None` recalls globally, preserving single agent
+    /// behavior.
+    #[allow(clippy::too_many_arguments)]
+    pub fn recall_hybrid_scoped_at_mode(
+        &self,
+        embedding: &[f32],
+        query_text: Option<&str>,
+        k: usize,
+        at: Timestamp,
+        tags: Option<&[&str]>,
+        tags_or: bool,
+        time_range: Option<(Timestamp, Timestamp)>,
+        agent: Option<AgentId>,
+    ) -> MenteResult<Vec<(MemoryId, f32)>> {
         debug!(
             "Recall hybrid, k={}, at={}, bm25={}, tags_or={}",
             k,
@@ -682,7 +713,7 @@ impl MenteDb {
                 if let Some(&page_id) = pm.get(id)
                     && let Ok(node) = self.storage.load_memory(page_id)
                 {
-                    node.is_valid_at(at)
+                    node.is_valid_at(at) && agent_visible(node.agent_id, agent)
                 } else {
                     true
                 }

--- a/crates/mentedb/src/process_turn.rs
+++ b/crates/mentedb/src/process_turn.rs
@@ -233,8 +233,12 @@ impl MenteDb {
         let query_embedding = self.embed_or_empty(&input.user_message)?;
 
         // §1b: Try speculative cache, fall back to hybrid search
-        let (context, current_ids, cache_hit) =
-            self.retrieve_context(&input.user_message, &query_embedding, delta_tracker)?;
+        let (context, current_ids, cache_hit) = self.retrieve_context(
+            &input.user_message,
+            &query_embedding,
+            input.agent_id.map(AgentId),
+            delta_tracker,
+        )?;
 
         // §2: Pain signals
         let pain_warnings = self.check_pain_signals(&input.user_message);
@@ -329,6 +333,7 @@ impl MenteDb {
         &self,
         user_message: &str,
         query_embedding: &[f32],
+        agent: Option<AgentId>,
         _delta_tracker: &DeltaTracker,
     ) -> crate::MenteResult<(Vec<ScoredMemory>, Vec<MemoryId>, bool)> {
         // Try speculative cache first
@@ -336,11 +341,11 @@ impl MenteDb {
             let matched: Vec<ScoredMemory> = entry
                 .memory_ids
                 .iter()
-                .filter_map(|id| {
-                    self.get_memory(*id).ok().map(|m| ScoredMemory {
-                        memory: m,
-                        score: 0.9,
-                    })
+                .filter_map(|id| self.get_memory(*id).ok())
+                .filter(|m| crate::agent_visible(m.agent_id, agent))
+                .map(|m| ScoredMemory {
+                    memory: m,
+                    score: 0.9,
                 })
                 .collect();
             if matched.len() >= entry.memory_ids.len() / 2 {
@@ -351,8 +356,16 @@ impl MenteDb {
 
         // Hybrid search fallback
         let now = now_us();
-        let results =
-            self.recall_hybrid_at(query_embedding, Some(user_message), 10, now, None, None)?;
+        let results = self.recall_hybrid_scoped_at_mode(
+            query_embedding,
+            Some(user_message),
+            10,
+            now,
+            None,
+            false,
+            None,
+            agent,
+        )?;
         let mut scored: Vec<ScoredMemory> = results
             .iter()
             .filter_map(|(mid, score)| {
@@ -372,6 +385,7 @@ impl MenteDb {
             if let Ok(mem) = self.storage.load_memory(*pid)
                 && mem.tags.iter().any(|t| t == always_scope_tag)
                 && !hybrid_ids.contains(&mem.id)
+                && crate::agent_visible(mem.agent_id, agent)
             {
                 scored.push(ScoredMemory {
                     memory: mem,

--- a/crates/mentedb/tests/agent_isolation.rs
+++ b/crates/mentedb/tests/agent_isolation.rs
@@ -1,0 +1,207 @@
+//! Agent scoped retrieval: memories owned by one agent are invisible to
+//! another agent's recall, injection, and turn context, while nil owned
+//! (shared) memories stay visible to everyone. No scope means global
+//! visibility, preserving single agent behavior.
+
+use mentedb::CognitiveConfig;
+use mentedb::MenteDb;
+use mentedb::injection::InjectionQuery;
+use mentedb::prelude::*;
+use mentedb::process_turn::ProcessTurnInput;
+use mentedb_context::DeltaTracker;
+use uuid::Uuid;
+
+fn open_db() -> (MenteDb, tempfile::TempDir) {
+    let dir = tempfile::tempdir().unwrap();
+    let db = MenteDb::open_with_config(dir.path(), CognitiveConfig::default()).unwrap();
+    (db, dir)
+}
+
+fn vec_for(axis: usize) -> Vec<f32> {
+    // Well separated directions: near coincident vectors can orphan HNSW
+    // nodes (a known indexing quirk), and with only a handful of nodes any
+    // reachable node is returned, so distance does not matter here.
+    let mut v = vec![0.1_f32; 8];
+    v[axis] = 1.0;
+    v
+}
+
+fn store_owned(db: &MenteDb, agent: AgentId, content: &str, topic: usize) -> MemoryId {
+    let node = MemoryNode::new(
+        agent,
+        MemoryType::Semantic,
+        content.to_string(),
+        vec_for(topic),
+    );
+    let id = node.id;
+    db.store(node).unwrap();
+    id
+}
+
+fn now_us() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_micros() as u64
+}
+
+#[test]
+fn scoped_recall_isolates_agents() {
+    let (db, _dir) = open_db();
+    let coder = AgentId::new();
+    let researcher = AgentId::new();
+
+    let coder_mem = store_owned(&db, coder, "the payment service uses rust and axum", 0);
+    let researcher_mem = store_owned(
+        &db,
+        researcher,
+        "the survey paper covers rust memory models",
+        1,
+    );
+    let shared = store_owned(
+        &db,
+        AgentId::nil(),
+        "the team standup about rust happens at nine",
+        2,
+    );
+
+    let query = vec_for(0);
+
+    // Scoped to the coder: own memory plus shared, never the researcher's.
+    let hits = db
+        .recall_hybrid_scoped_at_mode(
+            &query,
+            Some("rust"),
+            10,
+            now_us(),
+            None,
+            false,
+            None,
+            Some(coder),
+        )
+        .unwrap();
+    let ids: Vec<MemoryId> = hits.iter().map(|(id, _)| *id).collect();
+    assert!(ids.contains(&coder_mem), "agent must see its own memory");
+    assert!(
+        ids.contains(&shared),
+        "agent must see shared nil owned memory"
+    );
+    assert!(
+        !ids.contains(&researcher_mem),
+        "agent must not see another agent's memory"
+    );
+
+    // No scope: global visibility, everything is recallable.
+    let hits = db
+        .recall_hybrid_scoped_at_mode(&query, Some("rust"), 10, now_us(), None, false, None, None)
+        .unwrap();
+    let ids: Vec<MemoryId> = hits.iter().map(|(id, _)| *id).collect();
+    assert!(ids.contains(&coder_mem));
+    assert!(ids.contains(&researcher_mem));
+    assert!(ids.contains(&shared));
+}
+
+#[test]
+fn process_turn_context_is_agent_scoped() {
+    let (db, _dir) = open_db();
+    let mut delta = DeltaTracker::new();
+    let coder = Uuid::new_v4();
+    let researcher = Uuid::new_v4();
+
+    // The coder learns something in its own turns.
+    let input = ProcessTurnInput {
+        user_message: "our deployment pipeline uses blue green releases".to_string(),
+        assistant_response: Some("noted, blue green it is".to_string()),
+        turn_id: 0,
+        project_context: None,
+        agent_id: Some(coder),
+        session_id: None,
+    };
+    db.process_turn(&input, &mut delta).unwrap();
+
+    // The researcher asks about the same topic under its own identity.
+    let input = ProcessTurnInput {
+        user_message: "what do we know about deployment pipelines".to_string(),
+        assistant_response: None,
+        turn_id: 1,
+        project_context: None,
+        agent_id: Some(researcher),
+        session_id: None,
+    };
+    let result = db.process_turn(&input, &mut delta).unwrap();
+    assert!(
+        result
+            .context
+            .iter()
+            .all(|c| !c.memory.content.contains("blue green")),
+        "another agent's turns must not leak into context"
+    );
+
+    // An unscoped turn still sees everything.
+    let input = ProcessTurnInput {
+        user_message: "what do we know about deployment pipelines".to_string(),
+        assistant_response: None,
+        turn_id: 2,
+        project_context: None,
+        agent_id: None,
+        session_id: None,
+    };
+    let result = db.process_turn(&input, &mut delta).unwrap();
+    assert!(
+        result
+            .context
+            .iter()
+            .any(|c| c.memory.content.contains("blue green")),
+        "unscoped turns keep global visibility"
+    );
+}
+
+#[test]
+fn injection_respects_agent_scope() {
+    let (db, _dir) = open_db();
+    let coder = AgentId::new();
+    let researcher = AgentId::new();
+
+    // A pinned rule owned by the researcher, one owned by nobody.
+    let emb = vec_for(3);
+    let mut theirs = MemoryNode::new(
+        researcher,
+        MemoryType::Procedural,
+        "researcher only: cite every claim".to_string(),
+        emb.clone(),
+    );
+    theirs.tags = vec!["scope:always".to_string()];
+    db.store(theirs).unwrap();
+
+    let mut shared = MemoryNode::new(
+        AgentId::nil(),
+        MemoryType::Procedural,
+        "everyone: never commit secrets".to_string(),
+        emb,
+    );
+    shared.tags = vec!["scope:always".to_string()];
+    db.store(shared).unwrap();
+
+    let query_emb = vec_for(3);
+    let selected = db
+        .recall_for_injection(&InjectionQuery {
+            embedding: &query_emb,
+            query_text: Some("what are the rules"),
+            session_id: None,
+            exclude_ids: &[],
+            max_items: 6,
+            max_episodic: 2,
+            agent_id: Some(coder),
+        })
+        .unwrap();
+
+    let contents: Vec<&str> = selected.iter().map(|c| c.node.content.as_str()).collect();
+    assert!(
+        contents.iter().any(|c| c.contains("never commit secrets")),
+        "shared pinned memories inject for every agent"
+    );
+    assert!(
+        !contents.iter().any(|c| c.contains("researcher only")),
+        "another agent's pinned memories must not inject"
+    );
+}


### PR DESCRIPTION
## Summary
Implements the retrieval half of #88. Every memory already carries agent_id at storage time, but recall, injection, turn context, and the speculative cache were agent blind, so agents sharing an instance contaminated each other's context.

## Changes
- recall_hybrid_scoped_at_mode: hybrid recall visible to one agent (own memories plus nil owned shared knowledge); existing recall APIs delegate unchanged
- InjectionQuery gains agent_id; scoped candidates and pinned scope:always selection both respect it
- process_turn with an agent_id now retrieves context, pinned rules, and speculative cache hits scoped to that agent; omitting agent_id keeps global visibility, so single agent deployments are unchanged
- is_nil helper on id types

## Verification
- New agent_isolation test suite: scoped recall isolation, cross agent turn context isolation, pinned rule isolation, and unscoped global visibility all covered
- Full workspace gates green