### PR TITLE
Docs: build-an-agent rewrite + Node SDK processTurn parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ MenteDB is a purpose built database engine for AI agent memory. Not a wrapper ar
 | **[Cloud](docs/CLOUD.md)** | Managed. Get an API key, set `MENTEDB_API_KEY`, connect. The overnight maintenance runs for you. |
 | **[Self-host](docs/SELF_HOSTING.md)** | Run the engine yourself with `cargo install mentedb-server` or Docker. Nightly maintenance is built in. |
 
+Building your own agent? **[Build an agent](docs/BUILD_AN_AGENT.md)** has a
+runnable example for every combination of cloud or self-hosted and Python, Node,
+or Rust.
+
 **Cloud in 30 seconds** ([full guide](docs/CLOUD.md)):
 
 ```bash
@@ -76,45 +80,67 @@ pip install mentedb-langchain  # LangChain memory provider
 pip install mentedb-crewai     # CrewAI memory provider
 ```
 
-## Quick Start
+## Quick start: an agent that remembers
 
-**`process_turn` — one call does everything:**
+Memory is one call. `process_turn` embeds the user message, recalls what is
+relevant from everything stored so far, saves the turn, and returns the memories
+to put in your next prompt. Full walkthrough for every stack (cloud vs
+self-hosted, Python / Node / Rust) is in **[Build an agent](docs/BUILD_AN_AGENT.md)**.
+
+**Self-hosted, Python:**
 
 ```python
 from mentedb import MenteDB
 
 db = MenteDB("./my-agent-memory")
-db.configure_llm(provider="anthropic", api_key="sk-...")
 
-result = db.process_turn(
+# Turn 0: tell it something.
+db.process_turn(
     user_message="I switched from PostgreSQL to SQLite for side projects",
-    assistant_response="Got it, I'll suggest SQLite going forward.",
+    assistant_response="Got it, SQLite going forward.",
     turn_id=0,
 )
 
-# result.context       → relevant memories for your prompt
-# result.facts_extracted → what was learned this turn
-# result.contradiction_count → conflicting beliefs detected
-# result.pain_warnings → things that went wrong before
+# Turn 1: it remembers.
+result = db.process_turn(user_message="what database am I using?", turn_id=1)
+for memory in result.context:            # -> prepend these to your prompt
+    print(memory.content)
+
+# result.facts_extracted     -> what was learned this turn (needs an LLM)
+# result.contradiction_count -> conflicting beliefs detected
 ```
 
-One function call runs the full 14-step cognitive pipeline: embedding, speculative cache, hybrid search, pain signals, episodic storage, fact extraction, contradiction detection, sentiment analysis, and more.
+One call runs the full 14-step cognitive pipeline: embedding, speculative cache,
+hybrid search, pain signals, episodic storage, fact extraction, contradiction
+detection, sentiment analysis, and more. Fact extraction needs an LLM: set
+`MENTEDB_LLM_PROVIDER` and `MENTEDB_LLM_API_KEY` (or use [cloud](docs/CLOUD.md),
+where it is wired up for you). Without an LLM you still get storage and recall.
 
 > **Enrichment runs automatically in the background** — semantic facts, entity graphs,
 > community summaries, and a user profile are built over time after each `process_turn`.
 
-**Via MCP (zero code):**
+**Cloud, any language (no SDK, REST):**
+
+```bash
+export MENTEDB_API_KEY=mdb_your_key       # from app.mentedb.com
+curl -X POST https://api.mentedb.com/mcp/v1/tools/call \
+  -H "Authorization: Bearer $MENTEDB_API_KEY" -H "Content-Type: application/json" \
+  -d '{"name":"process_turn","arguments":{"user_message":"...","assistant_response":"...","turn_id":0}}'
+```
+
+**Connect an existing AI tool (no code):**
 
 ```bash
 npx mentedb-mcp@latest setup claude-code  # or copilot, claude, cursor
 ```
 
