### PR TITLE
fix: clippy useless_borrows_in_formatting (unblock main CI)

### DIFF
--- a/crates/mentedb-cognitive/src/interference.rs
+++ b/crates/mentedb-cognitive/src/interference.rs
@@ -57,7 +57,7 @@ impl InterferenceDetector {
     pub fn generate_disambiguation(&self, a: &MemoryNode, b: &MemoryNode) -> String {
         format!(
             "Note: Memory A: \"{}\" (created {}), Memory B: \"{}\" (created {}). Do not confuse.",
-            &a.content, a.created_at, &b.content, b.created_at
+            a.content, a.created_at, b.content, b.created_at
         )
     }
 


### PR DESCRIPTION
Newer clippy (1.97 on CI) flags &a.content / &b.content passed to format! in interference.rs. Removed the redundant borrows. Unblocks main.