### PR TITLE
fix: prevent cross-user memory leak in process_turn (proactive recall + write inference)

### DIFF
--- a/crates/mentedb/src/process_turn.rs
+++ b/crates/mentedb/src/process_turn.rs
@@ -255,16 +255,21 @@ impl MenteDb {
             &input.session_id,
         )?;
 
+        // Scope internal recalls to the turn's agent so cross-user inference,
+        // fact linking, and proactive recall cannot surface or link another
+        // user's private memories. None (no agent) preserves global behavior.
+        let scope_agent = input.agent_id.map(AgentId);
+
         // §4: Write inference on the episodic memory
         let inference_actions = if let Some(eid) = episodic_id {
-            self.run_explicit_write_inference(eid)?
+            self.run_explicit_write_inference(eid, scope_agent)?
         } else {
             0
         };
 
         // §5: Extract facts + link edges
         let (facts_extracted, edges_created) = if let Some(eid) = episodic_id {
-            self.extract_and_link_facts(eid)?
+            self.extract_and_link_facts(eid, scope_agent)?
         } else {
             (0, 0)
         };
@@ -274,7 +279,7 @@ impl MenteDb {
         let detected_actions = detect_actions(&combined_text);
 
         // §7: Proactive recall
-        let proactive_recalls = self.proactive_recall(&detected_actions)?;
+        let proactive_recalls = self.proactive_recall(&detected_actions, scope_agent)?;
 
         // §8: Auto-detect corrections (tags the episodic turn, never mints a node)
         let correction_id = self.auto_detect_correction(&input.user_message, episodic_id)?;
@@ -486,10 +491,25 @@ impl MenteDb {
         Ok((vec![id], Some(id)))
     }
 
-    fn run_explicit_write_inference(&self, id: MemoryId) -> crate::MenteResult<u32> {
+    fn run_explicit_write_inference(
+        &self,
+        id: MemoryId,
+        agent: Option<AgentId>,
+    ) -> crate::MenteResult<u32> {
         let target = self.get_memory(id)?;
+        // Scope to the turn's agent: contradiction and dedup edges must not form
+        // across users. Nil owned (shared/global) memories remain in scope.
         let similar_ids = self
-            .recall_similar(&target.embedding, 50)
+            .recall_hybrid_scoped_at_mode(
+                &target.embedding,
+                None,
+                50,
+                now_us(),
+                None,
+                false,
+                None,
+                agent,
+            )
             .unwrap_or_default();
         let existing: Vec<MemoryNode> = similar_ids
             .iter()
@@ -630,7 +650,11 @@ impl MenteDb {
         Ok(applied)
     }
 
-    fn extract_and_link_facts(&self, id: MemoryId) -> crate::MenteResult<(usize, u32)> {
+    fn extract_and_link_facts(
+        &self,
+        id: MemoryId,
+        agent: Option<AgentId>,
+    ) -> crate::MenteResult<(usize, u32)> {
         let target = self.get_memory(id)?;
         let extractor = FactExtractor::new();
         let facts = extractor.extract_facts(&target);
@@ -638,8 +662,19 @@ impl MenteDb {
             return Ok((0, 0));
         }
 
+        // Scope to the turn's agent: "related" edges must not link one user's
+        // memory to another's. Nil owned (shared/global) memories remain in scope.
         let similar_ids = self
-            .recall_similar(&target.embedding, 50)
+            .recall_hybrid_scoped_at_mode(
+                &target.embedding,
+                None,
+                50,
+                now_us(),
+                None,
+                false,
+                None,
+                agent,
+            )
             .unwrap_or_default();
         let nearby: Vec<MemoryNode> = similar_ids
             .iter()
@@ -680,6 +715,7 @@ impl MenteDb {
     fn proactive_recall(
         &self,
         actions: &[DetectedAction],
+        agent: Option<AgentId>,
     ) -> crate::MenteResult<Vec<ProactiveRecall>> {
         let mut recalls = Vec::new();
         for action in actions {
@@ -687,7 +723,11 @@ impl MenteDb {
             let Some(emb) = self.embed_text(&search_query)? else {
                 continue;
             };
-            let results = self.recall_similar(&emb, 3).unwrap_or_default();
+            // Scope to the turn's agent so proactive recall never surfaces
+            // another user's private memories (nil owned/global still pass).
+            let results = self
+                .recall_hybrid_scoped_at_mode(&emb, None, 3, now_us(), None, false, None, agent)
+                .unwrap_or_default();
             for (mid, score) in &results {
                 if let Ok(mem) = self.get_memory(*mid) {
                     recalls.push(ProactiveRecall {

--- a/crates/mentedb/tests/user_isolation.rs
+++ b/crates/mentedb/tests/user_isolation.rs
@@ -1,0 +1,183 @@
+//! End-user isolation (multi-tenant safety).
+//!
+//! When each end-user of an application is given a distinct `agent_id`, one
+//! user's private memories must never surface in another user's turn, through
+//! ANY channel: retrieved context, proactive recalls, or pain warnings. Global
+//! knowledge owned by nobody (nil agent) stays visible to everyone. This is the
+//! "each user sees their own memories plus global, never another user's" contract.
+//!
+//! These tests run WITH an embedder (so the proactive-recall path actually
+//! fires, the way it does in production) and are adversarial: the other user's
+//! private memory is placed on the exact topic the querying user touches, so any
+//! leak surfaces. A test that passed only because a code path stayed dormant
+//! would be worthless for a security boundary.
+
+use mentedb::CognitiveConfig;
+use mentedb::MenteDb;
+use mentedb::prelude::*;
+use mentedb::process_turn::{ProcessTurnInput, ProcessTurnResult};
+use mentedb_context::DeltaTracker;
+use mentedb_embedding::{EmbeddingProvider, HashEmbeddingProvider};
+use uuid::Uuid;
+
+const DIM: usize = 384;
+
+fn now_us() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_micros() as u64
+}
+
+fn open_db() -> (MenteDb, tempfile::TempDir) {
+    let dir = tempfile::tempdir().unwrap();
+    // A real (deterministic) embedder, so process_turn embeds queries and the
+    // proactive-recall / write-inference paths run exactly as in production.
+    let db = MenteDb::open_with_embedder_and_config(
+        dir.path(),
+        Box::new(HashEmbeddingProvider::new(DIM)),
+        CognitiveConfig::default(),
+    )
+    .unwrap();
+    (db, dir)
+}
+
+/// Deterministic embedding for stored content, matching the db's embedder so
+/// stored vectors and query vectors live in the same space.
+fn emb(text: &str) -> Vec<f32> {
+    HashEmbeddingProvider::new(DIM).embed(text).unwrap()
+}
+
+fn store_owned(db: &MenteDb, agent: AgentId, content: &str) -> MemoryId {
+    let node = MemoryNode::new(
+        agent,
+        MemoryType::Semantic,
+        content.to_string(),
+        emb(content),
+    );
+    let id = node.id;
+    db.store(node).unwrap();
+    id
+}
+
+/// Every content-bearing field of a turn result, flattened for leak checks.
+/// If another user's text appears anywhere in here, that is a leak.
+fn result_text(r: &ProcessTurnResult) -> String {
+    let mut s = String::new();
+    for c in &r.context {
+        s.push_str(&c.memory.content);
+        s.push('\n');
+    }
+    for p in &r.proactive_recalls {
+        s.push_str(&p.content);
+        s.push('\n');
+    }
+    for w in &r.pain_warnings {
+        s.push_str(&w.description);
+        s.push('\n');
+    }
+    for t in &r.predicted_topics {
+        s.push_str(t);
+        s.push('\n');
+    }
+    s
+}
+
+const ALICE_SECRET: &str = "ALICE_SECRET the deployment key is falcon9 do not share";
+const GLOBAL_NOTE: &str = "GLOBAL the office deploy runbook lives in the wiki";
+
+/// The core contract: nothing Alice stored privately may appear in Bob's turn,
+/// through any output channel, including proactive recall.
+#[test]
+fn other_users_memory_never_leaks_into_a_turn() {
+    let (db, _dir) = open_db();
+    let mut delta = DeltaTracker::new();
+    let alice = Uuid::new_v4();
+    let bob = Uuid::new_v4();
+
+    // Alice's private memory, on the very topic Bob will raise.
+    store_owned(&db, AgentId(alice), ALICE_SECRET);
+    // A global memory owned by nobody: both users may see it.
+    store_owned(&db, AgentId::nil(), GLOBAL_NOTE);
+
+    // Bob talks about deployment (action keywords fire proactive recall).
+    let input = ProcessTurnInput {
+        user_message: "help me deploy the new release to production".to_string(),
+        assistant_response: Some("sure, starting the deploy now".to_string()),
+        turn_id: 0,
+        project_context: None,
+        agent_id: Some(bob),
+        session_id: None,
+    };
+    let bob_result = db.process_turn(&input, &mut delta).unwrap();
+    let leaked = result_text(&bob_result);
+
+    assert!(
+        !leaked.contains("ALICE_SECRET") && !leaked.contains("falcon9"),
+        "SECURITY: another user's private memory leaked into Bob's turn output:\n{leaked}"
+    );
+}
+
+/// Isolation must not become a black hole: a scoped user still sees their own
+/// memory and global (nil owned) knowledge, just never another user's.
+#[test]
+fn scoped_user_still_sees_own_and_global() {
+    let (db, _dir) = open_db();
+    let bob = AgentId::new();
+
+    let bob_own = store_owned(&db, bob, "bob prefers dark mode in the deploy dashboard");
+    let global = store_owned(&db, AgentId::nil(), GLOBAL_NOTE);
+    let alice_secret = store_owned(&db, AgentId::new(), ALICE_SECRET);
+
+    let hits = db
+        .recall_hybrid_scoped_at_mode(
+            &emb("deploy dashboard runbook"),
+            Some("deploy dashboard runbook"),
+            10,
+            now_us(),
+            None,
+            false,
+            None,
+            Some(bob),
+        )
+        .unwrap();
+    let ids: Vec<MemoryId> = hits.iter().map(|(id, _)| *id).collect();
+
+    assert!(ids.contains(&bob_own), "user must see their own memory");
+    assert!(
+        ids.contains(&global),
+        "user must see global (nil owned) memory"
+    );
+    assert!(
+        !ids.contains(&alice_secret),
+        "user must never see another user's private memory"
+    );
+}
+
+/// Adversarial: Alice's private memory is the best match for Bob's query. It
+/// must still be excluded from Bob's scoped recall.
+#[test]
+fn scoped_recall_excludes_other_users_even_as_top_match() {
+    let (db, _dir) = open_db();
+    let bob = AgentId::new();
+    let secret = store_owned(&db, AgentId::new(), ALICE_SECRET);
+    store_owned(&db, bob, "bob's unrelated note about lunch plans");
+
+    let hits = db
+        .recall_hybrid_scoped_at_mode(
+            &emb(ALICE_SECRET),
+            Some("deployment key falcon9"),
+            10,
+            now_us(),
+            None,
+            false,
+            None,
+            Some(bob),
+        )
+        .unwrap();
+    let ids: Vec<MemoryId> = hits.iter().map(|(id, _)| *id).collect();
+    assert!(
+        !ids.contains(&secret),
+        "SECURITY: another user's private memory must never appear, even as the top match"
+    );
+}


### PR DESCRIPTION
## Summary
Security fix: `process_turn` could leak one user's private memories into another user's turn output. When an app scopes end-users by `agent_id`, the retrieved `context` was correctly filtered, but three internal paths used UNSCOPED recall and bypassed the filter:
- `proactive_recall` copied another agent's memory `content` straight into `result.proactive_recalls`.
- `run_explicit_write_inference` and `extract_and_link_facts` created `Contradicts` / `Related` edges across agents, linking one user's graph to another's private memories.

## Fix
Thread the turn's agent (`input.agent_id`) into all three helpers and route their recalls through `recall_hybrid_scoped_at_mode(..., agent)`, which already enforces `agent_visible` (own + nil-owned/global pass; other agents excluded).

Backward compatible: with no `agent_id` set, scope is `None` and behavior is unchanged (global). Only multi-user turns (agent_id present) are newly scoped, which is the intended isolation.

## Test (`crates/mentedb/tests/user_isolation.rs`)
Runs WITH a real embedder so `proactive_recall` actually fires as in production (a no-embedder test would pass vacuously and prove nothing).
- `other_users_memory_never_leaks_into_a_turn`: stores an Alice-private memory + a global one, runs Bob's `process_turn` on the same topic, asserts Alice's content appears in NO output field. This FAILS on the pre-fix code (verified: Alice's secret surfaced twice via `proactive_recalls`) and passes after the fix.
- `scoped_user_still_sees_own_and_global`: isolation is not a black hole, the user still sees their own memory and global (nil owned) knowledge.
- `scoped_recall_excludes_other_users_even_as_top_match`: holds even when the other user's memory is the best semantic match.

## Verification
- `cargo test -p mentedb`: 112 passed (incl. existing agent_isolation + process_turn suites, no regression).
- `cargo clippy --workspace -- -D warnings`: clean. `cargo fmt --all`: clean.

## Isolation model (for the docs)
Map each end-user to a stable `agent_id`; store shared knowledge nil-owned or `scope:always`. A turn scoped to a user then sees: their own memories + global/shared, never another user's, through every channel (context, proactive recalls, inference edges). The hosted gateway already forwards `agent_id` into the engine, and per-API-key tenants remain structurally separated (per-user EFS data dirs).
