### PR TITLE
fix: prevent cross-user memory merge in consolidation

### DIFF
--- a/crates/mentedb-consolidation/src/consolidation.rs
+++ b/crates/mentedb-consolidation/src/consolidation.rs
@@ -70,6 +70,12 @@ impl ConsolidationEngine {
 
         for i in 0..n {
             for j in (i + 1)..n {
+                // Never consolidate across owners: memories belonging to different
+                // agents (and agent-owned vs global) must never merge into one, or
+                // one user's content would leak into another's consolidated memory.
+                if memories[i].agent_id != memories[j].agent_id {
+                    continue;
+                }
                 let sim = cosine_similarity(&memories[i].embedding, &memories[j].embedding);
                 if sim > similarity_threshold {
                     union(&mut parent, &mut rank, i, j);
@@ -260,7 +266,8 @@ mod tests {
     fn test_find_candidates_and_consolidate() {
         let engine = ConsolidationEngine::new();
         let m1 = make_memory("topic A info", vec![1.0, 0.0, 0.0]);
-        let m2 = make_memory("topic A data", vec![0.99, 0.1, 0.0]);
+        let mut m2 = make_memory("topic A data", vec![0.99, 0.1, 0.0]);
+        m2.agent_id = m1.agent_id; // same owner: consolidation only merges within an agent
         let m3 = make_memory("topic B info", vec![0.0, 0.0, 1.0]);
 
         let candidates = engine.find_candidates(&[m1.clone(), m2.clone(), m3], 2, 0.9);
@@ -270,5 +277,43 @@ mod tests {
         let consolidated = engine.consolidate(&[m1, m2]);
         assert_eq!(consolidated.new_type, MemoryType::Semantic);
         assert!(!consolidated.combined_embedding.is_empty());
+    }
+
+    #[test]
+    fn find_candidates_never_merges_across_agents() {
+        use mentedb_core::types::AgentId;
+        let engine = ConsolidationEngine::new();
+        let alice = AgentId::new();
+        let bob = AgentId::new();
+
+        // Identical embeddings across owners. Without the owner guard these would
+        // all union into one cross-agent cluster, merging Bob's memory into Alice's.
+        let emb = vec![1.0, 0.0, 0.0];
+        let mut a1 = make_memory("the primary database is postgres", emb.clone());
+        a1.agent_id = alice;
+        let mut a2 = make_memory("the primary database is postgres as well", emb.clone());
+        a2.agent_id = alice;
+        let mut b1 = make_memory("the primary database is postgres", emb.clone());
+        b1.agent_id = bob;
+
+        let mems = vec![a1, a2, b1];
+        let candidates = engine.find_candidates(&mems, 2, 0.5);
+
+        for c in &candidates {
+            let owners: Vec<AgentId> = c
+                .memories
+                .iter()
+                .map(|id| mems.iter().find(|m| m.id == *id).unwrap().agent_id)
+                .collect();
+            assert!(
+                owners.windows(2).all(|w| w[0] == w[1]),
+                "consolidation cluster mixed owners across agents"
+            );
+        }
+        // Same-owner memories still consolidate: isolation is not a black hole.
+        assert!(
+            candidates.iter().any(|c| c.memories.len() == 2),
+            "two memories owned by the same agent should still cluster"
+        );
     }
 }

--- a/crates/mentedb/src/lib.rs
+++ b/crates/mentedb/src/lib.rs
@@ -1294,6 +1294,16 @@ impl MenteDb {
             ));
         }
 
+        // Never merge across owners. find_candidates already groups by agent, but
+        // if a caller hands us a hand-built mixed cluster, refuse rather than leak
+        // one user's content into another's consolidated memory.
+        let owner = cluster[0].agent_id;
+        if cluster.iter().any(|m| m.agent_id != owner) {
+            return Err(MenteError::Query(
+                "consolidation cluster mixes agents; refusing to merge across owners".into(),
+            ));
+        }
+
         let result = self.consolidation.consolidate(&cluster);
 
         // Create the consolidated memory node.


### PR DESCRIPTION
## Summary
Second isolation fix (follows the process_turn recall fix in #224). The consolidation maintenance job could **permanently merge memories owned by different agents** into one memory, mixing one user's content into another's. This is the most severe of the cross-agent mixing points found in the isolation audit.

## Root cause
`ConsolidationEngine::find_candidates` (consolidation.rs) ran union-find over memory embeddings with **no owner check**, so two similar memories owned by different agents were clustered together. `consolidate_cluster` (lib.rs) then merged the cluster and stamped it with `cluster[0].agent_id`, so Bob's content ended up inside a memory owned by Alice. Irreversible (sources are invalidated).

## Fix
- `find_candidates`: skip any pair whose `agent_id` differs before unioning, so every cluster is single-owner. Global (nil-owned) and agent-owned memories never merge together either.
- `consolidate_cluster`: defensive guard that refuses a hand-built cluster mixing agents.

## Tests
- New `find_candidates_never_merges_across_agents` (consolidation.rs): identical embeddings across two agents must not cluster; same-owner memories still do. Fails without the fix.
- Updated `test_find_candidates_and_consolidate`: `make_memory` assigns a fresh `agent_id` per call, so the two memories that should consolidate now share an owner (the realistic case).

## Verification
- `cargo test -p mentedb-consolidation`: 29 passed. `cargo test -p mentedb`: 112 passed (no regression).
- `cargo clippy --workspace -- -D warnings`: clean. `cargo fmt`: clean.

## Still open (next PR)
Consolidation was the most severe. The remaining cross-agent mixing points from the audit (user/agent **profile**, **entity linking**, **community detection**, **enrichment extraction**) are a larger per-agent enrichment refactor, tracked separately. Decay, archival, contradiction, and write-inference are already owner-scoped.