### PR TITLE
feat: add MenteDBClient hosted client for MenteDB Cloud

### DIFF
--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -77,6 +77,33 @@ with MenteDB("./agent-memory") as db:
     db.forget(mid)
 ```
 
+## MenteDB Cloud (hosted)
+
+Prefer a managed API with no engine to run? Use `MenteDBClient` with an `mdb_`
+key from [app.mentedb.com](https://app.mentedb.com). The verbs mirror the
+embedded client, so only the constructor changes.
+
+```python
+from mentedb import MenteDBClient
+
+client = MenteDBClient(api_key="mdb_...")
+
+# Turn 0: tell it something.
+client.process_turn("I switched from Postgres to SQLite for side projects", "Noted.", 0)
+
+# Turn 1: it remembers.
+result = client.process_turn("what database am I using for side projects?", "", 1)
+for memory in result.context:
+    print(memory.content)
+
+# Also available: client.search(...), client.store(...),
+# client.store_multimodal(data, media_type=...), client.forget(memory_id)
+```
+
+`MenteDBClient` is pure standard library (no extra dependencies) and talks to
+`https://api.mentedb.com`. `process_turn` uses the REST endpoint, while `store`,
+`search`, `store_multimodal`, and `forget` use the hosted MCP tools.
+
 ## Cognitive features
 
 The SDK also exposes MenteDB cognitive subsystems for real time stream

--- a/sdks/python/python/mentedb/__init__.py
+++ b/sdks/python/python/mentedb/__init__.py
@@ -5,5 +5,17 @@ try:
 except ImportError:
     MenteDB = None  # type: ignore[assignment,misc]
 
+# Hosted client for MenteDB Cloud. Pure stdlib, so it imports without the native
+# engine: self-host embedded uses MenteDB, the managed API uses MenteDBClient.
+from mentedb.hosted import MenteDBClient, MenteDBError
+
 __version__ = "0.3.1"
-__all__ = ["MenteDB", "MemoryType", "EdgeType", "RecallResult", "SearchResult"]
+__all__ = [
+    "MenteDB",
+    "MenteDBClient",
+    "MenteDBError",
+    "MemoryType",
+    "EdgeType",
+    "RecallResult",
+    "SearchResult",
+]

