### PR TITLE
fix: profile timestamp reflects last regeneration, not first creation

### DIFF
--- a/crates/mentedb/src/lib.rs
+++ b/crates/mentedb/src/lib.rs
@@ -2567,9 +2567,16 @@ impl MenteDb {
             if let Ok(mem) = self.storage.load_memory(*pid)
                 && mem.tags.iter().any(|t| t == "user_profile")
             {
-                // Update in place
+                // Update in place, bumping created_at so it reflects when the
+                // profile was last rebuilt. `profile_updated_at` reads created_at;
+                // without this the "updated" time stayed frozen at first creation
+                // (a regenerated profile still showed "updated N days ago").
                 let mut updated = mem.clone();
                 updated.content = profile.to_string();
+                updated.created_at = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_micros() as u64;
                 if let Some(ref embedder) = self.embedder {
                     updated.embedding = embedder
                         .embed(profile)

--- a/crates/mentedb/tests/integration.rs
+++ b/crates/mentedb/tests/integration.rs
@@ -1586,3 +1586,28 @@ mod injection_attention {
         );
     }
 }
+
+#[test]
+fn test_store_user_profile_bumps_updated_timestamp() {
+    // Regenerating the profile must move its timestamp forward. profile_updated_at
+    // reads the node's created_at, so if a rebuild kept the old created_at the UI
+    // showed "updated N days ago" forever.
+    let dir = tempfile::tempdir().unwrap();
+    let db = MenteDb::open(dir.path()).unwrap();
+    db.store_user_profile("first version").unwrap();
+    let t1 = db.user_profile().unwrap().created_at;
+    std::thread::sleep(std::time::Duration::from_millis(2));
+    db.store_user_profile("second version").unwrap();
+    let node = db.user_profile().unwrap();
+    assert_eq!(
+        node.content, "second version",
+        "content must update on rebuild"
+    );
+    assert!(
+        node.created_at > t1,
+        "created_at must bump on rebuild (was frozen at first creation): {} !> {}",
+        node.created_at,
+        t1
+    );
+    db.close().unwrap();
+}


### PR DESCRIPTION
## Summary

Regenerating the user profile succeeded but the dashboard kept showing "updated N days ago" (6 days, in practice) no matter how often it rebuilt.

`store_user_profile` updates the single profile memory in place, copying the existing node and overwriting its content, but it kept the original `created_at`. `/api/profile` derives `profile_updated_at` from that `created_at`, so the timestamp was frozen at first creation.

## Fix

The in-place update now bumps `created_at` to now, so `profile_updated_at` reflects the last rebuild.

## Verification

- New test `test_store_user_profile_bumps_updated_timestamp`: re-storing moves the timestamp forward and updates content.
- `cargo test -p mentedb`, `cargo clippy`, `cargo fmt --check`: clean.