### PR TITLE
docs: fix MenteDBChatHistory example (required session_id)

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ const result = db.processTurn('I switched to Neovim', 'Noted!', 0);
 ```python
 from mentedb_langchain import MenteDBChatHistory
 
-history = MenteDBChatHistory(data_dir="./memory", agent_id="my-agent")
+history = MenteDBChatHistory(session_id="chat-1", data_dir="./memory")
 history.add_user_message("I prefer dark mode")
 history.add_ai_message("Noted!")
 ```


### PR DESCRIPTION
The README LangChain example called `MenteDBChatHistory(data_dir=..., agent_id=...)` and omitted `session_id`, which is a required first positional argument (`def __init__(self, session_id: str, data_dir=..., agent_id=None)`), so the example raised TypeError. Pass `session_id`.