### PR TITLE
feat(cognitive): LLM-judged conflict detection, replacing the ~0%-precision cosine heuristic

### DIFF
--- a/crates/mentedb-cognitive/src/write_inference.rs
+++ b/crates/mentedb-cognitive/src/write_inference.rs
@@ -126,35 +126,23 @@ impl WriteInferenceEngine {
 
             let sim = cosine_similarity(&new_memory.embedding, &existing.embedding);
 
-            // The bands are mutually exclusive: each pair gets at most one
-            // action. A contradiction is flagged for review, NOT silently
-            // invalidated; an exact duplicate (same content) is superseded.
-            if sim > self.config.contradiction_threshold {
-                if existing.agent_id == new_memory.agent_id
-                    && existing.content != new_memory.content
-                {
-                    actions.push(InferredAction::FlagContradiction {
-                        existing: existing.id,
-                        new: new_memory.id,
-                        reason: format!(
-                            "High embedding similarity ({:.3}) with different content from same agent",
-                            sim
-                        ),
-                    });
-                } else if new_memory.created_at > existing.created_at {
-                    // Same content (or cross-agent duplicate): supersede the old copy.
-                    actions.push(InferredAction::InvalidateMemory {
-                        memory: existing.id,
-                        superseded_by: new_memory.id,
-                        valid_until: new_memory.created_at,
-                    });
-                }
-            } else if sim > self.config.obsolete_threshold
+            // Cosine similarity alone cannot tell a reworded duplicate from a
+            // genuine contradiction: paraphrases ("uses Postgres" / "uses
+            // PostgreSQL") and opposites ("prefers tabs" / "prefers spaces")
+            // both land in the high-similarity band. So the cheap write-time
+            // heuristic makes only the two judgments similarity CAN support:
+            //   1. byte-identical content -> a true duplicate, supersede it
+            //   2. moderate similarity    -> a Related edge
+            // Every semantic decision (merge, paraphrase dedup, real
+            // contradiction, which-fact-wins supersession) is deferred to the
+            // LLM paths (`consolidate_memories`, `detect_conflicts_with_llm`),
+            // which read the actual text. Flagging contradictions from bare
+            // similarity here produced ~0% precision (every reworded re-save
+            // looked like a contradiction), so it was removed.
+            if existing.content == new_memory.content
+                && sim > self.config.obsolete_threshold
                 && new_memory.created_at > existing.created_at
             {
-                // InvalidateMemory both sets valid_until and creates the
-                // Supersedes edge; emitting MarkObsolete as well would
-                // duplicate the edge and invalidate twice.
                 actions.push(InferredAction::InvalidateMemory {
                     memory: existing.id,
                     superseded_by: new_memory.id,
@@ -368,7 +356,13 @@ mod tests {
     }
 
     #[test]
-    fn test_flag_contradiction() {
+    fn test_heuristic_does_not_flag_contradiction_from_similarity() {
+        // Two facts with high embedding similarity but different content look
+        // identical to cosine similarity whether they are paraphrases or
+        // opposites. The cheap heuristic must NOT guess "contradiction" here
+        // (that produced ~0% precision in production); real contradiction
+        // detection is the LLM path's job. High-sim different-content yields no
+        // action from the heuristic.
         let agent = AgentId::new();
         let mut existing =
             make_memory("uses PostgreSQL", vec![1.0, 0.0, 0.0], MemoryType::Semantic);
@@ -381,10 +375,40 @@ mod tests {
         let engine = WriteInferenceEngine::new();
         let actions = engine.infer_on_write(&new_mem, &[existing], &[]);
         assert!(
-            actions
+            !actions
                 .iter()
                 .any(|a| matches!(a, InferredAction::FlagContradiction { .. })),
-            "Expected FlagContradiction, got: {:?}",
+            "Heuristic must not flag contradictions from bare similarity, got: {:?}",
+            actions
+        );
+    }
+
+    #[test]
+    fn test_byte_identical_duplicate_is_superseded() {
+        // The one supersession the heuristic can make safely: identical text.
+        let agent = AgentId::new();
+        let mut existing = make_memory(
+            "Ran command: ls -la",
+            vec![1.0, 0.0, 0.0],
+            MemoryType::Episodic,
+        );
+        existing.agent_id = agent;
+
+        let mut new_mem = make_memory(
+            "Ran command: ls -la",
+            vec![1.0, 0.0, 0.0],
+            MemoryType::Episodic,
+        );
+        new_mem.agent_id = agent;
+        new_mem.created_at = 2000;
+
+        let engine = WriteInferenceEngine::new();
+        let actions = engine.infer_on_write(&new_mem, &[existing], &[]);
+        assert!(
+            actions
+                .iter()
+                .any(|a| matches!(a, InferredAction::InvalidateMemory { .. })),
+            "Expected identical duplicate to be superseded, got: {:?}",
             actions
         );
     }

--- a/crates/mentedb-cognitive/tests/integration.rs
+++ b/crates/mentedb-cognitive/tests/integration.rs
@@ -35,7 +35,13 @@ fn test_stream_cognition_contradiction() {
 }
 
 #[test]
-fn test_write_inference_contradiction() {
+fn test_write_inference_defers_contradiction_to_llm() {
+    // "uses PostgreSQL" and "uses MySQL" look identical to cosine similarity
+    // whether they are opposites or paraphrases. The cheap write-time heuristic
+    // must NOT guess "contradiction" from bare similarity (that produced ~0%
+    // precision in production); real contradiction detection is the LLM path's
+    // job (`detect_conflicts_with_llm`). High-similarity, different-content
+    // memories yield no FlagContradiction from the heuristic.
     let agent = AgentId::new();
 
     let mut existing = make_memory(
@@ -58,10 +64,10 @@ fn test_write_inference_contradiction() {
     let actions = engine.infer_on_write(&new_mem, &[existing], &[]);
 
     assert!(
-        actions
+        !actions
             .iter()
             .any(|a| matches!(a, InferredAction::FlagContradiction { .. })),
-        "Expected FlagContradiction action. Got: {:?}",
+        "Heuristic must not flag contradictions from bare similarity. Got: {:?}",
         actions
     );
 }

--- a/crates/mentedb-graph/src/csr.rs
+++ b/crates/mentedb-graph/src/csr.rs
@@ -246,6 +246,71 @@ impl CsrGraph {
             .retain(|e| !(e.source_idx == src_idx && e.target_idx == tgt_idx));
     }
 
+    /// Remove every edge whose type is in `types`, preserving all other edges,
+    /// including edges of a different type between the same pair. Returns the
+    /// number of edges removed.
+    ///
+    /// The removal model suppresses a compressed edge at pair granularity, so
+    /// when a suppressed pair also carries a non-matching edge, that sibling is
+    /// re-added to the delta log to keep it. Callers should `compact()` after to
+    /// materialize the result into both CSR and CSC. This is a one-time cleanup
+    /// primitive (used to purge conflict edges the old write-time heuristic
+    /// created at ~0% precision), not a hot path.
+    pub fn remove_edges_of_types(&mut self, types: &[EdgeType]) -> usize {
+        let matches = |et: EdgeType| types.contains(&et);
+        let mut removed = 0usize;
+
+        // Delta edges: drop matching ones directly.
+        let before = self.delta_edges.len();
+        self.delta_edges.retain(|e| !matches(e.data.edge_type));
+        removed += before - self.delta_edges.len();
+
+        // Compressed edges: suppress matching ones. Suppression is pair level,
+        // so restore any non-matching sibling of a suppressed pair via delta.
+        let mut restore: Vec<DeltaEdge> = Vec::new();
+        let n = self.idx_to_id.len() as u32;
+        for src_idx in 0..n {
+            let row: Vec<(u32, StoredEdge)> = {
+                let neighbors = self.csr.neighbors(src_idx);
+                let edges = self.csr.edge_data_for(src_idx);
+                let mut v = Vec::new();
+                for (i, &t) in neighbors.iter().enumerate() {
+                    if !self.is_removed(src_idx, t) {
+                        v.push((t, edges[i].clone()));
+                    }
+                }
+                v
+            };
+            let matched_pairs: std::collections::HashSet<u32> = row
+                .iter()
+                .filter(|(_, e)| matches(e.edge_type))
+                .map(|(t, _)| *t)
+                .collect();
+            if matched_pairs.is_empty() {
+                continue;
+            }
+            for &tgt_idx in &matched_pairs {
+                self.removed_edges.push((src_idx, tgt_idx));
+            }
+            for (tgt_idx, e) in row {
+                if !matched_pairs.contains(&tgt_idx) {
+                    continue;
+                }
+                if matches(e.edge_type) {
+                    removed += 1;
+                } else {
+                    restore.push(DeltaEdge {
+                        source_idx: src_idx,
+                        target_idx: tgt_idx,
+                        data: e,
+                    });
+                }
+            }
+        }
+        self.delta_edges.extend(restore);
+        removed
+    }
+
     /// Get all outgoing edges from a node (CSR + delta, minus removed).
     pub fn outgoing(&self, id: MemoryId) -> Vec<(MemoryId, StoredEdge)> {
         let Some(&idx) = self.id_to_idx.get(&id) else {
@@ -536,6 +601,45 @@ mod tests {
 
         g.remove_edge(a, b);
         assert_eq!(g.outgoing(a).len(), 0);
+    }
+
+    #[test]
+    fn test_remove_edges_of_types_preserves_siblings() {
+        let mut g = CsrGraph::new();
+        let a = MemoryId::new();
+        let b = MemoryId::new();
+        let c = MemoryId::new();
+
+        // a->b carries BOTH a Supersedes and a Related edge (the collateral
+        // case: pair-level suppression must not drop the Related sibling).
+        g.add_edge(&make_edge(a, b, EdgeType::Supersedes));
+        g.add_edge(&make_edge(a, b, EdgeType::Related));
+        // a->c is a lone Contradicts edge.
+        g.add_edge(&make_edge(a, c, EdgeType::Contradicts));
+        // b->c is unrelated and must survive.
+        g.add_edge(&make_edge(b, c, EdgeType::Caused));
+
+        // Compact first so the targets live in compressed storage, exercising
+        // the suppress-pair + restore-sibling path rather than delta retain.
+        g.compact();
+
+        let removed = g.remove_edges_of_types(&[EdgeType::Contradicts, EdgeType::Supersedes]);
+        g.compact();
+        assert_eq!(removed, 2, "one Supersedes + one Contradicts");
+
+        // a->b: Supersedes gone, Related preserved.
+        let ab: Vec<_> = g.outgoing(a).into_iter().filter(|(t, _)| *t == b).collect();
+        assert_eq!(ab.len(), 1);
+        assert_eq!(ab[0].1.edge_type, EdgeType::Related);
+
+        // a->c contradiction gone entirely.
+        assert!(g.outgoing(a).into_iter().all(|(t, _)| t != c));
+
+        // Unrelated edge intact; incoming reflects the cleanup (only b->c left).
+        assert_eq!(g.outgoing(b).len(), 1);
+        let inc_c = g.incoming(c);
+        assert_eq!(inc_c.len(), 1);
+        assert_eq!(inc_c[0].0, b);
     }
 
     #[test]

--- a/crates/mentedb-graph/src/manager.rs
+++ b/crates/mentedb-graph/src/manager.rs
@@ -237,6 +237,17 @@ impl GraphManager {
         self.graph.write().compact();
     }
 
+    /// Remove every edge whose type is in `types`, preserving other types.
+    /// Returns the number removed.
+    ///
+    /// There is no per-removal log record, so this is not crash-durable on its
+    /// own: the caller must `save()` afterward to persist a fresh snapshot and
+    /// truncate the edge log (otherwise replaying the log would re-add the
+    /// removed edges). Intended for one-time bulk cleanup.
+    pub fn remove_edges_of_types(&self, types: &[mentedb_core::edge::EdgeType]) -> usize {
+        self.graph.write().remove_edges_of_types(types)
+    }
+
     /// Strengthen an edge weight (Hebbian learning: neurons that fire together wire together).
     pub fn strengthen_edge(&self, source: MemoryId, target: MemoryId, delta: f32) {
         self.graph.write().strengthen_edge(source, target, delta);

--- a/crates/mentedb-server/src/maintenance.rs
+++ b/crates/mentedb-server/src/maintenance.rs
@@ -21,6 +21,9 @@ const MIN_CLUSTER_SIZE: usize = 2;
 /// Recent trajectory topics to canonicalize per sweep. The learned topic cache
 /// makes already-labeled topics free, so this only spends LLM calls on new ones.
 const CANONICALIZE_LIMIT: usize = 32;
+/// Cap on LLM conflict checks per sweep. Pairs that already carry a conflict edge
+/// are skipped, so this only spends calls on unjudged high-similarity pairs.
+const CONFLICT_CHECK_LIMIT: usize = 32;
 /// Cosine similarity threshold for grouping memories to consolidate.
 const SIMILARITY_THRESHOLD: f32 = 0.85;
 /// Speculative cache entries older than this (24h) are evicted.
@@ -111,6 +114,42 @@ pub async fn canonicalize_topics(db: &MenteDb, config: &Option<ExtractionConfig>
     n
 }
 
+/// Detect genuine contradictions and supersessions among stored memories via the
+/// configured LLM, recording them as the typed edges the Conflicts view shows.
+/// Unlike the old cosine-similarity heuristic (removed for ~0% precision), the
+/// judge reads both texts. No-op when no LLM is configured. Async because the
+/// LLM calls are; call it outside the sweep's blocking pool.
+pub async fn detect_conflicts(db: &MenteDb, config: &Option<ExtractionConfig>) -> usize {
+    let Some(cfg) = config.clone() else {
+        return 0;
+    };
+    let provider = match HttpExtractionProvider::new(cfg) {
+        Ok(p) => p,
+        Err(e) => {
+            warn!("maintenance: conflict detection skipped, provider build failed: {e}");
+            return 0;
+        }
+    };
+    let judge = ExtractionLlmJudge::new(provider);
+    let candidates = db.memory_ids();
+    let params = mentedb::llm_consolidation::ConflictDetectionParams::default();
+    match db
+        .detect_conflicts_with_llm(&candidates, judge, &params, CONFLICT_CHECK_LIMIT)
+        .await
+    {
+        Ok(n) => {
+            if n > 0 {
+                info!(count = n, "maintenance: conflicts detected");
+            }
+            n
+        }
+        Err(e) => {
+            warn!("maintenance: conflict detection failed: {e}");
+            0
+        }
+    }
+}
+
 /// Spawn a background task that runs a sweep every `interval_hours`. A value of
 /// 0 disables the scheduler (run the `maintenance` subcommand from cron instead).
 /// When an LLM is configured, each cycle also canonicalizes recent topics.
@@ -139,6 +178,7 @@ pub fn spawn_scheduler(
                 Err(e) => warn!("maintenance sweep task panicked: {e}"),
             }
             canonicalize_topics(&db, &extraction_config).await;
+            detect_conflicts(&db, &extraction_config).await;
         }
     });
 }

--- a/crates/mentedb/src/llm_consolidation.rs
+++ b/crates/mentedb/src/llm_consolidation.rs
@@ -12,7 +12,10 @@
 //! `Derived` edge, mirroring [`MenteDb::consolidate_cluster`].
 
 use crate::MenteDb;
-use mentedb_cognitive::llm::{ClusterMember, CognitiveLlmService, ConsolidationDecision, LlmJudge};
+use mentedb_cognitive::llm::{
+    ClusterMember, CognitiveLlmService, ConsolidationDecision, ContradictionVerdict, LlmJudge,
+    MemorySummary,
+};
 use mentedb_core::edge::EdgeType;
 use mentedb_core::error::MenteResult;
 use mentedb_core::memory::MemoryType;
@@ -38,6 +41,31 @@ impl Default for ConsolidationParams {
             similarity_floor: 0.80,
             top_k: 6,
             coverage_min: 0.6,
+        }
+    }
+}
+
+/// Tunables for LLM conflict detection (contradictions and supersessions).
+#[derive(Debug, Clone)]
+pub struct ConflictDetectionParams {
+    /// Minimum cosine similarity for two memories to be worth an LLM check.
+    /// Below this they are unlikely to concern the same subject, so judging
+    /// them would only burn tokens.
+    pub check_floor: f32,
+    /// At or above this similarity the pair is a near-identical duplicate and is
+    /// left to `consolidate_memories` (merge/dedup) rather than flagged as a
+    /// conflict. Genuine contradictions live in the band between the two.
+    pub near_identical: f32,
+    /// Nearest neighbors fetched per candidate memory.
+    pub top_k: usize,
+}
+
+impl Default for ConflictDetectionParams {
+    fn default() -> Self {
+        Self {
+            check_floor: 0.72,
+            near_identical: 0.995,
+            top_k: 6,
         }
     }
 }
@@ -312,6 +340,211 @@ impl MenteDb {
             label: None,
         });
     }
+
+    /// Detect genuine contradictions and supersessions between semantically
+    /// similar memories using an LLM judge, recording them as typed edges.
+    ///
+    /// This is the correct path for conflict detection. Cosine similarity cannot
+    /// tell a reworded duplicate from a real contradiction (both land in the
+    /// high-similarity band), so the write-time heuristic no longer guesses; it
+    /// produced ~0% precision. Here, for each candidate the engine gathers
+    /// same-agent, same-scope neighbors in the "similar but not identical" band
+    /// and asks the judge to read both texts:
+    ///   - `Contradicts` becomes a `Contradicts` edge (both kept, flagged).
+    ///   - `Supersedes` invalidates the loser and records a `Supersedes` edge.
+    ///   - `Compatible` (or any judge/parse error) does nothing.
+    ///
+    /// Near-identical duplicates are skipped and left to `consolidate_memories`.
+    ///
+    /// Bounds work to `max_checks` LLM calls, fails soft per pair, and never
+    /// re-judges a pair that already carries a conflict edge. Returns the number
+    /// of conflict edges recorded.
+    pub async fn detect_conflicts_with_llm<J: LlmJudge>(
+        &self,
+        candidate_ids: &[MemoryId],
+        judge: J,
+        params: &ConflictDetectionParams,
+        max_checks: usize,
+    ) -> MenteResult<usize> {
+        if max_checks == 0 {
+            return Ok(0);
+        }
+
+        // Phase 1: gather unordered candidate pairs. Read-only; no lock is held
+        // across the later awaits because get_memory/recall_similar/graph each
+        // take and release their own lock.
+        let mut pairs: Vec<(MemoryNode, MemoryNode)> = Vec::new();
+        let mut seen: std::collections::HashSet<(MemoryId, MemoryId)> =
+            std::collections::HashSet::new();
+        'outer: for &cid in candidate_ids {
+            let Ok(node) = self.get_memory(cid) else {
+                continue;
+            };
+            if node.is_invalidated() || node.embedding.is_empty() {
+                continue;
+            }
+            let scope = scope_key(&node.tags).map(|s| s.to_string());
+            let hits = self
+                .recall_similar(&node.embedding, params.top_k)
+                .unwrap_or_default();
+            for (nid, sim) in hits {
+                if nid == cid || sim < params.check_floor || sim >= params.near_identical {
+                    continue;
+                }
+                let key = if cid < nid { (cid, nid) } else { (nid, cid) };
+                if !seen.insert(key) {
+                    continue;
+                }
+                let Ok(other) = self.get_memory(nid) else {
+                    continue;
+                };
+                // Same agent + same scope + not already a duplicate string, and
+                // not already judged (a conflict edge exists).
+                if other.is_invalidated()
+                    || other.agent_id != node.agent_id
+                    || other.content == node.content
+                    || scope_key(&other.tags).map(|s| s.to_string()) != scope
+                    || self.has_conflict_edge(cid, nid)
+                {
+                    continue;
+                }
+                pairs.push((node.clone(), other));
+                if pairs.len() >= max_checks {
+                    break 'outer;
+                }
+            }
+        }
+        if pairs.is_empty() {
+            return Ok(0);
+        }
+
+        // Phase 2: ask the judge to read each pair (no locks held).
+        let svc = CognitiveLlmService::new(judge);
+        enum Act {
+            Contradict {
+                a: MemoryId,
+                b: MemoryId,
+                reason: String,
+            },
+            Supersede {
+                winner: MemoryId,
+                loser: MemoryId,
+            },
+        }
+        let mut acts: Vec<Act> = Vec::new();
+        for (a, b) in &pairs {
+            match svc
+                .detect_contradiction(&conflict_summary(a), &conflict_summary(b))
+                .await
+            {
+                Ok(ContradictionVerdict::Contradicts { reason }) => acts.push(Act::Contradict {
+                    a: a.id,
+                    b: b.id,
+                    reason,
+                }),
+                Ok(ContradictionVerdict::Supersedes { winner, .. }) => {
+                    let (w, l) = if winner == a.id.to_string() {
+                        (a.id, b.id)
+                    } else {
+                        (b.id, a.id)
+                    };
+                    acts.push(Act::Supersede {
+                        winner: w,
+                        loser: l,
+                    });
+                }
+                _ => {} // Compatible, or judge/parse error: nothing.
+            }
+        }
+
+        // Phase 3: apply edges and invalidations.
+        let now = now_micros();
+        let mut recorded = 0usize;
+        for act in acts {
+            let ok = match act {
+                Act::Contradict { a, b, reason } => self
+                    .relate(MemoryEdge {
+                        source: a,
+                        target: b,
+                        edge_type: EdgeType::Contradicts,
+                        weight: 1.0,
+                        created_at: now,
+                        valid_from: None,
+                        valid_until: None,
+                        label: Some(reason),
+                    })
+                    .is_ok(),
+                Act::Supersede { winner, loser } => {
+                    let _ = self.invalidate_memory(loser, now);
+                    self.relate(MemoryEdge {
+                        source: winner,
+                        target: loser,
+                        edge_type: EdgeType::Supersedes,
+                        weight: 1.0,
+                        created_at: now,
+                        valid_from: None,
+                        valid_until: None,
+                        label: None,
+                    })
+                    .is_ok()
+                }
+            };
+            if ok {
+                recorded += 1;
+            }
+        }
+        Ok(recorded)
+    }
+
+    /// One-time cleanup: remove the conflict edges the old write-time heuristic
+    /// created from bare cosine similarity (which flagged reworded duplicates as
+    /// contradictions at ~0% precision). Removes every `Contradicts` and
+    /// `Supersedes` edge, compacts, and persists a fresh graph snapshot so the
+    /// edge log cannot re-add them on reopen.
+    ///
+    /// Does NOT alter memory validity: near-duplicate copies the heuristic hid
+    /// stay hidden, and `detect_conflicts_with_llm` re-adds only genuine
+    /// conflicts going forward. Returns `(contradicts_removed, supersedes_removed)`.
+    pub fn purge_inferred_conflicts(&self) -> MenteResult<(usize, usize)> {
+        let contradicts = self.graph().remove_edges_of_types(&[EdgeType::Contradicts]);
+        let supersedes = self.graph().remove_edges_of_types(&[EdgeType::Supersedes]);
+        self.graph().compact();
+        self.flush_full()?;
+        Ok((contradicts, supersedes))
+    }
+
+    /// True if a Contradicts or Supersedes edge already links `a` and `b` in
+    /// either direction, so the conflict sweep never re-judges the same pair.
+    fn has_conflict_edge(&self, a: MemoryId, b: MemoryId) -> bool {
+        let gm = self.graph();
+        let csr = gm.graph();
+        let is_conflict = |et: EdgeType| matches!(et, EdgeType::Contradicts | EdgeType::Supersedes);
+        if csr.contains_node(a) {
+            for (t, e) in csr.outgoing(a) {
+                if t == b && is_conflict(e.edge_type) {
+                    return true;
+                }
+            }
+        }
+        if csr.contains_node(b) {
+            for (t, e) in csr.outgoing(b) {
+                if t == a && is_conflict(e.edge_type) {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+}
+
+fn conflict_summary(n: &MemoryNode) -> MemorySummary {
+    MemorySummary {
+        id: n.id,
+        content: n.content.clone(),
+        memory_type: n.memory_type,
+        confidence: n.confidence,
+        created_at: n.created_at,
+    }
 }
 
 #[cfg(test)]
@@ -547,6 +780,100 @@ mod tests {
             .unwrap();
         assert_eq!(count, 0);
         assert!(!db.get_memory(n).unwrap().is_invalidated());
+        drop(db);
+        let _ = std::fs::remove_dir_all(&path);
+    }
+
+    #[tokio::test]
+    async fn detect_conflicts_flags_contradiction_via_judge() {
+        let (db, path) = open_db("conflict");
+        let agent = AgentId(uuid::Uuid::new_v4());
+        let a = store(
+            &db,
+            agent,
+            "User prefers tabs for indentation",
+            &["scope:global"],
+        );
+        let b = store(
+            &db,
+            agent,
+            "User prefers spaces for indentation",
+            &["scope:global"],
+        );
+
+        // Loose bands so the hash-embedding neighbor qualifies as a candidate
+        // (hash similarity is not semantic). The judge says they contradict.
+        let params = ConflictDetectionParams {
+            check_floor: 0.0,
+            near_identical: 1.0,
+            top_k: 6,
+        };
+        let judge = MockLlmJudge::new(r#"{"verdict":"contradicts","reason":"tabs vs spaces"}"#);
+        let recorded = db
+            .detect_conflicts_with_llm(&[b], judge, &params, 8)
+            .await
+            .unwrap();
+        assert_eq!(recorded, 1, "one contradiction edge expected");
+
+        let has_edge = {
+            let g = db.graph().read_graph();
+            g.outgoing(b)
+                .iter()
+                .any(|(t, e)| *t == a && e.edge_type == EdgeType::Contradicts)
+        };
+        assert!(has_edge, "expected a Contradicts edge b -> a");
+
+        // Idempotent: the pair already carries a conflict edge, so a second sweep
+        // records nothing.
+        let judge2 = MockLlmJudge::new(r#"{"verdict":"contradicts","reason":"x"}"#);
+        let again = db
+            .detect_conflicts_with_llm(&[b], judge2, &params, 8)
+            .await
+            .unwrap();
+        assert_eq!(again, 0, "existing conflict edge must not be re-judged");
+
+        drop(db);
+        let _ = std::fs::remove_dir_all(&path);
+    }
+
+    #[test]
+    fn purge_removes_conflict_edges_keeps_related() {
+        let (db, path) = open_db("purge");
+        let agent = AgentId(uuid::Uuid::new_v4());
+        let a = store(&db, agent, "fact A", &["scope:global"]);
+        let b = store(&db, agent, "fact B", &["scope:global"]);
+
+        let now = now_micros();
+        let edge = |et: EdgeType| MemoryEdge {
+            source: a,
+            target: b,
+            edge_type: et,
+            weight: 1.0,
+            created_at: now,
+            valid_from: None,
+            valid_until: None,
+            label: None,
+        };
+        db.relate(edge(EdgeType::Contradicts)).unwrap();
+        db.relate(edge(EdgeType::Related)).unwrap();
+        db.relate(edge(EdgeType::Supersedes)).unwrap();
+
+        let (c, s) = db.purge_inferred_conflicts().unwrap();
+        assert_eq!((c, s), (1, 1), "one contradicts + one supersedes removed");
+
+        let g = db.graph().read_graph();
+        let out = g.outgoing(a);
+        assert!(
+            out.iter().all(|(_, e)| e.edge_type != EdgeType::Contradicts
+                && e.edge_type != EdgeType::Supersedes),
+            "conflict edges must be gone"
+        );
+        assert!(
+            out.iter()
+                .any(|(t, e)| *t == b && e.edge_type == EdgeType::Related),
+            "the Related sibling must survive the purge"
+        );
+        drop(g);
         drop(db);
         let _ = std::fs::remove_dir_all(&path);
     }

--- a/crates/mentedb/tests/integration.rs
+++ b/crates/mentedb/tests/integration.rs
@@ -424,9 +424,12 @@ fn test_write_inference_creates_related_edge() {
 }
 
 #[test]
-fn test_write_inference_detects_contradiction() {
-    // Two memories with very high similarity (>0.95) but different content
-    // should trigger a contradiction edge.
+fn test_write_inference_defers_conflict_to_llm() {
+    // High similarity + different content is ambiguous to cosine similarity: a
+    // paraphrase and an opposite look identical. The write-time heuristic must
+    // NOT guess a conflict here (that produced ~0% precision); contradiction and
+    // supersession detection is the LLM path's job (detect_conflicts_with_llm,
+    // covered in the llm_consolidation tests). So no conflict edge appears.
     let dir = tempfile::tempdir().unwrap();
     let db = MenteDb::open(dir.path()).unwrap();
     let agent = AgentId::new();
@@ -440,7 +443,6 @@ fn test_write_inference_detects_contradiction() {
     let m1_id = m1.id;
     db.store(m1).unwrap();
 
-    // Near-identical embedding (sim ≈ 0.999) but different content → contradiction.
     let m2 = MemoryNode::new(
         agent,
         MemoryType::Semantic,
@@ -451,27 +453,25 @@ fn test_write_inference_detects_contradiction() {
     db.store(m2).unwrap();
 
     let graph = db.graph().graph();
-    let outgoing = graph.outgoing(m2_id);
-    let incoming = graph.incoming(m1_id);
-
-    // Should have Contradicts edge and/or Supersedes edge
-    let has_contradiction = outgoing
+    let has_conflict = graph
+        .outgoing(m2_id)
         .iter()
-        .any(|(_, e)| e.edge_type == EdgeType::Contradicts || e.edge_type == EdgeType::Supersedes)
-        || incoming.iter().any(|(_, e)| {
-            e.edge_type == EdgeType::Contradicts || e.edge_type == EdgeType::Supersedes
-        });
+        .chain(graph.incoming(m1_id).iter())
+        .any(|(_, e)| e.edge_type == EdgeType::Contradicts || e.edge_type == EdgeType::Supersedes);
     assert!(
-        has_contradiction,
-        "Near-identical embeddings with different content should trigger contradiction/supersede"
+        !has_conflict,
+        "heuristic must not create conflict edges from bare similarity"
     );
 
     db.close().unwrap();
 }
 
 #[test]
-fn test_write_inference_invalidates_superseded_memory() {
-    // When sim > 0.85 and new memory is newer, the old one should be invalidated.
+fn test_byte_identical_store_supersedes_old_copy() {
+    // The one supersession the heuristic makes without an LLM: byte-identical
+    // text is an unambiguous duplicate, so the older copy is invalidated and a
+    // Supersedes edge records it. (Reworded near-duplicates are left to the LLM
+    // consolidation/conflict paths, which read the text.)
     let dir = tempfile::tempdir().unwrap();
     let db = MenteDb::open(dir.path()).unwrap();
     let agent = AgentId::new();
@@ -485,25 +485,22 @@ fn test_write_inference_invalidates_superseded_memory() {
     let m1_id = m1.id;
     db.store(m1).unwrap();
 
-    // Similarity in the supersede band (0.85 < sim <= 0.95) marks m1 obsolete.
-    // Above 0.95 the engine flags a contradiction instead of invalidating.
+    // Identical content and embedding: a true duplicate.
     let m2 = MemoryNode::new(
         agent,
         MemoryType::Semantic,
-        "Project version is 3.0".to_string(),
-        vec![0.90, 0.43589, 0.0, 0.0],
+        "Project version is 2.0".to_string(),
+        vec![1.0, 0.0, 0.0, 0.0],
     );
     let m2_id = m2.id;
     db.store(m2).unwrap();
 
-    // m1 should now have valid_until set (invalidated).
     let m1_after = db.get_memory(m1_id).unwrap();
     assert!(
         m1_after.valid_until.is_some(),
-        "Superseded memory should have valid_until set, got None"
+        "identical duplicate should invalidate the older copy, got None"
     );
 
-    // Exactly one Supersedes edge, not parallel duplicates.
     let g = db.graph().read_graph();
     let supersedes: Vec<_> = g
         .outgoing(m2_id)
@@ -522,9 +519,11 @@ fn test_write_inference_invalidates_superseded_memory() {
 }
 
 #[test]
-fn test_contradiction_does_not_invalidate() {
-    // Above 0.95 similarity with different content: flag the contradiction,
-    // keep both memories valid for review.
+fn test_high_similarity_different_content_left_for_llm() {
+    // "User loves PostgreSQL" vs "User hates PostgreSQL": a real contradiction,
+    // but one the heuristic cannot distinguish from a paraphrase by embedding
+    // alone. It must not silently invalidate the old memory nor guess a conflict
+    // edge; the LLM path resolves this later. So both stay valid and unlinked.
     let dir = tempfile::tempdir().unwrap();
     let db = MenteDb::open(dir.path()).unwrap();
     let agent = AgentId::new();
@@ -550,13 +549,16 @@ fn test_contradiction_does_not_invalidate() {
     let m1_after = db.get_memory(m1_id).unwrap();
     assert!(
         m1_after.valid_until.is_none(),
-        "a flagged contradiction must not silently invalidate the old memory"
+        "the heuristic must not silently invalidate the old memory"
     );
 
     let g = db.graph().read_graph();
-    let edges = g.outgoing(m2_id);
-    assert_eq!(edges.len(), 1, "exactly one edge expected, got {edges:?}");
-    assert_eq!(edges[0].1.edge_type, EdgeType::Contradicts);
+    assert!(
+        g.outgoing(m2_id).iter().all(|(_, e)| {
+            e.edge_type != EdgeType::Contradicts && e.edge_type != EdgeType::Supersedes
+        }),
+        "the heuristic must not create a conflict edge from bare similarity"
+    );
     drop(g);
 
     db.close().unwrap();
@@ -577,27 +579,23 @@ fn test_store_batch_runs_write_inference() {
     let m1_id = m1.id;
     db.store(m1).unwrap();
 
-    // Batch-stored memory in the supersede band must invalidate + link like store().
+    // Batch-stored memory at moderate similarity (Related band) must be linked
+    // the same as store() would, proving inference runs on the batch path.
     let m2 = MemoryNode::new(
         agent,
         MemoryType::Semantic,
-        "User works at Globex now".to_string(),
-        vec![0.90, 0.43589, 0.0, 0.0],
+        "User enjoys the Acme office".to_string(),
+        vec![0.75, 0.66143782, 0.0, 0.0],
     );
     let m2_id = m2.id;
     db.store_batch(vec![m2]).unwrap();
 
-    let m1_after = db.get_memory(m1_id).unwrap();
-    assert!(
-        m1_after.valid_until.is_some(),
-        "store_batch must run write inference (supersede old memory)"
-    );
     let g = db.graph().read_graph();
     assert!(
         g.outgoing(m2_id)
             .iter()
-            .any(|(t, e)| *t == m1_id && e.edge_type == EdgeType::Supersedes),
-        "store_batch must create the Supersedes edge"
+            .any(|(t, e)| *t == m1_id && e.edge_type == EdgeType::Related),
+        "store_batch must run write inference (Related edge for moderate similarity)"
     );
     drop(g);
 

--- a/crates/mentedb/tests/scenarios.rs
+++ b/crates/mentedb/tests/scenarios.rs
@@ -186,25 +186,25 @@ fn test_coding_assistant_workflow() {
         db.store(m_switch.clone()).unwrap();
         memories.push(m_switch.clone());
 
-        // WriteInferenceEngine: detect relationship with existing memories.
-        // The Webpack memory uses an embedding very similar to the Vite memory (seed 3),
-        // so the engine should detect high similarity with different content.
+        // WriteInferenceEngine on a high-similarity, different-content pair
+        // (Webpack vs the Vite memory, seed 3). Under the corrected design the
+        // heuristic never fabricates a contradiction or obsolete-marking from
+        // bare embedding similarity (that produced ~0% precision); such pairs are
+        // deferred to the LLM conflict sweep (detect_conflicts_with_llm). It may
+        // still record a Related edge for moderate similarity. The meaningful
+        // guarantee to assert is that no conflict is fabricated here.
         let engine = WriteInferenceEngine::new();
         let actions = engine.infer_on_write(&m_switch, &memories, &[]);
-        // The new memory about Webpack should trigger at least one action against
-        // the Vite memory (they share high embedding similarity via seed proximity
-        // or textual overlap).
-        let has_flag = actions.iter().any(|a| {
+        let fabricated_conflict = actions.iter().any(|a| {
             matches!(
                 a,
                 mentedb_cognitive::InferredAction::FlagContradiction { .. }
                     | mentedb_cognitive::InferredAction::MarkObsolete { .. }
-                    | mentedb_cognitive::InferredAction::CreateEdge { .. }
             )
         });
         assert!(
-            has_flag,
-            "WriteInferenceEngine should detect relationship with existing memories: got {actions:?}"
+            !fabricated_conflict,
+            "heuristic must not fabricate a conflict from bare similarity: got {actions:?}"
         );
 
         // TrajectoryTracker


### PR DESCRIPTION
## Summary

The write-time contradiction/supersession detector used cosine similarity alone. It flagged any high-embedding-similarity pair with non-identical text as a contradiction, and superseded on bare similarity. Reworded duplicates dominate that band, so precision was effectively 0%: on a real store this produced 555 "contradictions" (every one the same fact reworded) and 3,407 "supersessions" (19% literally identical command logs). Cosine similarity cannot tell a paraphrase from an opposite, so this can never work as a heuristic.

This replaces the heuristic with LLM-judged detection that reads both texts, and adds a purge for the false edges already created.

## Changes

- **write_inference**: the cheap heuristic now makes only the judgments similarity can support, byte-identical duplicate dedup and Related edges. Contradiction and supersession are deferred to the LLM.
- **llm_consolidation**: add `detect_conflicts_with_llm` (gathers same-agent, same-scope neighbors in the "similar but not identical" band and asks the existing `detect_contradiction` judge), plus `ConflictDetectionParams`. Contradicts becomes a Contradicts edge, Supersedes invalidates the loser and records a Supersedes edge, Compatible does nothing. Idempotent (never re-judges a pair that already carries a conflict edge).
- **purge**: add `MenteDb::purge_inferred_conflicts` and `CsrGraph::remove_edges_of_types` (type-aware, preserves other edge types on the same pair) to clean the false edges the heuristic already created. Persists a fresh snapshot so the edge log cannot re-add them.
- **maintenance**: run conflict detection each self-host sweep, so self-hosters get real detection too.

## Verification

- `cargo test -p mentedb -p mentedb-graph -p mentedb-cognitive -p mentedb-server`: all green.
- New tests: `detect_conflicts_flags_contradiction_via_judge` (+ idempotency), `purge_removes_conflict_edges_keeps_related`, `test_remove_edges_of_types_preserves_siblings`, and the write-inference tests rewritten to assert the heuristic no longer fabricates conflicts.
- `cargo clippy` and `cargo fmt --all --check`: clean.