### PR TITLE
fix: release-plz gitignore conflict on committed benchmark proof

### DIFF
--- a/benchmarks/longmemeval/.gitignore
+++ b/benchmarks/longmemeval/.gitignore
@@ -4,4 +4,11 @@ data/
 # Benchmark results and eval logs
 results/*
 !results/longmemeval_s_results.jsonl
+# Committed as auditable proof for the published LongMemEval score (must be
+# un-ignored, or release-plz errors on files that are both committed and ignored)
+!results/hypotheses_baseline-shared_q0-500.jsonl
+!results/hypotheses_baseline-shared_q0-500.jsonl.eval-results-gpt-4o-2024-08-06
+!results/hypotheses_baseline-shared_q0-500_report.md
 extraction_cache.json
+reextraction_cache.jsonl
+.quarantine_tuning_artifacts/


### PR DESCRIPTION
release-plz errored: the LongMemEval baseline result files are both committed (force-added as audit proof) and matched by results/* in benchmarks/longmemeval/.gitignore. Added explicit un-ignore rules for the three committed files (matching the existing longmemeval_s_results.jsonl negation), plus ignore the reextraction cache and the quarantine dir.