### PR TITLE
feat: canonicalize trajectory topics off the hot path

### DIFF
--- a/crates/mentedb-cognitive/src/trajectory.rs
+++ b/crates/mentedb-cognitive/src/trajectory.rs
@@ -252,7 +252,14 @@ impl TrajectoryTracker {
         }
     }
 
-    pub fn record_turn(&mut self, turn: TrajectoryNode) {
+    pub fn record_turn(&mut self, mut turn: TrajectoryNode) {
+        // Collapse to the learned canonical label when one exists (populated off
+        // the hot path by canonicalize_trajectory_topics), so recurring
+        // phrasings converge to one node instead of one-per-message. Unknown
+        // topics keep their original text (casing preserved for resume context).
+        if let Some(canonical) = self.transitions.get_canonical(&turn.topic_summary).cloned() {
+            turn.topic_summary = canonical;
+        }
         if let Some(prev) = self.trajectory.last() {
             self.transitions
                 .record(&prev.topic_summary, &turn.topic_summary);
@@ -262,6 +269,44 @@ impl TrajectoryTracker {
             self.trajectory.remove(0);
         }
         self.trajectory.push(turn);
+    }
+
+    /// Recent distinct topic labels that have no learned canonical mapping yet,
+    /// most recent first. The async canonicalization pass uses this to decide
+    /// which topics still need an LLM label, so the sync recording path stays
+    /// fast and no LLM call ever happens per turn.
+    pub fn pending_canonicalization(&self, limit: usize) -> Vec<String> {
+        let canonical: std::collections::HashSet<String> =
+            self.transitions.known_topics().into_iter().collect();
+        let mut seen = std::collections::HashSet::new();
+        let mut out = Vec::new();
+        for node in self.trajectory.iter().rev() {
+            let t = &node.topic_summary;
+            // Skip topics already resolved: a canonical value itself, or a raw
+            // key that already maps to one.
+            if canonical.contains(t) || self.transitions.get_canonical(t).is_some() {
+                continue;
+            }
+            if seen.insert(t.clone()) {
+                out.push(t.clone());
+                if out.len() >= limit {
+                    break;
+                }
+            }
+        }
+        out
+    }
+
+    /// The set of learned canonical topic labels, for seeding LLM prompts so it
+    /// reuses existing labels instead of inventing near-duplicates.
+    pub fn known_topics(&self) -> Vec<String> {
+        self.transitions.known_topics()
+    }
+
+    /// Store a learned raw -> canonical mapping. Called by the async
+    /// canonicalization pass after it gets labels from the LLM.
+    pub fn learn_canonical(&mut self, raw: &str, canonical: &str) {
+        self.transitions.learn_canonical(raw, canonical);
     }
 
     /// Record a turn with LLM-powered topic canonicalization.
@@ -908,5 +953,48 @@ mod tests {
         assert_eq!(preds.len(), 1);
         assert_eq!(preds[0].0, "database");
         assert_eq!(preds[0].1, 1);
+    }
+
+    #[test]
+    fn record_turn_resolves_learned_canonical_and_clears_pending() {
+        let mut tracker = TrajectoryTracker::default();
+
+        // A brand-new phrasing records as normalized text and is pending an
+        // LLM label.
+        tracker.record_turn(make_turn(
+            1,
+            "I switched from Postgres to SQLite",
+            DecisionState::Investigating,
+            vec![],
+        ));
+        assert!(
+            tracker
+                .pending_canonicalization(10)
+                .iter()
+                .any(|t| t.contains("SQLite")),
+            "raw topic should be pending canonicalization"
+        );
+
+        // Once the async pass learns a canonical label, the same phrasing
+        // collapses to it on the next turn, and it is no longer pending.
+        tracker.learn_canonical("I switched from Postgres to SQLite", "database choice");
+        tracker.record_turn(make_turn(
+            2,
+            "I switched from Postgres to SQLite",
+            DecisionState::Investigating,
+            vec![],
+        ));
+        assert_eq!(
+            tracker.get_trajectory().last().unwrap().topic_summary,
+            "database choice",
+            "recurring phrasing should resolve to the learned canonical label"
+        );
+        assert!(
+            !tracker
+                .pending_canonicalization(10)
+                .iter()
+                .any(|t| t.contains("SQLite")),
+            "canonicalized topic should no longer be pending"
+        );
     }
 }

--- a/crates/mentedb-server/src/main.rs
+++ b/crates/mentedb-server/src/main.rs
@@ -360,9 +360,14 @@ async fn main() -> Result<()> {
             None => MenteDb::open(&config.data_dir)?,
         };
         let r = maintenance::run_sweep(&db);
+        // When an LLM is configured, also give recent trajectory topics a
+        // stable semantic label so the speculative cache and topic prediction
+        // stop keying on raw message text.
+        let extraction_config = build_extraction_config(&config);
+        let canonicalized = maintenance::canonicalize_topics(&db, &extraction_config).await;
         println!(
-            "maintenance sweep complete: {} consolidated, {} decayed, {} forgotten",
-            r.consolidated, r.decayed, r.forgotten
+            "maintenance sweep complete: {} consolidated, {} decayed, {} forgotten, {} topics canonicalized",
+            r.consolidated, r.decayed, r.forgotten, canonicalized
         );
         return Ok(());
     }