--- a/sdks/python/python/mentedb/hosted.py
+++ b/sdks/python/python/mentedb/hosted.py
@@ -1,0 +1,208 @@
+"""Hosted client for MenteDB Cloud (the managed service).
+
+Talks to the managed service at https://api.mentedb.com with an ``mdb_`` API key.
+No native engine, no local database, nothing to run. The verbs mirror the embedded
+``MenteDB`` so code moves between self-hosted and hosted by swapping the constructor::
+
+    from mentedb import MenteDBClient
+
+    client = MenteDBClient(api_key="mdb_...")   # get a key at https://app.mentedb.com
+
+    # Turn 0: tell it something.
+    client.process_turn("I switched from Postgres to SQLite for side projects", "Noted.", 0)
+
+    # Turn 1: it remembers.
+    result = client.process_turn("what database am I using for side projects?", "", 1)
+    for memory in result.context:
+        print(memory.content)
+
+Only the Python standard library is used, so this adds no dependencies to the package.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from types import SimpleNamespace
+from typing import Any, Optional
+
+DEFAULT_BASE_URL = "https://api.mentedb.com"
+
+
+class MenteDBError(RuntimeError):
+    """Raised when the hosted API returns an error."""
+
+
+def _ns(obj: Any) -> Any:
+    """Recursively turn dicts into attribute-accessible namespaces.
+
+    Keeps hosted results shaped like the embedded engine's, so ``result.context``
+    items expose ``.content`` the same way in both.
+    """
+    if isinstance(obj, dict):
+        return SimpleNamespace(**{k: _ns(v) for k, v in obj.items()})
+    if isinstance(obj, list):
+        return [_ns(v) for v in obj]
+    return obj
+
+
+class MenteDBClient:
+    """Client for MenteDB Cloud.
+
+    Args:
+        api_key: your ``mdb_`` key from https://app.mentedb.com.
+        base_url: override the API host (defaults to https://api.mentedb.com).
+        timeout: per-request timeout in seconds.
+    """
+
+    def __init__(
+        self,
+        api_key: str,
+        base_url: str = DEFAULT_BASE_URL,
+        timeout: float = 30.0,
+    ):
+        if not api_key:
+            raise ValueError(
+                "api_key is required (get one at https://app.mentedb.com)"
+            )
+        self.api_key = api_key
+        self.base_url = base_url.rstrip("/")
+        self.timeout = timeout
+
+    # ---- internal ------------------------------------------------------
+
+    def _post(self, path: str, payload: dict) -> Any:
+        req = urllib.request.Request(
+            f"{self.base_url}{path}",
+            data=json.dumps(payload).encode("utf-8"),
+            method="POST",
+            headers={
+                "Authorization": f"Bearer {self.api_key}",
+                "Content-Type": "application/json",
+            },
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=self.timeout) as resp:
+                return json.loads(resp.read().decode("utf-8"))
+        except urllib.error.HTTPError as exc:
+            detail = exc.read().decode("utf-8", "replace")
+            raise MenteDBError(f"mentedb {exc.code}: {detail}") from None
+
+    def _call_tool(self, name: str, arguments: dict) -> Any:
+        """Call an MCP tool over the hosted JSON-RPC endpoint.
+
+        The tool result comes back as MCP text content; when it is JSON (as the
+        memory tools return) it is parsed, otherwise the raw text is returned.
+        """
+        resp = self._post(
+            "/mcp",
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {"name": name, "arguments": arguments},
+            },
+        )
+        if isinstance(resp, dict) and resp.get("error"):
+            raise MenteDBError(f"tool {name}: {resp['error']}")
+        result = resp.get("result", {}) if isinstance(resp, dict) else {}
+        blocks = result.get("content", []) if isinstance(result, dict) else []
+        text = "\n".join(
+            b.get("text", "") for b in blocks if b.get("type") == "text"
+        )
+        if isinstance(result, dict) and result.get("isError"):
+            raise MenteDBError(f"tool {name}: {text}")
+        try:
+            return _ns(json.loads(text))
+        except (ValueError, TypeError):
+            return text
+
+    # ---- primary API ---------------------------------------------------
+
+    def process_turn(
+        self,
+        user_message: str,
+        assistant_response: Optional[str] = None,
+        turn_id: int = 0,
+        project_context: Optional[str] = None,
+        agent_id: Optional[str] = None,
+        session_id: Optional[str] = None,
+    ):
+        """Process one conversation turn through the managed cognitive pipeline.
+
+        Mirrors the embedded ``MenteDB.process_turn``. One call stores the turn,
+        runs hybrid recall, extracts facts, and returns attention-ordered
+        ``context`` for your next prompt (each item exposes ``.content``), plus the
+        other fields the service reports.
+        """
+        payload: dict[str, Any] = {
+            "user_message": user_message,
+            "assistant_response": assistant_response or "",
+            "turn_id": turn_id,
+        }
+        if project_context is not None:
+            payload["project_context"] = project_context
+        if agent_id is not None:
+            payload["agent_id"] = agent_id
+        if session_id is not None:
+            payload["session_id"] = session_id
+        return _ns(self._post("/v1/process_turn", payload))
+
+    def search(
+        self,
+        query: str,
+        limit: int = 10,
+        memory_type: Optional[str] = None,
+    ):
+        """Semantic search over stored memories."""
+        args: dict[str, Any] = {"query": query, "limit": limit}
+        if memory_type is not None:
+            args["memory_type"] = memory_type
+        return self._call_tool("search_memories", args)
+
+    def store(
+        self,
+        content: str,
+        memory_type: str = "semantic",
+        tags: Optional[list[str]] = None,
+        scope: Optional[str] = None,
+    ):
+        """Store a single memory. The result includes its ``memory_id``."""
+        args: dict[str, Any] = {"content": content, "memory_type": memory_type}
+        if tags is not None:
+            args["tags"] = tags
+        if scope is not None:
+            args["scope"] = scope
+        return self._call_tool("store_memory", args)
+
+    def store_multimodal(
+        self,
+        data: str,
+        media_type: str,
+        memory_type: str = "semantic",
+        tags: Optional[list[str]] = None,
+        scope: Optional[str] = None,
+    ):
+        """Store text extracted from a base64 image or PDF.
+
+        ``media_type`` is one of image/png, image/jpeg, image/webp, image/gif,
+        application/pdf. Only the extracted text is stored; the raw file is not.
+        """
+        args: dict[str, Any] = {
+            "data": data,
+            "media_type": media_type,
+            "memory_type": memory_type,
+        }
+        if tags is not None:
+            args["tags"] = tags
+        if scope is not None:
+            args["scope"] = scope
+        return self._call_tool("store_memory_multimodal", args)
+
+    def forget(self, memory_id: str, reason: Optional[str] = None):
+        """Delete a memory by id."""
+        args: dict[str, Any] = {"id": memory_id}
+        if reason is not None:
+            args["reason"] = reason
+        return self._call_tool("forget_memory", args)

--- a/sdks/python/tests/test_hosted.py
+++ b/sdks/python/tests/test_hosted.py
@@ -1,0 +1,153 @@
+"""Tests for the hosted MenteDB Cloud client (MenteDBClient).
+
+The hosted client is pure standard library, so these load it directly from source
+and mock urllib. No native extension or network is required. The mocked request and
+response shapes match the gateway contract: POST /v1/process_turn for the turn loop,
+and POST /mcp with a JSON-RPC tools/call whose result carries MCP text content.
+"""
+
+import importlib.util
+import io
+import json
+import os
+import urllib.error
+from unittest import mock
+
+_HOSTED = os.path.join(
+    os.path.dirname(__file__), "..", "python", "mentedb", "hosted.py"
+)
+_spec = importlib.util.spec_from_file_location("mentedb_hosted", _HOSTED)
+hosted = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(hosted)
+
+MenteDBClient = hosted.MenteDBClient
+MenteDBError = hosted.MenteDBError
+
+
+class _FakeResp:
+    def __init__(self, payload):
+        self._data = json.dumps(payload).encode("utf-8")
+
+    def read(self):
+        return self._data
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+
+def test_requires_api_key():
+    try:
+        MenteDBClient(api_key="")
+        assert False, "expected ValueError"
+    except ValueError:
+        pass
+
+
+def test_process_turn_posts_to_rest_and_parses_context():
+    captured = {}
+
+    def fake_urlopen(req, timeout=None):
+        captured["url"] = req.full_url
+        captured["method"] = req.get_method()
+        captured["headers"] = {k.lower(): v for k, v in req.header_items()}
+        captured["body"] = json.loads(req.data.decode("utf-8"))
+        return _FakeResp(
+            {
+                "ok": True,
+                "context": [
+                    {"content": "the sky is blue", "memory_type": "semantic"}
+                ],
+                "stored": 1,
+            }
+        )
+
+    with mock.patch("urllib.request.urlopen", fake_urlopen):
+        client = MenteDBClient(api_key="mdb_test")
+        result = client.process_turn("what color is the sky?", "", 1, project_context="u:1")
+
+    assert captured["url"] == "https://api.mentedb.com/v1/process_turn"
+    assert captured["method"] == "POST"
+    assert captured["headers"]["authorization"] == "Bearer mdb_test"
+    assert captured["body"]["user_message"] == "what color is the sky?"
+    assert captured["body"]["turn_id"] == 1
+    assert captured["body"]["project_context"] == "u:1"
+    # context items are attribute-accessible, mirroring the embedded engine
+    assert result.context[0].content == "the sky is blue"
+    assert result.stored == 1
+
+
+def test_call_tool_parses_json_text_block():
+    def fake_urlopen(req, timeout=None):
+        assert req.full_url == "https://api.mentedb.com/mcp"
+        body = json.loads(req.data.decode("utf-8"))
+        assert body["method"] == "tools/call"
+        assert body["params"]["name"] == "store_memory"
+        assert body["params"]["arguments"]["content"] == "hello world"
+        return _FakeResp(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": {
+                    "content": [
+                        {"type": "text", "text": '{"stored": true, "memory_id": "abc-123"}'}
+                    ],
+                    "isError": False,
+                },
+            }
+        )
+
+    with mock.patch("urllib.request.urlopen", fake_urlopen):
+        client = MenteDBClient(api_key="mdb_test")
+        res = client.store("hello world", memory_type="semantic")
+
+    assert res.stored is True
+    assert res.memory_id == "abc-123"
+
+
+def test_tool_error_raises():
+    def fake_urlopen(req, timeout=None):
+        return _FakeResp(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": {
+                    "content": [{"type": "text", "text": "over memory limit"}],
+                    "isError": True,
+                },
+            }
+        )
+
+    with mock.patch("urllib.request.urlopen", fake_urlopen):
+        client = MenteDBClient(api_key="mdb_test")
+        try:
+            client.store("x")
+            assert False, "expected MenteDBError"
+        except MenteDBError as exc:
+            assert "over memory limit" in str(exc)
+
+
+def test_http_error_raises_mentedb_error():
+    def fake_urlopen(req, timeout=None):
+        raise urllib.error.HTTPError(
+            req.full_url, 401, "Unauthorized", {}, io.BytesIO(b'{"error":"bad key"}')
+        )
+
+    with mock.patch("urllib.request.urlopen", fake_urlopen):
+        client = MenteDBClient(api_key="mdb_bad")
+        try:
+            client.process_turn("hi")
+            assert False, "expected MenteDBError"
+        except MenteDBError as exc:
+            assert "401" in str(exc)
+
+
+if __name__ == "__main__":
+    # Allow running without pytest installed.
+    for _name, _fn in sorted(globals().items()):
+        if _name.startswith("test_") and callable(_fn):
+            _fn()
+            print(f"ok {_name}")
+    print("all hosted client tests passed")


### PR DESCRIPTION
## Summary
- Adds `MenteDBClient`, a hosted client for MenteDB Cloud, so the managed API is a 3-line quickstart (`MenteDBClient(api_key=...).process_turn(...)`) instead of hand-rolled `requests`. The verbs mirror the embedded `MenteDB`, so code moves between self-host and hosted by swapping the constructor.
- Closes the top DX gap vs mem0 (their `MemoryClient(api_key=...)` hook); pairs with the site docs that now lead with the hosted service.

## Changes
- `mentedb/hosted.py`: `MenteDBClient(api_key, base_url=..., timeout=...)` with `process_turn`, `search`, `store`, `store_multimodal`, `forget`. Pure standard library (`urllib`), no new dependencies. `process_turn` calls `POST /v1/process_turn`; the tool methods use the hosted MCP endpoint (`POST /mcp`, JSON-RPC `tools/call`) and parse the MCP text-content result. Errors surface as `MenteDBError`.
- `mentedb/__init__.py`: export `MenteDBClient` and `MenteDBError`. The import is stdlib-only and unguarded, so it works even when the native engine is absent (the self-host `MenteDB` import stays guarded).
- `tests/test_hosted.py`: unit tests (mock `urllib`) asserting the request shape and response parsing against the gateway contract.
- `README.md`: hosted (MenteDB Cloud) section.

## Grounding
Shapes verified against the gateway, not guessed:
- `POST /v1/process_turn`, `Authorization: Bearer mdb_...`, body `{user_message, assistant_response, turn_id, project_context?, agent_id?, session_id?}` -> `{context: [{content, ...}], ...}`.
- MCP `tools/call` returns `{result: {content: [{type: "text", text}], isError}}`; the client parses the JSON text block (`store_memory` -> `{stored, memory_id}`), matching `mcp_transport.rs`.

## Verification
- `python3 -m pytest sdks/python/tests/test_hosted.py`: 5 passed.
- `from mentedb import MenteDBClient` imports cleanly with the native engine absent.

Note: repo CI is Rust-only and the SDKs are outside the Cargo workspace, so the Python test runs locally, not in PR CI. Publishing is handled by the existing release workflow (not this PR); the site docs cloud quickstart will switch to `MenteDBClient` once this ships to PyPI.
