### PR TITLE
perf: hot flushes checkpoint only

### DIFF
--- a/crates/mentedb-index/src/hnsw.rs
+++ b/crates/mentedb-index/src/hnsw.rs
@@ -661,6 +661,26 @@ impl HnswIndex {
     }
 
     /// Mark a node as deleted (tombstone). Does not reclaim memory.
+    /// True when the id is indexed and not tombstoned.
+    pub fn contains(&self, id: MemoryId) -> bool {
+        let inner = self.inner.read();
+        match inner.id_to_idx.get(&id) {
+            Some(idx) => !inner.deleted.contains(idx),
+            None => false,
+        }
+    }
+
+    /// All live (non tombstoned) memory ids in the index.
+    pub fn ids(&self) -> Vec<MemoryId> {
+        let inner = self.inner.read();
+        inner
+            .id_to_idx
+            .iter()
+            .filter(|(_, idx)| !inner.deleted.contains(*idx))
+            .map(|(id, _)| *id)
+            .collect()
+    }
+
     pub fn remove(&self, id: MemoryId) -> MenteResult<()> {
         let mut inner = self.inner.write();
         let idx = inner

--- a/crates/mentedb-index/src/manager.rs
+++ b/crates/mentedb-index/src/manager.rs
@@ -118,6 +118,23 @@ impl IndexManager {
         self.salience.insert(node.id, node.salience);
     }
 
+    /// True when the memory's vector is indexed and live.
+    pub fn contains_vector(&self, id: MemoryId) -> bool {
+        self.hnsw.contains(id)
+    }
+
+    /// All live vector indexed memory ids.
+    pub fn vector_ids(&self) -> Vec<MemoryId> {
+        self.hnsw.ids()
+    }
+
+    /// Tombstone a vector whose backing page no longer exists; used by open
+    /// time reconciliation when a snapshot is newer than the last forget.
+    pub fn remove_vector_only(&self, id: MemoryId) {
+        let _ = self.hnsw.remove(id);
+        self.bm25.remove(id);
+    }
+
     /// Remove a memory from all indexes.
     pub fn remove_memory(&self, id: MemoryId, node: &MemoryNode) {
         let _ = self.hnsw.remove(id);

--- a/crates/mentedb/src/lib.rs
+++ b/crates/mentedb/src/lib.rs
@@ -249,6 +249,11 @@ pub struct CognitiveConfig {
     pub pain_max_warnings: usize,
     /// Configuration for injection attention selection.
     pub injection_config: injection::InjectionConfig,
+    /// How many hot flushes may pass before index and graph snapshots are
+    /// rewritten. Durability comes from the WAL checkpoint on every flush;
+    /// snapshots only accelerate reopen, and open reconciles stale ones, so
+    /// rewriting them per flush just multiplies fsync cost.
+    pub flush_snapshot_interval: u32,
 }
 
 impl Default for CognitiveConfig {
@@ -272,6 +277,7 @@ impl Default for CognitiveConfig {
             speculative_cache_size: 10,
             pain_max_warnings: 5,
             injection_config: injection::InjectionConfig::default(),
+            flush_snapshot_interval: 8,
         }
     }
 }
@@ -290,6 +296,8 @@ pub struct MenteDb {
     graph: GraphManager,
     /// Maps memory IDs to their storage page IDs for retrieval.
     page_map: RwLock<HashMap<MemoryId, PageId>>,
+    /// Hot flushes since the last snapshot write; see flush_snapshot_interval.
+    flushes_since_snapshot: std::sync::atomic::AtomicU32,
     /// Expected embedding dimension (0 = no validation).
     embedding_dim: usize,
     /// Database directory path for persistence.
@@ -382,6 +390,31 @@ impl MenteDb {
             }
         }
 
+        // Snapshots are written every few flushes, not every flush, so they
+        // can trail storage. Heal both directions: index memories the
+        // snapshot missed, and tombstone vectors whose pages are gone
+        // (forgotten after the last snapshot).
+        let mut reindexed = 0usize;
+        for (memory_id, page_id) in &page_map {
+            if !index.contains_vector(*memory_id)
+                && let Ok(node) = storage.load_memory(*page_id)
+                && !node.embedding.is_empty()
+            {
+                index.index_memory(&node);
+                reindexed += 1;
+            }
+        }
+        let mut retired = 0usize;
+        for id in index.vector_ids() {
+            if !page_map.contains_key(&id) {
+                index.remove_vector_only(id);
+                retired += 1;
+            }
+        }
+        if reindexed > 0 || retired > 0 {
+            info!(reindexed, retired, "reconciled index with storage");
+        }
+
         let write_inference =
             WriteInferenceEngine::with_config(cognitive_config.inference_config.clone());
         let decay = DecayEngine::new(cognitive_config.decay_config.clone());
@@ -422,6 +455,7 @@ impl MenteDb {
             index,
             graph,
             page_map: RwLock::new(page_map),
+            flushes_since_snapshot: std::sync::atomic::AtomicU32::new(0),
             embedding_dim: 0,
             path: path.to_path_buf(),
             embedder: None,
@@ -1251,7 +1285,7 @@ impl MenteDb {
     /// Flushes all data and closes the database.
     pub fn close(&self) -> MenteResult<()> {
         info!("Closing MenteDB");
-        self.flush()?;
+        self.flush_full()?;
         self.storage.close()?;
         Ok(())
     }
@@ -1291,9 +1325,35 @@ impl MenteDb {
     /// Unlike `close()`, the database remains usable after flushing.
     pub fn flush(&self) -> MenteResult<()> {
         debug!("Flushing MenteDB to disk");
+        // Durability is the WAL checkpoint, paid on every flush. Index,
+        // graph, and cognitive snapshots only accelerate reopen (open
+        // reconciles stale ones against storage), so they are amortized
+        // across flush_snapshot_interval hot flushes instead of multiplying
+        // fsync cost on every write batch.
+        self.storage.checkpoint()?;
+
+        let n = self
+            .flushes_since_snapshot
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+            + 1;
+        if n >= self.cognitive_config.flush_snapshot_interval {
+            self.write_snapshots()?;
+        }
+        Ok(())
+    }
+
+    /// Flush everything including index, graph, and cognitive snapshots.
+    /// Used by close and by maintenance, where reopen speed matters more
+    /// than write latency.
+    pub fn flush_full(&self) -> MenteResult<()> {
+        debug!("Full flush of MenteDB to disk");
+        self.storage.checkpoint()?;
+        self.write_snapshots()
+    }
+
+    fn write_snapshots(&self) -> MenteResult<()> {
         self.index.save(&self.path.join("indexes"))?;
         self.graph.save(&self.path.join("graph"))?;
-        self.storage.checkpoint()?;
 
         // Persist cognitive subsystem state.
         let cognitive_dir = self.path.join("cognitive");
@@ -1312,6 +1372,8 @@ impl MenteDb {
                 .read()
                 .save(&cognitive_dir.join("entities.json"));
         }
+        self.flushes_since_snapshot
+            .store(0, std::sync::atomic::Ordering::Relaxed);
         Ok(())
     }
 

--- a/crates/mentedb/tests/snapshot_amortization.rs
+++ b/crates/mentedb/tests/snapshot_amortization.rs
@@ -1,0 +1,112 @@
+//! Hot flushes checkpoint the WAL only; index and graph snapshots are
+//! rewritten every flush_snapshot_interval flushes (and always on close).
+//! Open reconciles stale snapshots against storage in both directions, so a
+//! crash between snapshot writes never loses recall and never resurrects
+//! forgotten memories into the index.
+
+use mentedb::CognitiveConfig;
+use mentedb::MenteDb;
+use mentedb::prelude::*;
+
+fn vec_for(axis: usize) -> Vec<f32> {
+    let mut v = vec![0.1_f32; 8];
+    v[axis] = 1.0;
+    v
+}
+
+fn store(db: &MenteDb, content: &str, axis: usize) -> MemoryId {
+    let node = MemoryNode::new(
+        AgentId::nil(),
+        MemoryType::Semantic,
+        content.to_string(),
+        vec_for(axis),
+    );
+    let id = node.id;
+    db.store(node).unwrap();
+    id
+}
+
+fn now_us() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_micros() as u64
+}
+
+fn recall_ids(db: &MenteDb, axis: usize) -> Vec<MemoryId> {
+    db.recall_hybrid_at(&vec_for(axis), None, 10, now_us(), None, None)
+        .unwrap()
+        .into_iter()
+        .map(|(id, _)| id)
+        .collect()
+}
+
+#[test]
+fn recall_survives_crash_between_snapshots() {
+    let dir = tempfile::tempdir().unwrap();
+    let id;
+    {
+        let db = MenteDb::open_with_config(dir.path(), CognitiveConfig::default()).unwrap();
+        // Establish snapshots once so they exist, then go stale.
+        db.flush_full().unwrap();
+        id = store(&db, "stored after the last snapshot", 0);
+        // Hot flush: WAL checkpoint only, snapshots untouched.
+        db.flush().unwrap();
+        db.simulate_crash();
+    }
+    let db = MenteDb::open_with_config(dir.path(), CognitiveConfig::default()).unwrap();
+    assert!(
+        recall_ids(&db, 0).contains(&id),
+        "open must reindex memories the stale snapshot missed"
+    );
+}
+
+#[test]
+fn forgotten_memory_stays_gone_despite_newer_snapshot() {
+    let dir = tempfile::tempdir().unwrap();
+    let id;
+    {
+        let db = MenteDb::open_with_config(dir.path(), CognitiveConfig::default()).unwrap();
+        id = store(&db, "will be forgotten", 1);
+        // Snapshot contains the memory.
+        db.flush_full().unwrap();
+        // Forget afterwards, hot flush only: the snapshot still has it.
+        db.forget(id).unwrap();
+        db.flush().unwrap();
+        db.simulate_crash();
+    }
+    let db = MenteDb::open_with_config(dir.path(), CognitiveConfig::default()).unwrap();
+    assert!(
+        !recall_ids(&db, 1).contains(&id),
+        "open must retire vectors whose pages are gone"
+    );
+    assert!(
+        db.get_memory(id).is_err(),
+        "the memory itself stays deleted"
+    );
+}
+
+#[test]
+fn snapshots_write_on_the_configured_interval() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = CognitiveConfig {
+        flush_snapshot_interval: 3,
+        ..CognitiveConfig::default()
+    };
+    let db = MenteDb::open_with_config(dir.path(), config).unwrap();
+    store(&db, "first", 2);
+    db.flush_full().unwrap();
+
+    let hnsw = dir.path().join("indexes").join("hnsw.bin");
+    let before = std::fs::metadata(&hnsw).unwrap().modified().unwrap();
+
+    store(&db, "second", 3);
+    db.flush().unwrap();
+    db.flush().unwrap();
+    let mid = std::fs::metadata(&hnsw).unwrap().modified().unwrap();
+    assert_eq!(before, mid, "snapshots must not rewrite on hot flushes");
+
+    db.flush().unwrap();
+    let after = std::fs::metadata(&hnsw).unwrap().modified().unwrap();
+    assert!(after > before, "the Nth flush must rewrite snapshots");
+}


### PR DESCRIPTION
## Summary
Every flush rewrote the HNSW, graph, and cognitive snapshots plus the WAL checkpoint: six or more sequential fsyncs per write batch, measured at roughly 0.5s fixed cost per store call on EFS. Durability only needs the checkpoint; snapshots just accelerate reopen.

## Changes
- flush() checkpoints the WAL every time and rewrites snapshots only every flush_snapshot_interval hot flushes (config, default 8)
- flush_full() writes everything; close() uses it
- open() reconciles stale snapshots in both directions: reindexes memories the snapshot missed and retires vectors whose pages are gone, so a crash between snapshot writes neither loses recall nor resurrects forgotten memories
- New index APIs: contains_vector, vector_ids, remove_vector_only

## Verification
- New snapshot_amortization suite: recall survives a crash between snapshots, forgotten memories stay gone despite a newer snapshot, snapshots write exactly on the configured interval
- Full workspace gates green with pipefail