@@ -399,7 +404,11 @@ async fn main() -> Result<()> {
 
     // Background maintenance sweep (self-hosted overnight jobs). Default every
     // 24h; 0 disables it (run the `maintenance` subcommand from cron instead).
-    maintenance::spawn_scheduler(db.clone(), maintenance_interval_hours);
+    maintenance::spawn_scheduler(
+        db.clone(),
+        maintenance_interval_hours,
+        extraction_config.clone(),
+    );
 
     let auth_mode = if jwt_secret.is_some() {
         "enabled"

--- a/crates/mentedb-server/src/maintenance.rs
+++ b/crates/mentedb-server/src/maintenance.rs
@@ -13,10 +13,14 @@ use std::time::Duration;
 
 use mentedb::MenteDb;
 use mentedb::consolidation::archival::ArchivalDecision;
+use mentedb_extraction::{ExtractionConfig, ExtractionLlmJudge, HttpExtractionProvider};
 use tracing::{info, warn};
 
 /// Minimum cluster size for consolidation.
 const MIN_CLUSTER_SIZE: usize = 2;
+/// Recent trajectory topics to canonicalize per sweep. The learned topic cache
+/// makes already-labeled topics free, so this only spends LLM calls on new ones.
+const CANONICALIZE_LIMIT: usize = 32;
 /// Cosine similarity threshold for grouping memories to consolidate.
 const SIMILARITY_THRESHOLD: f32 = 0.85;
 /// Speculative cache entries older than this (24h) are evicted.
@@ -82,9 +86,39 @@ pub fn run_sweep(db: &MenteDb) -> MaintenanceReport {
     report
 }
 
+/// Give recent trajectory topics a stable semantic label via the configured
+/// LLM, so topic prediction and the speculative cache stop keying on raw
+/// message text. No-op when no LLM is configured. Async because the LLM call
+/// is; call it outside the sweep's blocking pool.
+pub async fn canonicalize_topics(db: &MenteDb, config: &Option<ExtractionConfig>) -> usize {
+    let Some(cfg) = config.clone() else {
+        return 0;
+    };
+    let provider = match HttpExtractionProvider::new(cfg) {
+        Ok(p) => p,
+        Err(e) => {
+            warn!("maintenance: topic canonicalization skipped, provider build failed: {e}");
+            return 0;
+        }
+    };
+    let judge = ExtractionLlmJudge::new(provider);
+    let n = db
+        .canonicalize_trajectory_topics(judge, CANONICALIZE_LIMIT)
+        .await;
+    if n > 0 {
+        info!(count = n, "maintenance: trajectory topics canonicalized");
+    }
+    n
+}
+
 /// Spawn a background task that runs a sweep every `interval_hours`. A value of
 /// 0 disables the scheduler (run the `maintenance` subcommand from cron instead).
-pub fn spawn_scheduler(db: Arc<MenteDb>, interval_hours: u64) {
+/// When an LLM is configured, each cycle also canonicalizes recent topics.
+pub fn spawn_scheduler(
+    db: Arc<MenteDb>,
+    interval_hours: u64,
+    extraction_config: Option<ExtractionConfig>,
+) {
     if interval_hours == 0 {
         info!("maintenance scheduler disabled (--maintenance-interval-hours 0)");
         return;
@@ -94,8 +128,8 @@ pub fn spawn_scheduler(db: Arc<MenteDb>, interval_hours: u64) {
         let interval = Duration::from_secs(interval_hours * 3600);
         loop {
             tokio::time::sleep(interval).await;
-            let db = Arc::clone(&db);
-            match tokio::task::spawn_blocking(move || run_sweep(&db)).await {
+            let db_sweep = Arc::clone(&db);
+            match tokio::task::spawn_blocking(move || run_sweep(&db_sweep)).await {
                 Ok(r) => info!(
                     consolidated = r.consolidated,
                     decayed = r.decayed,
@@ -104,6 +138,7 @@ pub fn spawn_scheduler(db: Arc<MenteDb>, interval_hours: u64) {
                 ),
                 Err(e) => warn!("maintenance sweep task panicked: {e}"),
             }
+            canonicalize_topics(&db, &extraction_config).await;
         }
     });
 }

--- a/crates/mentedb/src/lib.rs
+++ b/crates/mentedb/src/lib.rs
@@ -1587,6 +1587,50 @@ impl MenteDb {
         self.trajectory.write().record_turn(turn);
     }
 
+    /// Canonicalize recent trajectory topics via the LLM, populating the learned
+    /// topic cache so future turns collapse phrasings to one canonical label.
+    /// That label then flows into topic prediction, resume context, and the
+    /// speculative pre-assembly cache, which is why raw message text stops
+    /// showing up as a "topic".
+    ///
+    /// Runs OFF the per-turn hot path: call it from an async post-turn step or
+    /// the maintenance sweep. No lock is held across the LLM calls. The engine
+    /// stays LLM-optional: pass any judge, or do not call this and topics simply
+    /// stay at their normalized-raw form. Returns the number of new canonical
+    /// labels learned this pass.
+    pub async fn canonicalize_trajectory_topics<J: mentedb_cognitive::llm::LlmJudge>(
+        &self,
+        judge: J,
+        limit: usize,
+    ) -> usize {
+        // 1. Collect recent uncached topics + the known label set (read lock).
+        let (pending, mut known) = {
+            let traj = self.trajectory.read();
+            (traj.pending_canonicalization(limit), traj.known_topics())
+        };
+        if pending.is_empty() {
+            return 0;
+        }
+        // 2. Ask the LLM for a canonical label per topic (no lock held).
+        let svc = mentedb_cognitive::llm::CognitiveLlmService::new(judge);
+        let mut learned = Vec::new();
+        for raw in pending {
+            if let Ok(label) = svc.canonicalize_topic(&raw, &known).await {
+                known.push(label.topic.clone());
+                learned.push((raw, label.topic));
+            }
+        }
+        // 3. Store the learned mappings (write lock).
+        let n = learned.len();
+        if n > 0 {
+            let mut traj = self.trajectory.write();
+            for (raw, canonical) in learned {
+                traj.learn_canonical(&raw, &canonical);
+            }
+        }
+        n
+    }
+
     /// Get a resume context string summarizing the conversation so far.
     ///
     /// Returns None if no trajectory has been recorded.


### PR DESCRIPTION
## Summary

The speculative cache, topic prediction, and resume context were keying on **raw message text** (a topic was `user_message` truncated to 100 chars), so topics almost never recurred (~21% cache hit rate) and cached-context topics were verbatim messages. Root cause: the engine's LLM topic-canonicalization (`record_turn_with_llm` + `canonicalize_topic` + the learned `topic_cache`) was built but never wired into the facade, so `topic_cache` stayed empty.

This wires it in the architecturally correct way. `process_turn` is synchronous (spawn_blocking), so canonicalization runs OFF the hot path, no per-turn LLM call.

## Changes

- `trajectory.rs`: `record_turn` collapses a topic to its learned canonical label when one exists (casing preserved otherwise). Added `pending_canonicalization`, `known_topics`, and a `learn_canonical` passthrough. Since `record()` already resolves transitions through `topic_cache`, populating the cache makes prediction/resume/cache all canonicalize automatically.
- `mentedb/lib.rs`: `canonicalize_trajectory_topics(judge, limit)` async facade method. Read-collect, LLM-label (no lock held), write-back. LLM-optional.
- `mentedb-server` (self-host): the maintenance scheduler and one-shot `maintenance` subcommand build an `ExtractionLlmJudge` from the configured provider and canonicalize recent topics each cycle.
- Test: `record_turn_resolves_learned_canonical_and_clears_pending`.

## Verification

- 99 cognitive tests pass; `cargo clippy` clean on mentedb / mentedb-cognitive / mentedb-server; `cargo check --workspace` clean.

Follow-up (separate PR, gated on this publishing to crates.io): mentedb-platform wires the same call into its async `run_turn_enrichment` with `BedrockJudge`.