### PR TITLE
fix: integration tests for the InjectionQuery field

### DIFF
--- a/crates/mentedb/tests/integration.rs
+++ b/crates/mentedb/tests/integration.rs
@@ -1486,6 +1486,7 @@ mod injection_attention {
             exclude_ids: &[ledgered_id],
             max_items: 6,
             max_episodic: 2,
+            agent_id: None,
         };
         let out = db.recall_for_injection(&query).unwrap();
 
@@ -1569,6 +1570,7 @@ mod injection_attention {
             exclude_ids: &[],
             max_items: 1,
             max_episodic: 0,
+            agent_id: None,
         };
         let out = db.recall_for_injection(&query).unwrap();
         let relevant: Vec<_> = out


### PR DESCRIPTION
## Summary
Main CI broke after the agent scoping merge: two InjectionQuery literals in the integration suite were missing the new agent_id field. My pre merge gate piped cargo test through tail, which masked the failing exit code; gates now run with pipefail.

## Changes
- Both integration test literals set agent_id: None (global visibility, matching their original behavior)

## Verification
- Full workspace test run green with pipefail enabled