-Your AI assistant calls `process_turn` automatically every turn.
+Your assistant then calls `process_turn` automatically every turn.
 
 **Embed in Rust:**
 
 ```rust
-use mentedb::{MenteDb, process_turn::{ProcessTurnInput, DeltaTracker}};
+use mentedb::{MenteDb, process_turn::ProcessTurnInput};
+use mentedb_context::DeltaTracker;
 
 let db = MenteDb::open("./my-agent-memory")?;
 let mut delta = DeltaTracker::default();
@@ -124,6 +150,7 @@ let result = db.process_turn(&ProcessTurnInput {
     turn_id: 0,
     project_context: None,
     agent_id: None,
+    session_id: None,
 }, &mut delta)?;
 ```
 
@@ -283,12 +310,8 @@ result = db.process_turn(
 import { MenteDB } from 'mentedb';
 
 const db = new MenteDB('./agent-memory');
-const result = await db.processTurn({
-  userMessage: 'I switched to Neovim',
-  assistantResponse: 'Noted!',
-  turnId: 0,
-});
-// result.context has relevant memories for your prompt
+const result = db.processTurn('I switched to Neovim', 'Noted!', 0);
+// result.context has relevant memories for your prompt (result.factsExtracted, etc.)
 ```
 
 **LangChain:** `pip install mentedb-langchain`

--- a/docs/BUILD_AN_AGENT.md
+++ b/docs/BUILD_AN_AGENT.md
@@ -1,0 +1,325 @@
+# Build an agent with memory
+
+MenteDB gives your agent long-term memory through one call: `process_turn`. Each
+turn it stores what was said, retrieves what is relevant, and hands back the
+memories to put in your next prompt. That loop is the whole integration.
+
+This guide has a runnable example for every combination of **where MenteDB runs**
+(cloud or self-hosted) and **your language** (Python, Node, Rust). Pick the row
+that matches your stack and copy it.
+
+## The loop
+
+Every setup below is the same three lines wearing different clothes:
+
+```text
+each turn:
+  1. build your prompt with the memories from last turn's `context`
+  2. call your LLM, get a reply
+  3. process_turn(user_message, reply)  ->  returns `context` for next turn
+```
+
+`process_turn` embeds the user message, runs hybrid recall (vector + keyword +
+graph) over everything stored so far, saves the new turn, and returns the
+relevant memories as `context`. On the first turn `context` is empty because
+nothing has been learned yet. By turn two it carries the facts, preferences, and
+corrections from earlier in the conversation, and across sessions.
+
+Fact extraction and contradiction detection need an LLM. On **cloud** that is
+wired up for you. When **self-hosting** you set `MENTEDB_LLM_PROVIDER` and
+`MENTEDB_LLM_API_KEY`; without them you still get storage and recall, just no
+automatic extraction. There is no `configure_llm()` call, it is environment or
+platform config.
+
+## Which example do I want?
+
+| | Python | Node / TypeScript | Rust |
+|---|---|---|---|
+| **Cloud** (managed, no infra) | [REST + `requests`](#cloud--python) | [REST + `fetch`](#cloud--node) | [REST](#cloud--any-language) |
+| **Self-hosted** (embedded, your disk) | [`pip install mentedb`](#self-hosted--python) | [`npm install mentedb`](#self-hosted--node) | [`cargo add mentedb`](#self-hosted--rust) |
+
+Cloud talks to `https://api.mentedb.com` over REST with an `mdb_` API key, no SDK
+to install and nothing to run. Self-hosting embeds the engine in your process
+with data on local disk, you own the LLM key and the maintenance schedule (see
+[Self-hosting](./SELF_HOSTING.md)). If your language is not listed, self-host and
+call the server's REST API, shown [at the end](#self-hosted--any-language).
+
+---
+
+## Cloud + Python
+
+No SDK. Get a key at [app.mentedb.com](https://app.mentedb.com), then call the
+REST endpoint with any HTTP client.
+
+```bash
+export MENTEDB_API_KEY=mdb_your_key_here
+pip install requests
+```
+
+```python
+import os, json, requests
+
+API = "https://api.mentedb.com/mcp/v1/tools/call"
+HEADERS = {"Authorization": f"Bearer {os.environ['MENTEDB_API_KEY']}"}
+
+def process_turn(user_message, assistant_response, turn_id):
+    resp = requests.post(API, headers=HEADERS, json={
+        "name": "process_turn",
+        "arguments": {
+            "user_message": user_message,
+            "assistant_response": assistant_response,
+            "turn_id": turn_id,
+        },
+    })
+    resp.raise_for_status()
+    # MCP tool calls return content[0].text as a JSON string
+    return json.loads(resp.json()["content"][0]["text"])
+
+# Turn 0: tell it something.
+process_turn("I switched from Postgres to SQLite for side projects", "Noted.", 0)
+
+# Turn 1: it remembers.
+result = process_turn("what database am I using for side projects?", "", 1)
+for memory in result["context"]:
+    print(memory["content"])
+```
+
+In a real agent, `result["context"]` is what you inject into your model prompt:
+
+```python
+history = []                                   # memories from the previous turn
+for turn_id, user_message in enumerate(conversation):
+    prompt = build_prompt(history, user_message)   # your prompt template
+    reply = call_your_llm(prompt)                  # your model
+    result = process_turn(user_message, reply, turn_id)
+    history = result["context"]                    # feeds the next prompt
+```
+
+---
+
+## Cloud + Node
+
+Same REST endpoint, no SDK, use `fetch`.
+
+```bash
+export MENTEDB_API_KEY=mdb_your_key_here
+```
+
+```javascript
+const API = "https://api.mentedb.com/mcp/v1/tools/call";
+
+async function processTurn(userMessage, assistantResponse, turnId) {
+  const resp = await fetch(API, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${process.env.MENTEDB_API_KEY}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      name: "process_turn",
+      arguments: { user_message: userMessage, assistant_response: assistantResponse, turn_id: turnId },
+    }),
+  });
+  if (!resp.ok) throw new Error(`mentedb ${resp.status}`);
+  const body = await resp.json();
+  // MCP tool calls return content[0].text as a JSON string
+  return JSON.parse(body.content[0].text);
+}
+
+// Turn 0: tell it something. Turn 1: it remembers.
+await processTurn("I switched from Postgres to SQLite for side projects", "Noted.", 0);
+const result = await processTurn("what database am I using for side projects?", "", 1);
+for (const memory of result.context) console.log(memory.content);
+```
+
+The agent loop is identical to Python: prepend `result.context` to your next
+prompt, generate, call `processTurn`, repeat.
+
+---
+
+## Self-hosted + Python
+
+The engine runs in your process. Data lives on local disk. Install the SDK:
+
+```bash
+pip install mentedb
+# for automatic fact extraction, point it at an LLM:
+export MENTEDB_LLM_PROVIDER=anthropic      # openai | anthropic | ollama
+export MENTEDB_LLM_API_KEY=sk-ant-...
+```
+
+```python
+from mentedb import MenteDB
+
+db = MenteDB("./agent-memory")
+
+# Turn 0: tell it something.
+db.process_turn(
+    user_message="I switched from Postgres to SQLite for side projects",
+    assistant_response="Noted.",
+    turn_id=0,
+)
+
+# Turn 1: it remembers.
+result = db.process_turn(
+    user_message="what database am I using for side projects?",
+    turn_id=1,
+)
+for memory in result.context:
+    print(memory.content)
+
+# result.facts_extracted     -> facts learned this turn (needs an LLM)
+# result.contradiction_count -> conflicts with existing beliefs
+db.close()
+```
+
+Agent loop:
+
+```python
+history = []
+for turn_id, user_message in enumerate(conversation):
+    prompt = build_prompt(history, user_message)
+    reply = call_your_llm(prompt)
+    result = db.process_turn(user_message, reply, turn_id)
+    history = result.context
+```
+
+---
+
+## Self-hosted + Node
+
+Same embedded engine, native Node binding. Install the SDK:
+
+```bash
+npm install mentedb
+# for automatic fact extraction, point it at an LLM:
+export MENTEDB_LLM_PROVIDER=anthropic      # openai | anthropic | ollama
+export MENTEDB_LLM_API_KEY=sk-ant-...
+```
+
+```javascript
+const { MenteDB } = require("mentedb");
+
+const db = new MenteDB("./agent-memory");
+
+// Turn 0: tell it something.
+db.processTurn("I switched from Postgres to SQLite for side projects", "Noted.", 0);
+
+// Turn 1: it remembers.
+const result = db.processTurn("what database am I using for side projects?", undefined, 1);
+for (const memory of result.context) console.log(memory.content);
+
+// result.factsExtracted      -> facts learned this turn (needs an LLM)
+// result.contradictionCount  -> conflicts with existing beliefs
+db.close();
+```
+
+`processTurn(userMessage, assistantResponse?, turnId?, projectContext?, agentId?, sessionId?)`
+is synchronous and returns the result object directly. Agent loop:
+
+```javascript
+let history = [];
+for (let turnId = 0; turnId < conversation.length; turnId++) {
+  const userMessage = conversation[turnId];
+  const prompt = buildPrompt(history, userMessage);
+  const reply = await callYourLlm(prompt);
+  const result = db.processTurn(userMessage, reply, turnId);
+  history = result.context;
+}
+```
+
+---
+
+## Self-hosted + Rust
+
+Embed the engine directly, no server, no network.
+
+```bash
+cargo add mentedb
+```
+
+```rust
+use mentedb::{MenteDb, process_turn::ProcessTurnInput};
+use mentedb_context::DeltaTracker;
+
+let db = MenteDb::open("./agent-memory")?;
+let mut delta = DeltaTracker::default();
+
+let result = db.process_turn(&ProcessTurnInput {
+    user_message: "I switched from Postgres to SQLite for side projects".into(),
+    assistant_response: Some("Noted.".into()),
+    turn_id: 0,
+    project_context: None,
+    agent_id: None,
+    session_id: None,
+}, &mut delta)?;
+
+for memory in &result.context {
+    println!("{}", memory.content());
+}
+```
+
+---
+
+## Cloud + any language
+
+The cloud API is plain REST. Any language that can POST JSON works. Call
+`https://api.mentedb.com/mcp/v1/tools/call` with your `mdb_` key:
+
+```bash
+curl -X POST https://api.mentedb.com/mcp/v1/tools/call \
+  -H "Authorization: Bearer $MENTEDB_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"process_turn","arguments":{
+        "user_message":"I switched from Postgres to SQLite",
+        "assistant_response":"Noted.",
+        "turn_id":0}}'
+```
+
+The response is the standard MCP tool result. The turn data is a JSON string in
+`content[0].text`:
+
+```json
+{ "content": [ { "type": "text", "text": "{\"context\":[...],\"contradictions\":0}" } ], "is_error": false }
+```
+
+## Self-hosted + any language
+
+Run the server and call its REST API. Nothing to embed:
+
+```bash
+cargo install mentedb-server
+mentedb-server --data-dir ./data          # REST on :6677
+```
+
+```bash
+curl -X POST http://localhost:6677/v1/ingest \
+  -H "Content-Type: application/json" \
+  -d '{"user_message":"I switched from Postgres to SQLite","assistant_response":"Noted.","turn_id":0}'
+```
+
+See [Self-hosting](./SELF_HOSTING.md) for LLM config, embeddings, auth, and the
+overnight maintenance the server runs to keep memory healthy.
+
+## What `process_turn` returns
+
+One call runs the full cognitive pipeline and returns everything it found. The
+field you use most is `context`. The rest is signal you can act on or ignore.
+
+| Field | What it is |
+|-------|------------|
+| `context` | Memories relevant to this turn, attention-ordered. Prepend to your next prompt. |
+| `facts_extracted` | Facts learned this turn. Zero without an LLM configured. |
+| `contradiction_count` | New information that conflicts with an existing belief. |
+| `pain_warnings` | Things that went wrong in similar past contexts. |
+| `stored_ids` | Memory IDs written this turn. |
+| `predicted_topics` | Where the conversation is likely heading (from trajectory analysis). |
+
+Node returns these in camelCase (`factsExtracted`, `contradictionCount`); Python
+and the REST payload use snake_case.
+
+## Next steps
+
+- [Cloud](./CLOUD.md): keys, connecting AI coding tools, what runs for you.
+- [Self-hosting](./SELF_HOSTING.md): LLM providers, embeddings, overnight maintenance, production auth.
+- [MCP setup](https://github.com/nambok/mentedb-mcp): connect Claude Code, Cursor, Copilot, or Claude with one command instead of writing the loop yourself.

--- a/docs/CLOUD.md
+++ b/docs/CLOUD.md
@@ -57,6 +57,10 @@ resp = requests.post(
 print(resp.json())
 ```
 
+**Building your own agent?** The snippets above are the primitive. See
+[Build an agent](./BUILD_AN_AGENT.md) for the full turn-by-turn loop in Python
+and Node, cloud and self-hosted.
+
 ## What runs for you
 
 Every night the platform runs the same maintenance a self-hoster would have to

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -85,6 +85,9 @@ result = db.process_turn(user_message="...", assistant_response="...", turn_id=0
 # result.context -> memories for your prompt; result.facts_extracted -> what was learned
 ```
 
+For the full turn-by-turn agent loop in Python, Node, and Rust, see
+[Build an agent](./BUILD_AN_AGENT.md).
+
 ## Step 5: Overnight maintenance
 
 This is what keeps memory from turning into a junk drawer. The sweep runs, in

--- a/sdks/typescript/npm/client.ts
+++ b/sdks/typescript/npm/client.ts
@@ -4,6 +4,8 @@ import {
   type StoreOptions,
   type RecallResult,
   type SearchResult,
+  type ProcessTurnResult,
+  type IngestResult,
 } from './types';
 
 import * as os from 'os';
@@ -53,6 +55,47 @@ export class MenteDB {
 
   constructor(dataDir: string = './mentedb-data') {
     this.native = new nativeBinding.MenteDb(dataDir);
+  }
+
+  /**
+   * Process one conversation turn through the full cognitive pipeline.
+   *
+   * This is the primary API. A single call embeds the message, runs hybrid
+   * recall (vector + keyword + graph), stores the turn, extracts facts,
+   * detects contradictions, and returns attention-ordered context plus what
+   * was learned. The field you use most is `context`: inject those memories
+   * into your next prompt.
+   *
+   * Fact extraction and contradiction detection require an LLM. Set
+   * `MENTEDB_LLM_PROVIDER` and `MENTEDB_LLM_API_KEY` in the environment;
+   * without them you still get storage and recall.
+   */
+  processTurn(
+    userMessage: string,
+    assistantResponse?: string,
+    turnId: number = 0,
+    projectContext?: string,
+    agentId?: string,
+    sessionId?: string,
+  ): ProcessTurnResult {
+    return this.native.processTurn(
+      userMessage,
+      assistantResponse ?? null,
+      turnId,
+      projectContext ?? null,
+      agentId ?? null,
+      sessionId ?? null,
+    );
+  }
+
+  /**
+   * Extract memories from a raw conversation transcript and store them.
+   *
+   * Requires an LLM. Set `MENTEDB_LLM_PROVIDER` and `MENTEDB_LLM_API_KEY`,
+   * or pass `provider` ("openai", "anthropic", or "ollama") explicitly.
+   */
+  ingest(conversation: string, provider?: string, agentId?: string): IngestResult {
+    return this.native.ingest(conversation, provider ?? null, agentId ?? null);
   }
 
   /** Store a memory and return its UUID. */

--- a/sdks/typescript/npm/types.ts
+++ b/sdks/typescript/npm/types.ts
@@ -36,3 +36,64 @@ export interface StoreOptions {
   agentId?: string;
   tags?: string[];
 }
+
+/** A single memory selected for the working-context window. */
+export interface ContextItem {
+  id: string;
+  content: string;
+  score: number;
+}
+
+export interface PainWarning {
+  signalId: string;
+  intensity: number;
+  description: string;
+}
+
+export interface DetectedAction {
+  actionType: string;
+  detail: string;
+}
+
+export interface ProactiveRecall {
+  memoryId: string;
+  content: string;
+  relevance: number;
+  actionType: string;
+}
+
+/**
+ * Everything one `processTurn` call produced. The field you use most is
+ * `context`: the attention-ordered memories to inject into your next prompt.
+ */
+export interface ProcessTurnResult {
+  /** Attention-ordered memories relevant to this turn. Inject into your next prompt. */
+  context: ContextItem[];
+  /** IDs of the memories stored from this turn. */
+  storedIds: string[];
+  episodicId?: string;
+  painWarnings: PainWarning[];
+  cacheHit: boolean;
+  inferenceActions: number;
+  detectedActions: DetectedAction[];
+  proactiveRecalls: ProactiveRecall[];
+  correctionId?: string;
+  sentiment: number;
+  phantomCount: number;
+  contradictionCount: number;
+  predictedTopics: string[];
+  /** Facts extracted this turn. Zero unless an LLM is configured (see MENTEDB_LLM_PROVIDER). */
+  factsExtracted: number;
+  edgesCreated: number;
+  enrichmentPending: boolean;
+  deltaAdded: string[];
+  deltaRemoved: string[];
+}
+
+export interface IngestResult {
+  memoriesStored: number;
+  rejectedLowQuality: number;
+  rejectedDuplicate: number;
+  contradictions: number;
+  storedIds: string[];
+}


### PR DESCRIPTION
## Summary

The onboarding docs opened with an example that does not run: `db.configure_llm(...)`, a method no SDK ships. They also framed cloud as just the MCP connector (`npx mentedb-mcp setup`), which is how you wire an existing AI tool, not how you build your own agent. This reframes the docs around building an agent, with a runnable example for every combination of cloud or self-hosted and Python, Node, or Rust, and fixes the Node SDK gap the rewrite exposed.

## Changes

- **Node SDK parity:** the shipped TypeScript `MenteDB` wrapper only forwarded `store/recall/search/relate/forget/close`. `process_turn`, the primary API, and `ingest` existed in the native binding but were never exposed. Added both, plus `ProcessTurnResult`/`IngestResult` types. Same class of gap as the Python `process_turn` fix in #194.
- **docs/BUILD_AN_AGENT.md (new):** the agent loop explained once, then a runnable example per stack. Cloud examples parse the real MCP REST shape (`content[0].text` is a JSON string). Includes a which-example matrix.
- **README:** replaced the broken `configure_llm` quick start with a correct one; fixed the TypeScript example (was object-arg + `await`, real API is positional and synchronous); fixed the Rust example (`DeltaTracker` import path, missing `session_id`); linked the new guide.
- **docs/CLOUD.md, docs/SELF_HOSTING.md:** cross-link the agent guide.

## Verification

- Ran `processTurn` through the compiled Node wrapper: turn 2 `context` correctly recalls turn 1. `npx tsc` compiles clean.
- Every signature checked against the SDK sources; cloud response shape checked against the platform gateway handler.
- `grep` confirms no `configure_llm` or object-arg `processTurn` remain in README or docs.
- `publish-sdks.yml` runs `npx tsc` before `npm publish`, so the wrapper change ships to npm on release.