### PR TITLE
docs: note overnight maintenance runs in the Docker image

### DIFF
--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -29,6 +29,9 @@ docker run -p 6677:6677 -v mentedb-data:/data ghcr.io/nambok/mentedb:latest
 ```
 
 The server listens on `6677` (REST) and `6678` (gRPC). Data lives in `--data-dir`.
+The image runs the overnight maintenance sweep automatically (every 24h by
+default, see [Step 5](#step-5-overnight-maintenance)), so a plain `docker run`
+already keeps memory healthy with nothing extra to schedule.
 
 ## Step 2: Configure an LLM (recommended)
 


### PR DESCRIPTION
## Summary

Item requested: make it obvious that a self-hosted Docker deployment runs the overnight maintenance sweep. It already does (`mentedb-server` auto-spawns the maintenance scheduler on startup, 24h default, verified at `crates/mentedb-server/src/main.rs`), but the Docker step did not call it out. Added a note to the Docker install step in SELF_HOSTING.md pointing to the maintenance section.

## Verification

- No code change; confirmed `spawn_scheduler` is invoked unconditionally after DB open with the default 24h interval, so `docker run ...` runs the sweep with nothing extra to schedule.