### PR TITLE
docs: deps.rs status badge + grouped Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,8 @@
 # Dependabot keeps the engine's Rust dependencies and CI actions current.
-# Cargo bumps (including 0.x minor jumps) are PR'd daily and GitHub Actions
-# bumps weekly; CI gates each one, and release-plz cuts the crates.io release
-# when a dependency change lands on main.
+# Updates are GROUPED so a day's bumps arrive as one or two PRs, not dozens:
+# all minor/patch cargo bumps in one PR (majors stay separate so a breaking one
+# does not block the safe ones), and all GitHub Actions in one PR. CI gates each
+# PR, and release-plz cuts the crates.io release when a bump lands on main.
 version: 2
 updates:
   - package-ecosystem: cargo
@@ -10,6 +11,11 @@ updates:
       interval: daily
     allow:
       - dependency-type: all
+    groups:
+      cargo-minor-patch:
+        update-types:
+          - minor
+          - patch
     labels:
       - dependencies
     open-pull-requests-limit: 5
@@ -17,6 +23,10 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    groups:
+      github-actions:
+        patterns:
+          - "*"
     labels:
       - dependencies
     open-pull-requests-limit: 5

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > ⚠️ **Beta** — MenteDB is under active development. APIs may change between minor versions.
 
-[![Crates.io](https://img.shields.io/crates/v/mentedb-core)](https://crates.io/crates/mentedb-core) [![docs.rs](https://img.shields.io/docsrs/mentedb-core)](https://docs.rs/mentedb-core) [![CI](https://github.com/nambok/mentedb/actions/workflows/ci.yml/badge.svg)](https://github.com/nambok/mentedb/actions/workflows/ci.yml) [![Dependabot](https://img.shields.io/badge/Dependabot-enabled-2ea44f?logo=dependabot&logoColor=white)](https://github.com/nambok/mentedb/network/updates) [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE) [![npm](https://img.shields.io/npm/v/mentedb)](https://www.npmjs.com/package/mentedb) [![PyPI](https://img.shields.io/pypi/v/mentedb)](https://pypi.org/project/mentedb/)
+[![Crates.io](https://img.shields.io/crates/v/mentedb-core)](https://crates.io/crates/mentedb-core) [![docs.rs](https://img.shields.io/docsrs/mentedb-core)](https://docs.rs/mentedb-core) [![CI](https://github.com/nambok/mentedb/actions/workflows/ci.yml/badge.svg)](https://github.com/nambok/mentedb/actions/workflows/ci.yml) [![dependency status](https://deps.rs/repo/github/nambok/mentedb/status.svg)](https://deps.rs/repo/github/nambok/mentedb) [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE) [![npm](https://img.shields.io/npm/v/mentedb)](https://www.npmjs.com/package/mentedb) [![PyPI](https://img.shields.io/pypi/v/mentedb)](https://pypi.org/project/mentedb/)
 
 **The Mind Database for AI Agents**
 


### PR DESCRIPTION
Two things:

1. Replace the static Dependabot 'enabled' badge with a live deps.rs badge that shows real dependency freshness (up to date / N outdated), so the badge means something.
2. Group Dependabot updates: all minor/patch cargo bumps in one PR, all GitHub Actions in one PR (majors stay separate). Stops the daily-bump PR storm where dozens of individual PRs conflict on Cargo.lock and can only merge one-at-a-time.