### PR TITLE
feat(python): process_turn in the Python SDK + cloud Python docs

### DIFF
--- a/docs/CLOUD.md
+++ b/docs/CLOUD.md
@@ -40,7 +40,22 @@ curl -X POST https://api.mentedb.com/mcp/v1/tools/call \
   -d '{"name":"process_turn","arguments":{"user_message":"...","assistant_response":"...","turn_id":0}}'
 ```
 
-Python and TypeScript SDKs are available too, see the [docs site](https://mentedb.com/docs).
+**From Python** (any HTTP client, no SDK needed):
+
+```python
+import os, requests
+
+resp = requests.post(
+    "https://api.mentedb.com/mcp/v1/tools/call",
+    headers={"Authorization": f"Bearer {os.environ['MENTEDB_API_KEY']}"},
+    json={"name": "process_turn", "arguments": {
+        "user_message": "I switched from Postgres to SQLite",
+        "assistant_response": "Noted.",
+        "turn_id": 0,
+    }},
+)
+print(resp.json())
+```
 
 ## What runs for you
 

--- a/sdks/python/python/mentedb/client.py
+++ b/sdks/python/python/mentedb/client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from typing import Optional
 
 from mentedb._mentedb_python import MenteDB as _MenteDB
@@ -36,6 +37,33 @@ class MenteDB:
             embedding_api_key=embedding_api_key,
             embedding_model=embedding_model,
         )
+
+    def process_turn(
+        self,
+        user_message: str,
+        assistant_response: str | None = None,
+        turn_id: int = 0,
+        project_context: str | None = None,
+        agent_id: str | None = None,
+        session_id: str | None = None,
+    ):
+        """Process a conversation turn through the full cognitive pipeline.
+
+        The primary API. One call embeds the message, runs hybrid recall, stores
+        the turn, extracts facts, detects contradictions, and returns
+        attention-ordered context plus what was learned. Returns an object with
+        ``context`` (memories for your prompt), ``facts_extracted``,
+        ``contradiction_count``, and more.
+        """
+        result = self._db.process_turn(
+            user_message,
+            assistant_response,
+            turn_id,
+            project_context,
+            agent_id,
+            session_id,
+        )
+        return SimpleNamespace(**result) if isinstance(result, dict) else result
 
     def store(
         self,


### PR DESCRIPTION
The docs (README, SDK, docs site) present `db.process_turn(...)` as the primary Python API, but the high-level Python client wrapper never forwarded it, so it did not actually exist on the `mentedb` package (the PyO3 binding has it; the client.py wrapper just did not expose it).

- Add `MenteDB.process_turn(user_message, assistant_response=None, turn_id=0, project_context=None, agent_id=None, session_id=None)` to sdks/python, forwarding to the existing binding, returning an attribute-accessible result (result.context, result.facts_extracted, ...). Now the documented Python quickstart actually works.
- docs/CLOUD.md: replace the vague 'SDKs available' line with a real cloud-from-Python example (there is no cloud Python SDK yet; cloud usage is REST via requests).