### PR TITLE
feat: server maintenance runner + speculative cache entries accessor

### DIFF
--- a/crates/mentedb-cognitive/src/speculative.rs
+++ b/crates/mentedb-cognitive/src/speculative.rs
@@ -175,6 +175,12 @@ impl SpeculativeCache {
         }
     }
 
+    /// The current cache entries (predicted topic, pre-assembled context,
+    /// source memories, hit count, age), for introspection and display.
+    pub fn entries(&self) -> &[CacheEntry] {
+        &self.entries
+    }
+
     fn evict_lru(&mut self) {
         if self.entries.is_empty() {
             return;

--- a/crates/mentedb-server/src/main.rs
+++ b/crates/mentedb-server/src/main.rs
@@ -5,6 +5,7 @@ mod error;
 mod extraction_queue;
 mod grpc;
 mod handlers;
+mod maintenance;
 mod rate_limit;
 mod routes;
 mod state;
@@ -48,6 +49,7 @@ struct ServerConfig {
     extraction_quality_threshold: Option<f32>,
     extraction_dedup_threshold: Option<f32>,
     embedding_provider: Option<String>,
+    maintenance_interval_hours: u64,
 }
 fn parse_args() -> ServerConfig {
     let args: Vec<String> = env::args().collect();
@@ -65,8 +67,13 @@ fn parse_args() -> ServerConfig {
     let mut extraction_quality_threshold: Option<f32> = None;
     let mut extraction_dedup_threshold: Option<f32> = None;
     let mut embedding_provider: Option<String> = None;
+    let mut maintenance_interval_hours: u64 = 24;
 
     let mut i = 1;
+    // Skip a leading subcommand (e.g. `maintenance`) so flags still parse.
+    if args.len() > 1 && !args[1].starts_with("--") {
+        i = 2;
+    }
     while i < args.len() {
         match args[i].as_str() {
             "--data-dir" => {
@@ -173,6 +180,18 @@ fn parse_args() -> ServerConfig {
                     std::process::exit(1);
                 }
             }
+            "--maintenance-interval-hours" => {
+                if i + 1 < args.len() {
+                    maintenance_interval_hours = args[i + 1].parse().unwrap_or_else(|_| {
+                        eprintln!("Error: --maintenance-interval-hours must be a number");
+                        std::process::exit(1);
+                    });
+                    i += 2;
+                } else {
+                    eprintln!("Error: --maintenance-interval-hours requires a value");
+                    std::process::exit(1);
+                }
+            }
             _ => {
                 eprintln!("Unknown argument: {}", args[i]);
                 std::process::exit(1);
@@ -227,6 +246,11 @@ fn parse_args() -> ServerConfig {
     {
         embedding_provider = Some(v);
     }
+    if let Ok(v) = env::var("MENTEDB_MAINTENANCE_INTERVAL_HOURS")
+        && let Ok(n) = v.parse::<u64>()
+    {
+        maintenance_interval_hours = n;
+    }
     ServerConfig {
         data_dir,
         port,
@@ -242,6 +266,7 @@ fn parse_args() -> ServerConfig {
         extraction_quality_threshold,
         extraction_dedup_threshold,
         embedding_provider,
+        maintenance_interval_hours,
     }
 }
 
@@ -325,9 +350,27 @@ async fn main() -> Result<()> {
 
     let config = parse_args();
 
+    // One-shot maintenance sweep: `mentedb-server maintenance --data-dir ./data`
+    // (for external cron). Runs consolidation, decay, archival, and cache
+    // eviction once, then exits.
+    if std::env::args().nth(1).as_deref() == Some("maintenance") {
+        std::fs::create_dir_all(&config.data_dir)?;
+        let db = match build_embedder(config.embedding_provider.as_deref()) {
+            Some(embedder) => MenteDb::open_with_embedder(&config.data_dir, embedder)?,
+            None => MenteDb::open(&config.data_dir)?,
+        };
+        let r = maintenance::run_sweep(&db);
+        println!(
+            "maintenance sweep complete: {} consolidated, {} decayed, {} forgotten",
+            r.consolidated, r.decayed, r.forgotten
+        );
+        return Ok(());
+    }
+
     // Build extraction config first (before moving fields out of config)
     let extraction_config = build_extraction_config(&config);
     let auto_extract = config.auto_extract;
+    let maintenance_interval_hours = config.maintenance_interval_hours;
 
     let (data_dir, port, grpc_port, jwt_secret) = (
         config.data_dir,
@@ -353,6 +396,10 @@ async fn main() -> Result<()> {
         None => MenteDb::open(&data_dir)?,
     };
     let db = Arc::new(db);
+
+    // Background maintenance sweep (self-hosted overnight jobs). Default every
+    // 24h; 0 disables it (run the `maintenance` subcommand from cron instead).
+    maintenance::spawn_scheduler(db.clone(), maintenance_interval_hours);
 
     let auth_mode = if jwt_secret.is_some() {
         "enabled"

--- a/crates/mentedb-server/src/maintenance.rs
+++ b/crates/mentedb-server/src/maintenance.rs
@@ -116,8 +116,7 @@ mod tests {
 
     #[test]
     fn sweep_runs_on_a_populated_db_without_error() {
-        let path =
-            std::env::temp_dir().join(format!("mentedb_maint_test_{}", std::process::id()));
+        let path = std::env::temp_dir().join(format!("mentedb_maint_test_{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&path);
         let db = MenteDb::open_with_embedder(&path, Box::new(HashEmbeddingProvider::new(256)))
             .expect("open db");

--- a/crates/mentedb-server/src/maintenance.rs
+++ b/crates/mentedb-server/src/maintenance.rs
@@ -1,0 +1,142 @@
+//! Built-in maintenance sweep for self-hosted deployments.
+//!
+//! Runs the rule-based "overnight" jobs that keep memory healthy: consolidate
+//! near-duplicates, decay salience, forget cold memories, and evict the stale
+//! speculative cache. A self-hoster gets the same upkeep the cloud worker
+//! provides, either automatically on a timer (`--maintenance-interval-hours`)
+//! or one-shot via the `maintenance` subcommand for external cron, without
+//! writing any code. Per-turn fact extraction is handled separately by
+//! `--auto-extract`.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use mentedb::MenteDb;
+use mentedb::consolidation::archival::ArchivalDecision;
+use tracing::{info, warn};
+
+/// Minimum cluster size for consolidation.
+const MIN_CLUSTER_SIZE: usize = 2;
+/// Cosine similarity threshold for grouping memories to consolidate.
+const SIMILARITY_THRESHOLD: f32 = 0.85;
+/// Speculative cache entries older than this (24h) are evicted.
+const CACHE_MAX_AGE_US: u64 = 24 * 3600 * 1_000_000;
+/// Cap on deletions per sweep, so a single run can never mass-delete.
+const MAX_FORGETS_PER_SWEEP: usize = 500;
+
+/// What one maintenance sweep did.
+#[derive(Debug, Default)]
+pub struct MaintenanceReport {
+    pub consolidated: usize,
+    pub decayed: usize,
+    pub forgotten: usize,
+}
+
+/// Run one maintenance sweep synchronously. Each job is best-effort: a failure
+/// in one is logged and the remaining jobs still run.
+pub fn run_sweep(db: &MenteDb) -> MaintenanceReport {
+    let mut report = MaintenanceReport::default();
+
+    // 1. Consolidation: merge near-duplicate memories into one richer memory
+    //    (sources invalidated and linked, not deleted).
+    match db.find_consolidation_candidates(MIN_CLUSTER_SIZE, SIMILARITY_THRESHOLD) {
+        Ok(candidates) => {
+            for c in candidates {
+                if db.consolidate_cluster(&c.memories).is_ok() {
+                    report.consolidated += 1;
+                }
+            }
+        }
+        Err(e) => warn!("maintenance: consolidation failed: {e}"),
+    }
+
+    // 2. Decay: age salience so old, unused memories rank lower over time.
+    match db.apply_decay_global() {
+        Ok(n) => report.decayed = n,
+        Err(e) => warn!("maintenance: decay failed: {e}"),
+    }
+
+    // 3. Archival: forget cold memories flagged for deletion (capped per sweep).
+    match db.evaluate_archival_global() {
+        Ok(decisions) => {
+            for (id, decision) in decisions {
+                if report.forgotten >= MAX_FORGETS_PER_SWEEP {
+                    break;
+                }
+                if decision == ArchivalDecision::Delete && db.forget(id).is_ok() {
+                    report.forgotten += 1;
+                }
+            }
+        }
+        Err(e) => warn!("maintenance: archival failed: {e}"),
+    }
+
+    // 4. Evict stale speculative pre-assembly cache entries.
+    db.evict_stale_speculative(CACHE_MAX_AGE_US);
+
+    // 5. Persist everything to disk.
+    if let Err(e) = db.flush() {
+        warn!("maintenance: flush failed: {e}");
+    }
+
+    report
+}
+
+/// Spawn a background task that runs a sweep every `interval_hours`. A value of
+/// 0 disables the scheduler (run the `maintenance` subcommand from cron instead).
+pub fn spawn_scheduler(db: Arc<MenteDb>, interval_hours: u64) {
+    if interval_hours == 0 {
+        info!("maintenance scheduler disabled (--maintenance-interval-hours 0)");
+        return;
+    }
+    info!("maintenance scheduler enabled: sweep every {interval_hours}h");
+    tokio::spawn(async move {
+        let interval = Duration::from_secs(interval_hours * 3600);
+        loop {
+            tokio::time::sleep(interval).await;
+            let db = Arc::clone(&db);
+            match tokio::task::spawn_blocking(move || run_sweep(&db)).await {
+                Ok(r) => info!(
+                    consolidated = r.consolidated,
+                    decayed = r.decayed,
+                    forgotten = r.forgotten,
+                    "maintenance sweep complete"
+                ),
+                Err(e) => warn!("maintenance sweep task panicked: {e}"),
+            }
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mentedb::prelude::*;
+    use mentedb_embedding::hash_provider::HashEmbeddingProvider;
+
+    #[test]
+    fn sweep_runs_on_a_populated_db_without_error() {
+        let path =
+            std::env::temp_dir().join(format!("mentedb_maint_test_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&path);
+        let db = MenteDb::open_with_embedder(&path, Box::new(HashEmbeddingProvider::new(256)))
+            .expect("open db");
+
+        let agent = AgentId::new();
+        for i in 0..5 {
+            let content = format!("fact number {i} about the project");
+            let emb = db.embed_text(&content).unwrap().unwrap();
+            db.store(MemoryNode::new(agent, MemoryType::Semantic, content, emb))
+                .unwrap();
+        }
+
+        // Must complete without panicking; counts are well-formed. On a small
+        // fresh DB nothing is necessarily removed, this is a smoke test that the
+        // full sweep (consolidate -> decay -> archival -> evict -> flush) runs.
+        let report = run_sweep(&db);
+        assert!(report.forgotten <= MAX_FORGETS_PER_SWEEP);
+
+        drop(db);
+        let _ = std::fs::remove_dir_all(&path);
+    }
+}

--- a/crates/mentedb/src/lib.rs
+++ b/crates/mentedb/src/lib.rs
@@ -1734,6 +1734,13 @@ impl MenteDb {
         self.speculative.read().stats()
     }
 
+    /// Get the current speculative cache entries (predicted topic, pre-assembled
+    /// context, source memory ids, hit count, and age), for introspection and
+    /// dashboards. This is the live pre-assembly cache, not aggregate stats.
+    pub fn speculative_cache_entries(&self) -> Vec<CacheEntry> {
+        self.speculative.read().entries().to_vec()
+    }
+
     // -----------------------------------------------------------------------
     // Cognitive Engine: Interference Detection
     // -----------------------------------------------------------------------

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -1,0 +1,145 @@
+# Self-hosting MenteDB
+
+Run the engine yourself. You own the data, the LLM keys, and the schedule. If
+you'd rather not run anything, use the managed [cloud](./CLOUD.md) instead, one
+API key and you're done.
+
+There are two moving parts to understand:
+
+1. **The server** handles every conversation turn (store, recall, extract).
+2. **The maintenance sweep** runs periodically to keep memory healthy
+   (merge duplicates, forget stale facts, decay old ones). This is the part
+   people forget, so it is built in, see [Step 5](#step-5-overnight-maintenance).
+
+---
+
+## Step 1: Install the server
+
+**With Cargo:**
+
+```bash
+cargo install mentedb-server
+mentedb-server --data-dir ./data
+```
+
+**With Docker** (the image bundles the local embedding model):
+
+```bash
+docker run -p 6677:6677 -v mentedb-data:/data ghcr.io/nambok/mentedb:latest
+```
+
+The server listens on `6677` (REST) and `6678` (gRPC). Data lives in `--data-dir`.
+
+## Step 2: Configure an LLM (recommended)
+
+**What it does:** the LLM extracts what matters from each turn (facts,
+preferences, corrections), detects contradictions, and powers consolidation.
+Without it you still get storage and keyword/vector recall, but no automatic
+fact extraction.
+
+```bash
+export MENTEDB_LLM_PROVIDER=anthropic      # openai | anthropic | ollama | none
+export MENTEDB_LLM_API_KEY=sk-ant-...
+export MENTEDB_LLM_MODEL=claude-sonnet-4-6 # optional, provider default otherwise
+mentedb-server --data-dir ./data --auto-extract
+```
+
+`--auto-extract` (or `MENTEDB_AUTO_EXTRACT=1`) turns on per-turn extraction. For
+a fully local setup, point `MENTEDB_LLM_PROVIDER=ollama` and
+`MENTEDB_LLM_BASE_URL=http://localhost:11434`.
+
+## Step 3: Choose an embedding provider
+
+**What it does:** embeddings power semantic search, auto-linking, and
+contradiction detection. Without a real embedder only keyword recall works.
+
+- `candle` (default in the Docker image): local, semantic (all-MiniLM-L6-v2,
+  384 dims), no API key. Requires the `local-embeddings` build feature.
+- `hash`: deterministic but **not** semantic. Fine for testing, weak for recall.
+- `none`: disables embeddings (not recommended).
+
+```bash
+mentedb-server --data-dir ./data --embedding-provider candle
+```
+
+## Step 4: Use it
+
+Every turn goes through one call. **`process_turn`** embeds the message, runs
+hybrid recall (vector + keyword + graph), stores the turn, extracts facts,
+detects contradictions, and returns attention-ordered context for your prompt.
+
+**REST:**
+
+```bash
+curl -X POST http://localhost:6677/v1/ingest \
+  -H "Content-Type: application/json" \
+  -d '{"user_message":"I switched from Postgres to SQLite","assistant_response":"Noted.","turn_id":0}'
+```
+
+**SDK** (Python / TypeScript / Rust):
+
+```python
+from mentedb import MenteDB
+db = MenteDB("./data")
+result = db.process_turn(user_message="...", assistant_response="...", turn_id=0)
+# result.context -> memories for your prompt; result.facts_extracted -> what was learned
+```
+
+## Step 5: Overnight maintenance
+
+This is what keeps memory from turning into a junk drawer. The sweep runs, in
+order:
+
+| Job | What it does |
+|-----|--------------|
+| Consolidation | Merges near-duplicate memories into one richer memory (sources kept, linked). |
+| Decay | Ages salience so old, unused memories rank lower over time. |
+| Archival | Forgets cold memories flagged for deletion (capped per sweep). |
+| Cache eviction | Clears stale speculative pre-assembly cache entries. |
+
+**It is built into the server and on by default (every 24h):**
+
+```bash
+mentedb-server --data-dir ./data                    # sweeps every 24h
+mentedb-server --data-dir ./data --maintenance-interval-hours 12
+mentedb-server --data-dir ./data --maintenance-interval-hours 0   # disable
+```
+
+**Or run it one-shot from cron** (set the interval to 0 to avoid double-running):
+
+```bash
+# /etc/cron.d/mentedb  — 2am daily
+0 2 * * *  mentedb-server maintenance --data-dir /var/lib/mentedb
+```
+
+**If you never run it:** duplicates pile up, stale facts keep getting recalled,
+and old low-value memories never decay, recall quality degrades over time. Don't
+skip it.
+
+## Environment variable reference
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `MENTEDB_LLM_PROVIDER` | `none` | `openai`, `anthropic`, `ollama`, or `none` |
+| `MENTEDB_LLM_API_KEY` | — | LLM API key |
+| `MENTEDB_LLM_MODEL` | provider default | Model name |
+| `MENTEDB_LLM_BASE_URL` | — | For Ollama or a proxy |
+| `MENTEDB_AUTO_EXTRACT` | `false` | Per-turn fact extraction (`--auto-extract`) |
+| `MENTEDB_EMBEDDING_PROVIDER` | `candle`/`hash` | `candle`, `hash`, or `none` |
+| `MENTEDB_MAINTENANCE_INTERVAL_HOURS` | `24` | Sweep interval; `0` disables |
+| `MENTEDB_JWT_SECRET` | — | Enables auth; required with `--require-auth` |
+| `MENTEDB_ADMIN_KEY` | — | Admin token issuance |
+| `MENTEDB_EXTRACTION_QUALITY_THRESHOLD` | `0.7` | Min confidence to store an extracted fact |
+| `MENTEDB_EXTRACTION_DEDUP_THRESHOLD` | `0.85` | Similarity above which an extraction is a duplicate |
+
+## Production notes
+
+Run with auth on:
+
+```bash
+export MENTEDB_JWT_SECRET=$(openssl rand -base64 32)
+mentedb-server --data-dir ./data --require-auth
+```
+
+Without `--require-auth` every endpoint is open, fine for local, not for a
+public host.


### PR DESCRIPTION
Two engine additions that unblock honest self-host docs and the dashboard cache/recall UI.

## Maintenance runner (self-host overnight jobs)
Self-hosters had no way to run the maintenance jobs without writing Rust (mentedb-consolidation is a library; the server exposed no trigger). Now mentedb-server has:
- `--maintenance-interval-hours N` (default 24, 0 disables) - spawns an in-process sweep on a timer.
- `mentedb-server maintenance --data-dir ./data` - runs one sweep and exits, for external cron.
- Env: `MENTEDB_MAINTENANCE_INTERVAL_HOURS`.
It mirrors the cloud worker: consolidate near-duplicates, decay salience, forget cold memories (Delete-flagged, capped 500/sweep), evict the stale speculative cache, flush. Each job is best-effort. Per-turn extraction stays with --auto-extract.

## speculative_cache_entries() accessor
`MenteDb::speculative_cache_entries()` returns the live cache entries (predicted topic, pre-assembled context, source memory ids, hit count, age) so the platform can display Cached Contexts. Previously only aggregate stats were exposed. Adds `SpeculativeCache::entries()`.

## Verification
cargo fmt clean, cargo clippy --workspace -- -D warnings clean, maintenance smoke test + speculative tests pass.