### PR TITLE
docs: self-host + cloud onboarding (repo)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,27 @@ MenteDB is a purpose built database engine for AI agent memory. Not a wrapper ar
 
 > *mente* (Spanish): mind, intellect
 
+## Two ways to run it
+
+|  |  |
+|---|---|
+| **[Cloud](docs/CLOUD.md)** | Managed. Get an API key, set `MENTEDB_API_KEY`, connect. The overnight maintenance runs for you. |
+| **[Self-host](docs/SELF_HOSTING.md)** | Run the engine yourself with `cargo install mentedb-server` or Docker. Nightly maintenance is built in. |
+
+**Cloud in 30 seconds** ([full guide](docs/CLOUD.md)):
+
+```bash
+export MENTEDB_API_KEY=mdb_your_key        # from app.mentedb.com -> API Keys
+npx mentedb-mcp@latest setup claude-code   # or cursor, copilot, claude
+```
+
+**Self-host in 30 seconds** ([full guide](docs/SELF_HOSTING.md)):
+
+```bash
+cargo install mentedb-server
+mentedb-server --data-dir ./data           # REST on :6677, nightly maintenance built in
+```
+
 ## Installation
 
 ### Docker (fastest)

--- a/docs/CLOUD.md
+++ b/docs/CLOUD.md
@@ -1,0 +1,53 @@
+# MenteDB Cloud
+
+The managed version. No servers, no cron, no LLM keys to wire up, and the
+overnight maintenance runs for you. Three steps.
+
+## 1. Get an API key
+
+Sign up at [app.mentedb.com](https://app.mentedb.com) (email or GitHub), open
+**API Keys**, and create one. It looks like `mdb_...` and is shown once, copy it
+somewhere safe.
+
+## 2. Set it
+
+```bash
+export MENTEDB_API_KEY=mdb_your_key_here
+```
+
+That is the only credential you need. The endpoint defaults to
+`https://api.mentedb.com`; override it with `MENTEDB_CLOUD_URL` if you ever need
+to.
+
+## 3. Connect
+
+**AI coding tools, one command:**
+
+```bash
+npx mentedb-mcp@latest setup claude-code   # or: cursor, copilot, claude
+```
+
+With `MENTEDB_API_KEY` set it connects to the cloud automatically. Your assistant
+now calls `process_turn` every turn, persistent memory across sessions, no glue
+code.
+
+**Or call the API directly:**
+
+```bash
+curl -X POST https://api.mentedb.com/mcp/v1/tools/call \
+  -H "Authorization: Bearer $MENTEDB_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"process_turn","arguments":{"user_message":"...","assistant_response":"...","turn_id":0}}'
+```
+
+Python and TypeScript SDKs are available too, see the [docs site](https://mentedb.com/docs).
+
+## What runs for you
+
+Every night the platform runs the same maintenance a self-hoster would have to
+schedule, consolidation, decay, archival, and cache eviction, plus enrichment
+and profile building. You do nothing. That is the whole point of cloud.
+
+---
+
+Prefer to run it yourself? See [Self-hosting](./SELF_HOSTING.md).


### PR DESCRIPTION
Adds an obvious two-path onboarding right in the repo, so someone cloning it immediately knows how to run MenteDB.

- README: a 'Two ways to run it' fork at the top with a 30-second quickstart for each path.
- docs/SELF_HOSTING.md: install (cargo/Docker), configure LLM + embeddings (what each does), per-turn usage, and the overnight maintenance (the new --maintenance-interval-hours scheduler + `mentedb-server maintenance` cron one-shot, with a table of what each job does and what happens if you skip it), plus an env-var reference.
- docs/CLOUD.md: get API key -> set MENTEDB_API_KEY -> connect (npx mentedb-mcp setup / REST). What the platform runs for you.

Pairs with the server maintenance runner (#190) so the self-host overnight jobs are real, not 'write your own Rust'.