### PR TITLE
fix(cognitive): dedup exact copies with Derived edge, tighten phantom extraction

### DIFF
--- a/crates/mentedb-cognitive/src/phantom.rs
+++ b/crates/mentedb-cognitive/src/phantom.rs
@@ -111,6 +111,32 @@ impl Default for PhantomConfig {
     }
 }
 
+/// A heuristic candidate is only worth surfacing as a knowledge gap if it reads
+/// like a genuine named reference, not a sentence fragment, a data value, or a
+/// possessive the tokenizer split off. These are cheap structural checks, used
+/// because this path has no LLM entity extraction to lean on.
+fn is_entity_like(term: &str) -> bool {
+    let t = term.trim().trim_end_matches(['.', ',', ';', ':', '!', '?']);
+    let letters = t.chars().filter(|c| c.is_alphabetic()).count();
+    // Needs real letters, and short enough to be a name rather than prose.
+    if letters < 2 || t.chars().count() > 40 {
+        return false;
+    }
+    // key=value fragments and data readouts are not concepts.
+    if t.contains('=') {
+        return false;
+    }
+    // Mid-string sentence punctuation means this is prose, not a reference.
+    if t.contains(". ") || t.contains(", ") || t.contains("; ") || t.contains(": ") {
+        return false;
+    }
+    // A lone lowercase word ("exactly") is not a named entity.
+    if t.split_whitespace().count() == 1 && t.chars().next().is_some_and(|c| c.is_lowercase()) {
+        return false;
+    }
+    true
+}
+
 pub struct PhantomTracker {
     phantoms: Vec<PhantomMemory>,
     config: PhantomConfig,
@@ -254,16 +280,17 @@ impl PhantomTracker {
     ) -> Vec<String> {
         let mut detected = Vec::new();
 
-        // Detect quoted terms
+        // Detect double-quoted terms. Apostrophes are deliberately excluded:
+        // treating them as quotes grabbed possessives and contractions
+        // ("Matt's", "we're") as phantom references, which was pure noise.
         let mut in_quote = false;
         let mut quote_start = 0;
         for (i, ch) in content.char_indices() {
-            if ch == '\'' || ch == '"' || ch == '\u{2018}' || ch == '\u{2019}' {
+            if ch == '"' || ch == '\u{201C}' || ch == '\u{201D}' {
                 if in_quote {
                     let term = &content[quote_start..i];
                     let trimmed = term.trim();
-                    if !trimmed.is_empty()
-                        && trimmed.len() >= 2
+                    if is_entity_like(trimmed)
                         && !known_lower.contains(&trimmed.to_lowercase())
                         && seen.insert(trimmed.to_lowercase())
                     {
@@ -306,7 +333,8 @@ impl PhantomTracker {
                     continue;
                 }
 
-                if !known_lower.contains(&entity.to_lowercase())
+                if is_entity_like(&entity)
+                    && !known_lower.contains(&entity.to_lowercase())
                     && seen.insert(entity.to_lowercase())
                 {
                     detected.push(entity);
@@ -322,6 +350,7 @@ impl PhantomTracker {
                                 .all(|c| c.is_uppercase() || c.is_ascii_digit() || c == '_'));
 
                     if is_technical
+                        && is_entity_like(w)
                         && !known_lower.contains(&w.to_lowercase())
                         && seen.insert(w.to_lowercase())
                     {
@@ -404,6 +433,30 @@ mod tests {
             refs.iter().any(|r| r.contains("Terraform")),
             "Expected Terraform, got: {:?}",
             refs
+        );
+    }
+
+    #[test]
+    fn heuristic_rejects_data_values_keeps_entities() {
+        // The tightened heuristic keeps genuine named entities but drops
+        // key=value data readouts that are not concepts worth teaching.
+        let mut tracker = PhantomTracker::default();
+        let phantoms = tracker.detect_gaps(
+            "The Payment Gateway service reported on_hand=0 for that item.",
+            &[],
+            1,
+        );
+        let refs: Vec<String> = phantoms
+            .iter()
+            .map(|p| p.source_reference.clone())
+            .collect();
+        assert!(
+            refs.iter().any(|r| r.contains("Payment Gateway")),
+            "should keep 'Payment Gateway', got: {refs:?}"
+        );
+        assert!(
+            !refs.iter().any(|r| r.contains('=')),
+            "should drop key=value data fragments like on_hand=0, got: {refs:?}"
         );
     }
 

--- a/crates/mentedb-cognitive/src/write_inference.rs
+++ b/crates/mentedb-cognitive/src/write_inference.rs
@@ -24,6 +24,14 @@ pub enum InferredAction {
         superseded_by: MemoryId,
         valid_until: u64,
     },
+    /// A byte-identical re-save: invalidate the duplicate and link it to the
+    /// surviving copy with a `Derived` edge (deduplication lineage), NOT a
+    /// `Supersedes` edge. A Supersedes edge here reads as a memory superseding an
+    /// exact copy of itself, which only shows up as noise in the conflict view.
+    DeduplicateExact {
+        duplicate: MemoryId,
+        keeper: MemoryId,
+    },
     /// Update the content of an existing memory with merged information.
     UpdateContent {
         memory: MemoryId,
@@ -143,10 +151,9 @@ impl WriteInferenceEngine {
                 && sim > self.config.obsolete_threshold
                 && new_memory.created_at > existing.created_at
             {
-                actions.push(InferredAction::InvalidateMemory {
-                    memory: existing.id,
-                    superseded_by: new_memory.id,
-                    valid_until: new_memory.created_at,
+                actions.push(InferredAction::DeduplicateExact {
+                    duplicate: existing.id,
+                    keeper: new_memory.id,
                 });
             } else if sim > self.config.related_min && sim <= self.config.related_max {
                 actions.push(InferredAction::CreateEdge {
@@ -384,8 +391,9 @@ mod tests {
     }
 
     #[test]
-    fn test_byte_identical_duplicate_is_superseded() {
-        // The one supersession the heuristic can make safely: identical text.
+    fn test_byte_identical_duplicate_is_deduplicated() {
+        // Identical text is deduplicated (invalidate + Derived lineage), not a
+        // supersession, so it never surfaces as a conflict.
         let agent = AgentId::new();
         let mut existing = make_memory(
             "Ran command: ls -la",
@@ -407,8 +415,8 @@ mod tests {
         assert!(
             actions
                 .iter()
-                .any(|a| matches!(a, InferredAction::InvalidateMemory { .. })),
-            "Expected identical duplicate to be superseded, got: {:?}",
+                .any(|a| matches!(a, InferredAction::DeduplicateExact { .. })),
+            "Expected identical duplicate to be deduplicated, got: {:?}",
             actions
         );
     }

--- a/crates/mentedb/src/lib.rs
+++ b/crates/mentedb/src/lib.rs
@@ -1052,6 +1052,28 @@ impl MenteDb {
                 };
                 self.graph.add_relationship(&edge)?;
             }
+            InferredAction::DeduplicateExact { duplicate, keeper } => {
+                debug!("Deduplicating exact copy {duplicate} into {keeper}");
+                let now = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_micros() as u64;
+                self.invalidate_memory(duplicate, now)?;
+                // Derived edge (dedup lineage), NOT Supersedes: an exact copy is
+                // deduplicated, not a meaningful supersession, so it must not
+                // surface in the contradiction/supersession view.
+                let edge = MemoryEdge {
+                    source: keeper,
+                    target: duplicate,
+                    edge_type: EdgeType::Derived,
+                    weight: 1.0,
+                    created_at: now,
+                    valid_from: None,
+                    valid_until: None,
+                    label: None,
+                };
+                self.graph.add_relationship(&edge)?;
+            }
             InferredAction::MarkObsolete {
                 memory,
                 superseded_by,

--- a/crates/mentedb/src/process_turn.rs
+++ b/crates/mentedb/src/process_turn.rs
@@ -602,6 +602,29 @@ impl MenteDb {
                 crate::InferredAction::PropagateBeliefChange { .. } => {
                     applied += 1;
                 }
+                crate::InferredAction::DeduplicateExact { duplicate, keeper } => {
+                    // Byte-identical re-save: invalidate the duplicate and link it
+                    // to the survivor with a Derived edge (dedup lineage), not a
+                    // Supersedes edge that would read as a conflict.
+                    if let Ok(mut mem) = self.get_memory(*duplicate) {
+                        mem.valid_until = Some(now);
+                        let _ = self.store(mem);
+                    }
+                    let edge = MemoryEdge {
+                        source: *keeper,
+                        target: *duplicate,
+                        edge_type: EdgeType::Derived,
+                        weight: 1.0,
+                        created_at: now,
+                        valid_from: None,
+                        valid_until: None,
+                        label: None,
+                    };
+                    if let Err(e) = self.relate(edge) {
+                        tracing::warn!("failed to create dedup edge: {e}");
+                    }
+                    applied += 1;
+                }
             }
         }
         Ok(applied)

--- a/crates/mentedb/tests/integration.rs
+++ b/crates/mentedb/tests/integration.rs
@@ -467,11 +467,11 @@ fn test_write_inference_defers_conflict_to_llm() {
 }
 
 #[test]
-fn test_byte_identical_store_supersedes_old_copy() {
-    // The one supersession the heuristic makes without an LLM: byte-identical
-    // text is an unambiguous duplicate, so the older copy is invalidated and a
-    // Supersedes edge records it. (Reworded near-duplicates are left to the LLM
-    // consolidation/conflict paths, which read the text.)
+fn test_byte_identical_store_deduplicates_old_copy() {
+    // Byte-identical text is an unambiguous duplicate: the older copy is
+    // invalidated and linked to the survivor by a Derived edge (dedup lineage),
+    // NOT a Supersedes edge, so it never surfaces as a conflict. (Reworded
+    // near-duplicates are left to the LLM consolidation/conflict paths.)
     let dir = tempfile::tempdir().unwrap();
     let db = MenteDb::open(dir.path()).unwrap();
     let agent = AgentId::new();
@@ -502,16 +502,20 @@ fn test_byte_identical_store_supersedes_old_copy() {
     );
 
     let g = db.graph().read_graph();
-    let supersedes: Vec<_> = g
+    let edges: Vec<_> = g
         .outgoing(m2_id)
         .into_iter()
-        .filter(|(t, e)| *t == m1_id && e.edge_type == EdgeType::Supersedes)
+        .filter(|(t, _)| *t == m1_id)
         .collect();
-    assert_eq!(
-        supersedes.len(),
-        1,
-        "supersede must create exactly one edge, got {}",
-        supersedes.len()
+    assert!(
+        edges.iter().any(|(_, e)| e.edge_type == EdgeType::Derived),
+        "dedup must link the duplicate with a Derived edge, got {edges:?}"
+    );
+    assert!(
+        edges
+            .iter()
+            .all(|(_, e)| e.edge_type != EdgeType::Supersedes),
+        "dedup must NOT create a Supersedes edge (it would read as a conflict), got {edges:?}"
     );
     drop(g);
 


### PR DESCRIPTION
## Summary

Two root-cause fixes for the "Agent view / Conflicts" quality issues, so the fix is at the source rather than filtered in the UI.

### 1. Byte-identical dedup no longer shows as a conflict

A re-saved, byte-identical memory was invalidated AND linked with a `Supersedes` edge. That edge reads as "a memory supersedes an exact copy of itself" and surfaced as noise in the Conflicts view (18 of 23 recent supersessions on a real account were exact duplicates).

Now the write-time heuristic emits a new `DeduplicateExact` action that invalidates the duplicate and links it with a `Derived` edge (deduplication lineage), never a `Supersedes` edge. Deduplication still happens; it just is not a conflict.

### 2. Phantom (knowledge-gap) extraction rejects fragments

Heuristic phantom detection (the only path, since per-turn LLM entity extraction was removed for cost) grabbed possessives, contractions, sentence fragments, and data values as "knowledge gaps" ("Matt's", "exactly.", "on_hand=0", rule text). Two fixes:
- Quote detection now matches double quotes only. Apostrophes were treated as quotes, which grabbed possessives/contractions.
- Every heuristic candidate passes an `is_entity_like` gate: real letters, name-length (not prose), no `key=value` data, no mid-sentence punctuation, not a lone lowercase word.

Honest limitation: heuristic phantom detection is inherently coarse. The real long-term fix is reinstating lightweight LLM entity extraction for this path; this change removes the worst of the noise in the meantime.

## Changes

- `write_inference`: add `InferredAction::DeduplicateExact`; the byte-identical branch emits it instead of `InvalidateMemory`.
- `lib.rs` / `process_turn.rs`: apply `DeduplicateExact` as invalidate + `Derived` edge.
- `phantom`: double-quote-only detection + `is_entity_like` gate on all heuristic candidates.

## Verification

- `cargo test -p mentedb -p mentedb-cognitive`: all green, including new `test_byte_identical_duplicate_is_deduplicated`, `test_byte_identical_store_deduplicates_old_copy`, and `heuristic_rejects_data_values_keeps_entities`.
- `cargo clippy` + `cargo fmt --check`: clean.