### PR TITLE
chore: ignore bincode major bumps in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,12 @@ updates:
       interval: daily
     allow:
       - dependency-type: all
+    ignore:
+      # bincode 3.0.0 is a non-compiling placeholder (compile_error! -> xkcd 2347).
+      # bincode major bumps also change the on-disk serialization format, so they
+      # must be a deliberate, wire-format-tested migration, never an auto-PR.
+      - dependency-name: "bincode"
+        update-types: ["version-update:semver-major"]
     groups:
       cargo-minor-patch:
         update-types:


### PR DESCRIPTION
bincode 3.0.0 is a deliberately non-compiling placeholder (src/lib.rs line 1 is compile_error! pointing at xkcd 2347), which is why #165's CI failed and no code change could fix it. This tells Dependabot to stop proposing bincode major bumps, so it does not recur. bincode major upgrades also change the on-disk serialization format, so any real move to 2.x must be a deliberate, wire-format-tested migration, not an auto-PR. Engine stays on 1.3.3.