### PR TITLE
fix: speculative ghosts stay out of injected context

### DIFF
--- a/crates/mentedb/src/injection.rs
+++ b/crates/mentedb/src/injection.rs
@@ -202,8 +202,14 @@ impl MenteDb {
             let Ok(node) = self.get_memory(id) else {
                 continue;
             };
-            if has_tag(&node, "action") || has_tag(&node, "scope:always") {
+            if has_tag(&node, "action")
+                || has_tag(&node, "scope:always")
+                || has_tag(&node, "ghost-memory")
+            {
                 // Actions never inject; pinned items are handled separately.
+                // Ghost memories are speculative working material for the
+                // trajectory tracker, not confirmed knowledge; injecting
+                // "Unconfirmed: ..." as if it were a fact misleads.
                 continue;
             }
             if let Some(ref st) = session_tag

--- a/crates/mentedb/tests/agent_isolation.rs
+++ b/crates/mentedb/tests/agent_isolation.rs
@@ -205,3 +205,39 @@ fn injection_respects_agent_scope() {
         "another agent's pinned memories must not inject"
     );
 }
+
+#[test]
+fn ghost_memories_never_inject() {
+    let (db, _dir) = open_db();
+    let mut ghost = MemoryNode::new(
+        AgentId::nil(),
+        MemoryType::Semantic,
+        "Unconfirmed: maybe we should rewrite everything in zig".to_string(),
+        vec_for(4),
+    );
+    ghost.tags = vec!["ghost-memory".to_string(), "unconfirmed".to_string()];
+    db.store(ghost).unwrap();
+
+    let real = store_owned(&db, AgentId::nil(), "the api uses axum", 4);
+
+    let selected = db
+        .recall_for_injection(&InjectionQuery {
+            embedding: &vec_for(4),
+            query_text: Some("what about the architecture"),
+            session_id: None,
+            exclude_ids: &[],
+            max_items: 6,
+            max_episodic: 2,
+            agent_id: None,
+        })
+        .unwrap();
+    let contents: Vec<&str> = selected.iter().map(|c| c.node.content.as_str()).collect();
+    assert!(
+        !contents.iter().any(|c| c.starts_with("Unconfirmed:")),
+        "speculative ghosts must not inject as knowledge"
+    );
+    assert!(
+        selected.iter().any(|c| c.node.id == real),
+        "real memories still inject"
+    );
+}


### PR DESCRIPTION
## Summary
Ghost memories (Unconfirmed: speculative content stored at low confidence for the trajectory tracker) were injecting into context like confirmed facts, surfacing lines like "Unconfirmed: you are working on the rest?" as recalled knowledge.

## Changes
- Injection candidate selection skips ghost-memory tagged nodes, alongside the existing action and pinned exclusions

## Verification
- New test: a ghost and a real memory on the same topic; injection returns the real one and never the ghost
- Full workspace gates green with pipefail