### PR TITLE
feat: shutdown fast enough for zero downtime deploys

### DIFF
--- a/crates/mentedb/src/lib.rs
+++ b/crates/mentedb/src/lib.rs
@@ -1290,6 +1290,17 @@ impl MenteDb {
         Ok(())
     }
 
+    /// Close with durability only: checkpoint the WAL and release the
+    /// process lock without rewriting snapshots. Reopen reconciles stale
+    /// snapshots, so this trades a slower next open for a shutdown fast
+    /// enough to release every user's lock inside a deploy drain window.
+    pub fn close_quick(&self) -> MenteResult<()> {
+        info!("Quick closing MenteDB");
+        self.storage.checkpoint()?;
+        self.storage.close()?;
+        Ok(())
+    }
+
     /// Simulate a process crash for tests: releases the storage process lock
     /// exactly as the operating system would when a process dies, then drops
     /// the instance without flushing or closing anything.

--- a/crates/mentedb/tests/snapshot_amortization.rs
+++ b/crates/mentedb/tests/snapshot_amortization.rs
@@ -110,3 +110,21 @@ fn snapshots_write_on_the_configured_interval() {
     let after = std::fs::metadata(&hnsw).unwrap().modified().unwrap();
     assert!(after > before, "the Nth flush must rewrite snapshots");
 }
+
+#[test]
+fn quick_close_survives_reopen_with_full_recall() {
+    let dir = tempfile::tempdir().unwrap();
+    let id;
+    {
+        let db = MenteDb::open_with_config(dir.path(), CognitiveConfig::default()).unwrap();
+        db.flush_full().unwrap();
+        id = store(&db, "written just before quick close", 5);
+        db.close_quick().unwrap();
+    }
+    let db = MenteDb::open_with_config(dir.path(), CognitiveConfig::default()).unwrap();
+    assert!(
+        recall_ids(&db, 5).contains(&id),
+        "quick close must lose nothing; open reconciles the stale snapshot"
+    );
+    assert!(db.get_memory(id).is_ok());
+}


### PR DESCRIPTION
## Summary
Graceful shutdown flushes every open database fully, including snapshot rewrites; with many open databases that outlasts the deploy drain window and the SIGKILL deadline, holding user locks past the handover.

## Changes
- close_quick: WAL checkpoint plus lock release, no snapshot rewrites; reopen reconciles stale snapshots (already covered by the open reconcile suite)

## Verification
- New test: store, quick close, reopen, full recall of the pre close write
- Full workspace gates green with pipefail