### PR TITLE
fix: bump Docker builder to Rust 1.94 (deps need >=1.89)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 # Builder stage
-FROM rust:1.88-slim AS builder
+# Rust 1.94: several deps (konst, redb) now require >= 1.89; keep headroom so a
+# dependency MSRV bump does not break the image build (which CI does not run).
+FROM rust:1.94-slim AS builder
 
 RUN apt-get update && apt-get install -y pkg-config libssl-dev protobuf-compiler && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
The Publish SDKs Docker build fails with 'rustc 1.88.0 is not supported': konst 0.4.3 and redb 3.1.3 (pulled in by the recent grouped dep bumps) require rustc 1.89. The Dockerfile pinned rust:1.88-slim. Bumped to 1.94-slim (matches recent stable, headroom over the 1.89 MSRV). CI does not build the Docker image, so this only surfaced in Publish SDKs. Pairs with the hf-hub revert (#186) that fixed the other half of the local-embeddings build.