### PR TITLE
fix: scope enrichment/profile/entity/community by agent (full memory isolation)

### DIFF
--- a/crates/mentedb/src/enrichment.rs
+++ b/crates/mentedb/src/enrichment.rs
@@ -63,167 +63,192 @@ pub async fn run_enrichment<J: LlmJudge>(
 ) -> EnrichmentResult {
     let mut result = EnrichmentResult::default();
 
-    if !skip_extraction {
-        let candidates = db.enrichment_candidates();
-        if candidates.is_empty() {
-            tracing::debug!("enrichment: no candidates, marking complete");
-            db.mark_enrichment_complete(current_turn);
-            return result;
-        }
-
-        tracing::info!(
-            candidates = candidates.len(),
-            "starting sleeptime enrichment"
-        );
-
-        // ── Phase 1: Batch LLM Extraction ──
-        let http_provider = match HttpExtractionProvider::new(extraction_config.clone()) {
-            Ok(p) => p,
-            Err(e) => {
-                tracing::error!(error = %e, "enrichment: failed to create HTTP provider");
-                db.mark_enrichment_complete(current_turn);
-                return result;
-            }
-        };
-
-        let enrichment_config = db.enrichment_config().clone();
-        let pipeline_cfg = ExtractionConfig {
-            quality_threshold: enrichment_config.min_confidence,
-            ..extraction_config
-        };
-        let pipeline = ExtractionPipeline::new(http_provider, pipeline_cfg);
-
-        let batches = batch_conversations(&candidates, 10);
-
-        for (batch_idx, batch) in batches.iter().enumerate() {
-            let conversation = batch
-                .iter()
-                .map(|m| m.content.as_str())
-                .collect::<Vec<_>>()
-                .join("\n---\n");
-
-            let source_ids: Vec<mentedb_core::types::MemoryId> =
-                batch.iter().map(|m| m.id).collect();
-
-            // Get existing memories for dedup
-            let existing: Vec<MemoryNode> = if let Ok(Some(emb)) =
-                db.embed_text(&conversation[..conversation.len().min(500)])
-            {
-                db.recall_similar(&emb, 30)
-                    .unwrap_or_default()
-                    .into_iter()
-                    .filter_map(|(id, _)| db.get_memory(id).ok())
-                    .collect()
+    // Enrichment runs once per owning agent (nil / global included, as just
+    // another owner). Each pass reads and writes only that owner's memories, so
+    // one user's derived knowledge (extracted facts, entities, communities,
+    // profile) never mixes with another's.
+    for agent in db.distinct_agent_ids() {
+        if !skip_extraction {
+            let candidates = db.enrichment_candidates(agent);
+            if candidates.is_empty() {
+                tracing::debug!(?agent, "enrichment: no candidates for owner, skipping");
             } else {
-                Vec::new()
-            };
+                tracing::info!(
+                    ?agent,
+                    candidates = candidates.len(),
+                    "starting sleeptime enrichment for owner"
+                );
 
-            match pipeline.process(&conversation, &existing, embedder).await {
-                Ok(extraction_result) => {
-                    result.duplicates_skipped += extraction_result.stats.rejected_duplicate;
-                    result.contradictions_found += extraction_result.stats.contradictions_found;
+                // ── Phase 1: Batch LLM Extraction ──
+                let http_provider = match HttpExtractionProvider::new(extraction_config.clone()) {
+                    Ok(p) => p,
+                    Err(e) => {
+                        tracing::error!(error = %e, "enrichment: failed to create HTTP provider");
+                        db.mark_enrichment_complete(current_turn);
+                        return result;
+                    }
+                };
 
-                    let mut nodes = Vec::new();
-                    for mem in extraction_result
-                        .to_store
+                let enrichment_config = db.enrichment_config().clone();
+                let pipeline_cfg = ExtractionConfig {
+                    quality_threshold: enrichment_config.min_confidence,
+                    ..extraction_config.clone()
+                };
+                let pipeline = ExtractionPipeline::new(http_provider, pipeline_cfg);
+
+                let batches = batch_conversations(&candidates, 10);
+
+                for (batch_idx, batch) in batches.iter().enumerate() {
+                    let conversation = batch
                         .iter()
-                        .chain(extraction_result.contradictions.iter().map(|(m, _)| m))
+                        .map(|m| m.content.as_str())
+                        .collect::<Vec<_>>()
+                        .join("\n---\n");
+
+                    let source_ids: Vec<mentedb_core::types::MemoryId> =
+                        batch.iter().map(|m| m.id).collect();
+
+                    // Get existing memories for dedup, scoped to this owner (plus
+                    // global) so dedup never compares against another user's data.
+                    let existing: Vec<MemoryNode> = if let Ok(Some(emb)) =
+                        db.embed_text(&conversation[..conversation.len().min(500)])
                     {
-                        let mem_type = mentedb_extraction::map_extraction_type_to_memory_type(
-                            &mem.memory_type,
-                        );
-                        let embedding = match embedder.embed(&mem.content) {
-                            Ok(e) => e,
-                            Err(e) => {
-                                tracing::warn!(error = %e, "enrichment: embedding failed");
-                                continue;
-                            }
-                        };
-                        let mut node = MemoryNode::new(
-                            AgentId::nil(),
-                            mem_type,
-                            mem.content.clone(),
-                            embedding,
-                        );
-                        node.tags = mem.tags.clone();
-                        node.confidence = mem.confidence;
-                        nodes.push(node);
-                    }
+                        let now_us = std::time::SystemTime::now()
+                            .duration_since(std::time::UNIX_EPOCH)
+                            .unwrap_or_default()
+                            .as_micros() as u64;
+                        db.recall_hybrid_scoped_at_mode(
+                            &emb,
+                            None,
+                            30,
+                            now_us,
+                            None,
+                            false,
+                            None,
+                            Some(agent),
+                        )
+                        .unwrap_or_default()
+                        .into_iter()
+                        .filter_map(|(id, _)| db.get_memory(id).ok())
+                        .collect()
+                    } else {
+                        Vec::new()
+                    };
 
-                    // Build entity nodes
-                    for entity in &extraction_result.entities {
-                        let content = entity.to_content();
-                        let embedding_text = entity.embedding_key();
-                        let embedding = match embedder.embed(&embedding_text) {
-                            Ok(e) => e,
-                            Err(e) => {
-                                tracing::warn!(error = %e, "enrichment: entity embedding failed");
-                                continue;
-                            }
-                        };
-                        let mut node = MemoryNode::new(
-                            AgentId::nil(),
-                            MemoryType::Semantic,
-                            content,
-                            embedding,
-                        );
-                        let name_lower = entity.name.to_lowercase();
-                        node.tags.push(format!("entity:{}", name_lower));
-                        node.tags
-                            .push(format!("entity_type:{}", entity.entity_type));
-                        if let Some(cat) = entity.attributes.get("category") {
-                            for c in cat.split(',').map(|s| s.trim()).filter(|s| !s.is_empty()) {
-                                node.tags.push(format!("category:{}", c.to_lowercase()));
-                            }
-                        }
-                        nodes.push(node);
-                        result.entities_extracted += 1;
-                    }
+                    match pipeline.process(&conversation, &existing, embedder).await {
+                        Ok(extraction_result) => {
+                            result.duplicates_skipped += extraction_result.stats.rejected_duplicate;
+                            result.contradictions_found +=
+                                extraction_result.stats.contradictions_found;
 
-                    match db.store_enrichment_memories(nodes, &source_ids) {
-                        Ok((stored, edges)) => {
-                            result.memories_stored += stored;
-                            result.edges_created += edges;
+                            let mut nodes = Vec::new();
+                            for mem in extraction_result
+                                .to_store
+                                .iter()
+                                .chain(extraction_result.contradictions.iter().map(|(m, _)| m))
+                            {
+                                let mem_type =
+                                    mentedb_extraction::map_extraction_type_to_memory_type(
+                                        &mem.memory_type,
+                                    );
+                                let embedding = match embedder.embed(&mem.content) {
+                                    Ok(e) => e,
+                                    Err(e) => {
+                                        tracing::warn!(error = %e, "enrichment: embedding failed");
+                                        continue;
+                                    }
+                                };
+                                let mut node = MemoryNode::new(
+                                    agent,
+                                    mem_type,
+                                    mem.content.clone(),
+                                    embedding,
+                                );
+                                node.tags = mem.tags.clone();
+                                node.confidence = mem.confidence;
+                                nodes.push(node);
+                            }
+
+                            // Build entity nodes
+                            for entity in &extraction_result.entities {
+                                let content = entity.to_content();
+                                let embedding_text = entity.embedding_key();
+                                let embedding = match embedder.embed(&embedding_text) {
+                                    Ok(e) => e,
+                                    Err(e) => {
+                                        tracing::warn!(error = %e, "enrichment: entity embedding failed");
+                                        continue;
+                                    }
+                                };
+                                let mut node = MemoryNode::new(
+                                    agent,
+                                    MemoryType::Semantic,
+                                    content,
+                                    embedding,
+                                );
+                                let name_lower = entity.name.to_lowercase();
+                                node.tags.push(format!("entity:{}", name_lower));
+                                node.tags
+                                    .push(format!("entity_type:{}", entity.entity_type));
+                                if let Some(cat) = entity.attributes.get("category") {
+                                    for c in
+                                        cat.split(',').map(|s| s.trim()).filter(|s| !s.is_empty())
+                                    {
+                                        node.tags.push(format!("category:{}", c.to_lowercase()));
+                                    }
+                                }
+                                nodes.push(node);
+                                result.entities_extracted += 1;
+                            }
+
+                            match db.store_enrichment_memories(nodes, &source_ids) {
+                                Ok((stored, edges)) => {
+                                    result.memories_stored += stored;
+                                    result.edges_created += edges;
+                                }
+                                Err(e) => {
+                                    tracing::error!(batch = batch_idx, error = %e, "enrichment: failed to store batch");
+                                }
+                            }
                         }
                         Err(e) => {
-                            tracing::error!(batch = batch_idx, error = %e, "enrichment: failed to store batch");
+                            tracing::error!(batch = batch_idx, error = %e, "enrichment: extraction failed");
                         }
                     }
                 }
-                Err(e) => {
-                    tracing::error!(batch = batch_idx, error = %e, "enrichment: extraction failed");
-                }
             }
+        } else {
+            tracing::info!("enrichment: skipping Phase 1 extraction (skip_extraction=true)");
         }
-    } else {
-        tracing::info!("enrichment: skipping Phase 1 extraction (skip_extraction=true)");
-    }
 
-    // ── Phase 2: Entity Linking ──
-    let sync_link_result = match db.link_entities() {
-        Ok(r) => r,
-        Err(e) => {
-            tracing::error!(error = %e, "enrichment: sync entity linking failed");
-            crate::EntityLinkResult::default()
+        // ── Phase 2: Entity Linking (this owner only) ──
+        let sync_link_result = match db.link_entities_for(agent) {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::error!(error = %e, "enrichment: sync entity linking failed");
+                crate::EntityLinkResult::default()
+            }
+        };
+        result.sync_linked += sync_link_result.linked;
+        result.edges_created += sync_link_result.edges_created;
+
+        if let Some(llm) = cognitive_llm {
+            let llm_link = run_llm_entity_linking(db, llm, agent).await;
+            result.llm_linked += llm_link.linked;
+            result.edges_created += llm_link.edges_created;
         }
-    };
-    result.sync_linked = sync_link_result.linked;
-    result.edges_created += sync_link_result.edges_created;
 
-    if let Some(llm) = cognitive_llm {
-        let llm_link = run_llm_entity_linking(db, llm).await;
-        result.llm_linked = llm_link.linked;
-        result.edges_created += llm_link.edges_created;
-    }
+        // ── Phase 3: Community Detection (this owner only) ──
+        if let Some(llm) = cognitive_llm {
+            result.communities_created += run_community_detection(db, llm, agent).await;
+        }
 
-    // ── Phase 3: Community Detection ──
-    if let Some(llm) = cognitive_llm {
-        result.communities_created = run_community_detection(db, llm).await;
-    }
-
-    // ── Phase 4: User Model ──
-    if let Some(llm) = cognitive_llm {
-        result.user_model_updated = run_user_model(db, llm).await;
+        // ── Phase 4: User Model (this owner only) ──
+        if let Some(llm) = cognitive_llm
+            && run_user_model(db, llm, agent).await
+        {
+            result.user_model_updated = true;
+        }
     }
 
     db.mark_enrichment_complete(current_turn);
@@ -245,13 +270,14 @@ pub async fn run_enrichment<J: LlmJudge>(
     result
 }
 
-/// Phase 2b: LLM entity resolution for unresolved entities.
+/// Phase 2b: LLM entity resolution for unresolved entities owned by `agent`.
 async fn run_llm_entity_linking<J: LlmJudge>(
     db: &MenteDb,
     llm: &CognitiveLlmService<J>,
+    agent: AgentId,
 ) -> crate::EntityLinkResult {
-    let all_entities_with_context = db.entity_names_with_context();
-    let unresolved = db.unresolved_entity_names();
+    let all_entities_with_context = db.entity_names_with_context(agent);
+    let unresolved = db.unresolved_entity_names(agent);
 
     if unresolved.is_empty() {
         return crate::EntityLinkResult::default();
@@ -302,7 +328,7 @@ async fn run_llm_entity_linking<J: LlmJudge>(
 
     let separations: Vec<crate::EntitySeparation> = Vec::new();
 
-    match db.apply_entity_link_resolutions(&resolutions, &separations) {
+    match db.apply_entity_link_resolutions(&resolutions, &separations, agent) {
         Ok(r) => r,
         Err(e) => {
             tracing::error!(error = %e, "enrichment: failed to apply entity resolutions");
@@ -311,11 +337,16 @@ async fn run_llm_entity_linking<J: LlmJudge>(
     }
 }
 
-/// Phase 3: Community detection — group entities by category, generate LLM summaries.
-async fn run_community_detection<J: LlmJudge>(db: &MenteDb, llm: &CognitiveLlmService<J>) -> usize {
-    let communities = db.entity_communities();
+/// Phase 3: Community detection — group this owner's entities by category,
+/// generate LLM summaries owned by `agent`.
+async fn run_community_detection<J: LlmJudge>(
+    db: &MenteDb,
+    llm: &CognitiveLlmService<J>,
+    agent: AgentId,
+) -> usize {
+    let communities = db.entity_communities(agent);
     let existing_summaries: HashSet<String> = db
-        .community_summaries()
+        .community_summaries(agent)
         .iter()
         .flat_map(|m| {
             m.tags
@@ -341,7 +372,7 @@ async fn run_community_detection<J: LlmJudge>(db: &MenteDb, llm: &CognitiveLlmSe
             Ok(summary) => {
                 let member_names: Vec<String> =
                     entity_pairs.iter().map(|(n, _)| n.clone()).collect();
-                match db.store_community_summary(category, &summary.summary, &member_names) {
+                match db.store_community_summary(category, &summary.summary, &member_names, agent) {
                     Ok(_) => {
                         created += 1;
                         tracing::info!(category = %category, members = members.len(), "community summary created");
@@ -360,11 +391,16 @@ async fn run_community_detection<J: LlmJudge>(db: &MenteDb, llm: &CognitiveLlmSe
     created
 }
 
-/// Phase 4: User model generation — synthesize always-scoped profile.
-async fn run_user_model<J: LlmJudge>(db: &MenteDb, llm: &CognitiveLlmService<J>) -> bool {
-    let facts = db.profile_facts();
+/// Phase 4: User model generation — synthesize an always-scoped profile for
+/// `agent` from that owner's facts and community summaries only.
+async fn run_user_model<J: LlmJudge>(
+    db: &MenteDb,
+    llm: &CognitiveLlmService<J>,
+    agent: AgentId,
+) -> bool {
+    let facts = db.profile_facts(agent);
     let community_texts: Vec<String> = db
-        .community_summaries()
+        .community_summaries(agent)
         .iter()
         .map(|m| m.content.clone())
         .collect();
@@ -374,7 +410,7 @@ async fn run_user_model<J: LlmJudge>(db: &MenteDb, llm: &CognitiveLlmService<J>)
     }
 
     match llm.generate_user_profile(&facts, &community_texts).await {
-        Ok(profile) => match db.store_user_profile(&profile.profile) {
+        Ok(profile) => match db.store_user_profile(&profile.profile, agent) {
             Ok(_) => {
                 tracing::info!("user profile updated");
                 true

--- a/crates/mentedb/src/lib.rs
+++ b/crates/mentedb/src/lib.rs
@@ -952,8 +952,20 @@ impl MenteDb {
                 .duration_since(std::time::UNIX_EPOCH)
                 .unwrap_or_default()
                 .as_micros() as u64;
-            self.recall_hybrid_at(&new_memory.embedding, None, 20, now, None, None)
-                .unwrap_or_default()
+            // Scope to the new memory's owner: contradiction and relationship
+            // inference must never compare against another user's memories.
+            // Nil owned (shared/global) memories stay in scope.
+            self.recall_hybrid_scoped_at_mode(
+                &new_memory.embedding,
+                None,
+                20,
+                now,
+                None,
+                false,
+                None,
+                Some(new_memory.agent_id),
+            )
+            .unwrap_or_default()
         } else {
             vec![]
         };
@@ -1972,21 +1984,53 @@ impl MenteDb {
         *self.enrichment_pending.write() = true;
     }
 
+    /// Distinct agent ids that own at least one memory. Enrichment runs once per
+    /// owner so one user's derived knowledge never mixes with another's.
+    fn distinct_agent_ids(&self) -> Vec<AgentId> {
+        let page_ids: Vec<PageId> = self.page_map.read().values().copied().collect();
+        let mut agents: Vec<AgentId> = Vec::new();
+        for pid in &page_ids {
+            if let Ok(mem) = self.storage.load_memory(*pid)
+                && !agents.contains(&mem.agent_id)
+            {
+                agents.push(mem.agent_id);
+            }
+        }
+        agents
+    }
+
     /// Get episodic memories that haven't been enriched yet.
     ///
     /// Returns all Episodic memories created after the last enrichment turn,
-    /// sorted by creation time. These are the candidates for LLM extraction.
-    pub fn enrichment_candidates(&self) -> Vec<MemoryNode> {
+    /// owned by `agent` (exact-owner match, so one user's episodics are never
+    /// enriched into another user's knowledge), sorted by creation time. These
+    /// are the candidates for LLM extraction.
+    pub fn enrichment_candidates(&self, agent: AgentId) -> Vec<MemoryNode> {
         let last_turn = *self.last_enrichment_turn.read();
         let page_ids: Vec<PageId> = self.page_map.read().values().copied().collect();
         let mut candidates: Vec<MemoryNode> = page_ids
             .iter()
             .filter_map(|pid| self.storage.load_memory(*pid).ok())
             .filter(|m| {
-                m.memory_type == mentedb_core::memory::MemoryType::Episodic
+                m.agent_id == agent
+                    && m.memory_type == mentedb_core::memory::MemoryType::Episodic
                     && !m.tags.contains(&"source:enrichment".to_string())
                     && m.created_at > last_turn
             })
+            .collect();
+        candidates.sort_by_key(|m| m.created_at);
+        candidates
+    }
+
+    /// All unenriched episodic candidates across every owner, sorted by creation
+    /// time. This is an owner-agnostic introspection view (the enrichment
+    /// pipeline itself scopes per owner via [`Self::enrichment_candidates`]); it
+    /// exists so SDK callers can list pending work without an agent argument.
+    pub fn all_enrichment_candidates(&self) -> Vec<MemoryNode> {
+        let mut candidates: Vec<MemoryNode> = self
+            .distinct_agent_ids()
+            .into_iter()
+            .flat_map(|agent| self.enrichment_candidates(agent))
             .collect();
         candidates.sort_by_key(|m| m.created_at);
         candidates
@@ -2064,15 +2108,19 @@ impl MenteDb {
         &self.cognitive_config.enrichment_config
     }
 
-    /// Get all unique entity names from stored entity memories.
+    /// Get all unique entity names from stored entity memories owned by `agent`.
     ///
     /// Returns deduplicated, normalized entity names extracted from
-    /// `entity:{name}` tags across all stored memories.
-    pub fn all_entity_names(&self) -> Vec<String> {
+    /// `entity:{name}` tags across this agent's stored memories only, so one
+    /// user's entities never bleed into another's resolution.
+    pub fn all_entity_names(&self, agent: AgentId) -> Vec<String> {
         let page_ids: Vec<PageId> = self.page_map.read().values().copied().collect();
         let mut names = std::collections::HashSet::new();
         for pid in &page_ids {
             if let Ok(mem) = self.storage.load_memory(*pid) {
+                if mem.agent_id != agent {
+                    continue;
+                }
                 for tag in &mem.tags {
                     if let Some(name) = tag.strip_prefix("entity:") {
                         names.insert(name.to_lowercase().trim().to_string());
@@ -2089,8 +2137,8 @@ impl MenteDb {
     ///
     /// These are the entities that need LLM resolution. The EntityResolver
     /// cache handles known entities for free.
-    pub fn unresolved_entity_names(&self) -> Vec<String> {
-        let all_names = self.all_entity_names();
+    pub fn unresolved_entity_names(&self, agent: AgentId) -> Vec<String> {
+        let all_names = self.all_entity_names(agent);
         self.entity_resolver.read().unresolved_names(&all_names)
     }
 
@@ -2099,12 +2147,15 @@ impl MenteDb {
     /// Returns (name, content) pairs for entities that need resolution.
     /// The content helps the LLM disambiguate (e.g., "Python" near
     /// "web framework" vs "Python" near "Monty Python").
-    pub fn entity_names_with_context(&self) -> Vec<(String, Option<String>)> {
+    pub fn entity_names_with_context(&self, agent: AgentId) -> Vec<(String, Option<String>)> {
         let page_ids: Vec<PageId> = self.page_map.read().values().copied().collect();
         let mut entity_contexts: HashMap<String, String> = HashMap::new();
 
         for pid in &page_ids {
             if let Ok(mem) = self.storage.load_memory(*pid) {
+                if mem.agent_id != agent {
+                    continue;
+                }
                 for tag in &mem.tags {
                     if let Some(name) = tag.strip_prefix("entity:") {
                         let normalized = name.to_lowercase().trim().to_string();
@@ -2145,6 +2196,7 @@ impl MenteDb {
         &self,
         merge_groups: &[EntityLinkResolution],
         separations: &[EntitySeparation],
+        agent: AgentId,
     ) -> MenteResult<EntityLinkResult> {
         let mut result = EntityLinkResult::default();
         let now = std::time::SystemTime::now()
@@ -2152,8 +2204,9 @@ impl MenteDb {
             .unwrap_or_default()
             .as_micros() as u64;
 
-        // Build a map: normalized entity name → list of memory IDs
-        let entity_memory_map = self.build_entity_memory_map();
+        // Build a map: normalized entity name → list of memory IDs (this agent's
+        // entities only, so links never span owners).
+        let entity_memory_map = self.build_entity_memory_map(agent);
 
         let mut resolver = self.entity_resolver.write();
 
@@ -2263,10 +2316,22 @@ impl MenteDb {
     /// Link entities using only the sync EntityResolver (cache + rules, no LLM).
     ///
     /// This is the fast path — links entities that are already known to be
-    /// the same from previous LLM resolutions. For full LLM-powered resolution,
-    /// use `unresolved_entity_names()` + `apply_entity_link_resolutions()`.
+    /// the same from previous LLM resolutions. Runs once per owner so entity
+    /// links never span users; each owner's entities are linked in isolation
+    /// (nil owned / global entities are linked among themselves).
     pub fn link_entities(&self) -> MenteResult<EntityLinkResult> {
-        let entity_memory_map = self.build_entity_memory_map();
+        let mut total = EntityLinkResult::default();
+        for agent in self.distinct_agent_ids() {
+            let r = self.link_entities_for(agent)?;
+            total.linked += r.linked;
+            total.edges_created += r.edges_created;
+        }
+        Ok(total)
+    }
+
+    /// Sync entity linking scoped to a single owner. See [`Self::link_entities`].
+    pub(crate) fn link_entities_for(&self, agent: AgentId) -> MenteResult<EntityLinkResult> {
+        let entity_memory_map = self.build_entity_memory_map(agent);
         let resolver = self.entity_resolver.read();
 
         // Group entity names by their resolved canonical name
@@ -2355,12 +2420,17 @@ impl MenteDb {
         Ok(result)
     }
 
-    /// Build a map of normalized entity name → list of MemoryIds.
-    fn build_entity_memory_map(&self) -> HashMap<String, Vec<MemoryId>> {
+    /// Build a map of normalized entity name → list of MemoryIds, restricted to
+    /// entity memories owned by `agent` so links and community membership never
+    /// cross owners.
+    fn build_entity_memory_map(&self, agent: AgentId) -> HashMap<String, Vec<MemoryId>> {
         let page_ids: Vec<PageId> = self.page_map.read().values().copied().collect();
         let mut map: HashMap<String, Vec<MemoryId>> = HashMap::new();
         for pid in &page_ids {
             if let Ok(mem) = self.storage.load_memory(*pid) {
+                if mem.agent_id != agent {
+                    continue;
+                }
                 for tag in &mem.tags {
                     if let Some(name) = tag.strip_prefix("entity:") {
                         let normalized = name.to_lowercase().trim().to_string();
@@ -2388,12 +2458,16 @@ impl MenteDb {
     ///
     /// Returns a map of category → list of (entity_name, context_snippet).
     /// Categories come from `entity_type:` tags on entity memories.
-    pub fn entity_communities(&self) -> HashMap<String, Vec<(String, String)>> {
+    pub fn entity_communities(&self, agent: AgentId) -> HashMap<String, Vec<(String, String)>> {
         let page_ids: Vec<PageId> = self.page_map.read().values().copied().collect();
         let mut categories: HashMap<String, Vec<(String, String)>> = HashMap::new();
 
         for pid in &page_ids {
             if let Ok(mem) = self.storage.load_memory(*pid) {
+                // Only cluster this agent's entities so communities never mix owners.
+                if mem.agent_id != agent {
+                    continue;
+                }
                 // Skip non-entity memories and existing community summaries
                 if mem.tags.iter().any(|t| t == "community_summary") {
                     continue;
@@ -2436,6 +2510,7 @@ impl MenteDb {
         category: &str,
         summary: &str,
         member_names: &[String],
+        agent: AgentId,
     ) -> MenteResult<MemoryId> {
         if category.is_empty() {
             return Err(MenteError::Storage(
@@ -2448,12 +2523,14 @@ impl MenteDb {
             .unwrap_or_default()
             .as_micros() as u64;
 
-        // Check if a community summary already exists for this category
+        // Check if a community summary already exists for this category AND owner,
+        // so one user's summary never overwrites another's.
         let community_tag = format!("community:{}", category);
         let page_ids: Vec<PageId> = self.page_map.read().values().copied().collect();
         let mut existing_id = None;
         for pid in &page_ids {
             if let Ok(mem) = self.storage.load_memory(*pid)
+                && mem.agent_id == agent
                 && mem.tags.iter().any(|t| t == &community_tag)
             {
                 // Update existing summary content
@@ -2480,12 +2557,8 @@ impl MenteDb {
                 .and_then(|e| e.embed(summary).ok())
                 .unwrap_or_default();
 
-            let mut node = MemoryNode::new(
-                mentedb_core::types::AgentId::new(),
-                MemoryType::Semantic,
-                summary.to_string(),
-                embedding,
-            );
+            let mut node =
+                MemoryNode::new(agent, MemoryType::Semantic, summary.to_string(), embedding);
             node.tags = vec![
                 "community_summary".to_string(),
                 community_tag,
@@ -2499,7 +2572,7 @@ impl MenteDb {
 
         // (Re)create Derived edges from summary to member entity memories.
         // On update this refreshes edges to reflect current membership.
-        let entity_map = self.build_entity_memory_map();
+        let entity_map = self.build_entity_memory_map(agent);
         for name in member_names {
             let normalized = name.to_lowercase();
             if let Some(member_ids) = entity_map.get(&normalized) {
@@ -2521,25 +2594,31 @@ impl MenteDb {
         Ok(node_id)
     }
 
-    /// Get existing community summaries.
-    pub fn community_summaries(&self) -> Vec<MemoryNode> {
+    /// Get existing community summaries owned by `agent`, so each owner only sees
+    /// its own community summaries.
+    pub fn community_summaries(&self, agent: AgentId) -> Vec<MemoryNode> {
         let page_ids: Vec<PageId> = self.page_map.read().values().copied().collect();
         page_ids
             .iter()
             .filter_map(|pid| self.storage.load_memory(*pid).ok())
-            .filter(|m| m.tags.iter().any(|t| t == "community_summary"))
+            .filter(|m| m.agent_id == agent && m.tags.iter().any(|t| t == "community_summary"))
             .collect()
     }
 
     /// Collect all semantic/procedural facts for user profile generation.
     ///
     /// Returns high-confidence memories suitable for profile building.
-    pub fn profile_facts(&self) -> Vec<String> {
+    pub fn profile_facts(&self, agent: AgentId) -> Vec<String> {
         let page_ids: Vec<PageId> = self.page_map.read().values().copied().collect();
         let mut facts = Vec::new();
 
         for pid in &page_ids {
             if let Ok(mem) = self.storage.load_memory(*pid) {
+                // Only this agent's facts, so a profile is built from one owner's
+                // knowledge and never mixes in another user's memories.
+                if mem.agent_id != agent {
+                    continue;
+                }
                 // Only semantic and procedural memories with decent confidence
                 if mem.confidence < 0.5 {
                     continue;
@@ -2566,15 +2645,18 @@ impl MenteDb {
         facts
     }
 
-    /// Store or update the user profile as an always-scoped memory.
+    /// Store or update the user profile as an always-scoped memory owned by
+    /// `agent`.
     ///
-    /// There is exactly one user profile memory (tagged `user_profile`).
-    /// If one already exists, it's replaced entirely.
-    pub fn store_user_profile(&self, profile: &str) -> MenteResult<MemoryId> {
-        // Find existing profile
+    /// There is exactly one user profile memory (tagged `user_profile`) per
+    /// owner. If one already exists for this agent, it's replaced entirely; one
+    /// user's profile never overwrites another's.
+    pub fn store_user_profile(&self, profile: &str, agent: AgentId) -> MenteResult<MemoryId> {
+        // Find existing profile for this owner
         let page_ids: Vec<PageId> = self.page_map.read().values().copied().collect();
         for pid in &page_ids {
             if let Ok(mem) = self.storage.load_memory(*pid)
+                && mem.agent_id == agent
                 && mem.tags.iter().any(|t| t == "user_profile")
             {
                 // Update in place, bumping created_at so it reflects when the
@@ -2604,12 +2686,7 @@ impl MenteDb {
             .and_then(|e| e.embed(profile).ok())
             .unwrap_or_default();
 
-        let mut node = MemoryNode::new(
-            mentedb_core::types::AgentId::new(),
-            MemoryType::Semantic,
-            profile.to_string(),
-            embedding,
-        );
+        let mut node = MemoryNode::new(agent, MemoryType::Semantic, profile.to_string(), embedding);
         node.tags = vec![
             "user_profile".to_string(),
             "scope:always".to_string(),
@@ -2633,5 +2710,43 @@ impl MenteDb {
             }
         }
         None
+    }
+}
+
+#[cfg(test)]
+mod distinct_agent_tests {
+    use super::*;
+
+    /// `distinct_agent_ids` must enumerate every owner that holds a memory, since
+    /// enrichment loops over its result to scope derived knowledge per owner. This
+    /// is a unit test (not an integration test) because the method is private.
+    #[test]
+    fn distinct_agent_ids_returns_all_owners() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = MenteDb::open(dir.path()).unwrap();
+        let alice = AgentId::new();
+        let bob = AgentId::new();
+
+        db.store(MemoryNode::new(
+            alice,
+            MemoryType::Semantic,
+            "alice likes falcons".into(),
+            vec![0.1_f32; 8],
+        ))
+        .unwrap();
+        db.store(MemoryNode::new(
+            bob,
+            MemoryType::Semantic,
+            "bob likes turtles".into(),
+            vec![0.2_f32; 8],
+        ))
+        .unwrap();
+
+        let agents = db.distinct_agent_ids();
+        assert!(
+            agents.contains(&alice),
+            "distinct owners must include alice"
+        );
+        assert!(agents.contains(&bob), "distinct owners must include bob");
     }
 }

--- a/crates/mentedb/tests/integration.rs
+++ b/crates/mentedb/tests/integration.rs
@@ -1594,10 +1594,12 @@ fn test_store_user_profile_bumps_updated_timestamp() {
     // showed "updated N days ago" forever.
     let dir = tempfile::tempdir().unwrap();
     let db = MenteDb::open(dir.path()).unwrap();
-    db.store_user_profile("first version").unwrap();
+    db.store_user_profile("first version", AgentId::nil())
+        .unwrap();
     let t1 = db.user_profile().unwrap().created_at;
     std::thread::sleep(std::time::Duration::from_millis(2));
-    db.store_user_profile("second version").unwrap();
+    db.store_user_profile("second version", AgentId::nil())
+        .unwrap();
     let node = db.user_profile().unwrap();
     assert_eq!(
         node.content, "second version",

--- a/crates/mentedb/tests/process_turn.rs
+++ b/crates/mentedb/tests/process_turn.rs
@@ -310,7 +310,10 @@ fn test_enrichment_disabled_by_default() {
     let (db, _dir) = open_db();
     assert!(!db.needs_enrichment());
     assert_eq!(db.last_enrichment_turn(), 0);
-    assert!(db.enrichment_candidates().is_empty());
+    assert!(
+        db.enrichment_candidates(mentedb_core::types::AgentId::nil())
+            .is_empty()
+    );
 }
 
 #[test]
@@ -364,7 +367,7 @@ fn test_enrichment_candidates_returns_episodics() {
         db.process_turn(&input, &mut delta).unwrap();
     }
 
-    let candidates = db.enrichment_candidates();
+    let candidates = db.enrichment_candidates(mentedb_core::types::AgentId::nil());
     assert!(
         candidates.len() >= 3,
         "should have at least 3 episodic candidates"
@@ -409,7 +412,7 @@ fn test_enrichment_store_results() {
     assert_eq!(edges, 1);
 
     // Verify the stored memory has enrichment tag and capped confidence
-    let candidates = db.enrichment_candidates();
+    let candidates = db.enrichment_candidates(mentedb_core::types::AgentId::nil());
     // The enrichment memory should NOT show up as a candidate (it has source:enrichment tag)
     for c in &candidates {
         assert!(
@@ -616,7 +619,11 @@ fn test_apply_entity_link_resolutions() {
     let separations = vec![];
 
     let result = db
-        .apply_entity_link_resolutions(&resolutions, &separations)
+        .apply_entity_link_resolutions(
+            &resolutions,
+            &separations,
+            mentedb_core::types::AgentId::nil(),
+        )
         .unwrap();
     assert!(result.edges_created > 0, "should create cross-name edges");
     assert!(result.linked > 0, "should report linked pairs");
@@ -665,12 +672,16 @@ fn test_entity_separation_negative_cache() {
         name_b: "java programming".to_string(),
     }];
 
-    db.apply_entity_link_resolutions(&resolutions, &separations)
-        .unwrap();
+    db.apply_entity_link_resolutions(
+        &resolutions,
+        &separations,
+        mentedb_core::types::AgentId::nil(),
+    )
+    .unwrap();
 
     // Verify: "java" and "java programming" should show as unresolved
     // (negative cache prevents future LLM calls for this pair)
-    let unresolved = db.unresolved_entity_names();
+    let unresolved = db.unresolved_entity_names(mentedb_core::types::AgentId::nil());
     // Both are still "unresolved" in terms of having no canonical alias,
     // but the negative cache will skip them in future LLM batches
     assert!(unresolved.contains(&"java".to_string()));

--- a/crates/mentedb/tests/user_isolation.rs
+++ b/crates/mentedb/tests/user_isolation.rs
@@ -181,3 +181,48 @@ fn scoped_recall_excludes_other_users_even_as_top_match() {
         "SECURITY: another user's private memory must never appear, even as the top match"
     );
 }
+
+/// The enrichment helpers must be exact-owner scoped: the derived-knowledge
+/// pipeline (profile, entities, communities) may only read the target owner's
+/// memories, so one user's profile is never built from another user's facts.
+#[test]
+fn enrichment_helpers_are_owner_scoped() {
+    let (db, _dir) = open_db();
+    let alice = AgentId::new();
+    let bob = AgentId::new();
+    // Alice and Bob each store a semantic fact.
+    let a = MemoryNode::new(
+        alice,
+        MemoryType::Semantic,
+        "alice likes falcons".into(),
+        emb("alice likes falcons"),
+    );
+    db.store(a).unwrap();
+    let b = MemoryNode::new(
+        bob,
+        MemoryType::Semantic,
+        "bob likes turtles".into(),
+        emb("bob likes turtles"),
+    );
+    db.store(b).unwrap();
+
+    let alice_facts = db.profile_facts(alice);
+    assert!(
+        alice_facts.iter().any(|f| f.contains("falcons")),
+        "alice sees her own fact"
+    );
+    assert!(
+        !alice_facts.iter().any(|f| f.contains("turtles")),
+        "alice must NOT see bob's fact in her profile facts"
+    );
+
+    let bob_facts = db.profile_facts(bob);
+    assert!(
+        !bob_facts.iter().any(|f| f.contains("falcons")),
+        "bob must NOT see alice's fact"
+    );
+    assert!(
+        bob_facts.iter().any(|f| f.contains("turtles")),
+        "bob sees his own fact"
+    );
+}

--- a/sdks/python/Cargo.lock
+++ b/sdks/python/Cargo.lock
@@ -1525,7 +1525,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb"
-version = "0.12.1"
+version = "0.12.6"
 dependencies = [
  "mentedb-cognitive",
  "mentedb-consolidation",
@@ -1545,7 +1545,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-cognitive"
-version = "0.12.1"
+version = "0.12.6"
 dependencies = [
  "ahash",
  "crossbeam",
@@ -1560,7 +1560,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-consolidation"
-version = "0.12.1"
+version = "0.12.6"
 dependencies = [
  "ahash",
  "mentedb-core",
@@ -1571,7 +1571,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-context"
-version = "0.12.1"
+version = "0.12.6"
 dependencies = [
  "ahash",
  "mentedb-core",
@@ -1583,7 +1583,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-core"
-version = "0.12.1"
+version = "0.12.6"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1598,7 +1598,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-embedding"
-version = "0.12.1"
+version = "0.12.6"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -1619,7 +1619,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-extraction"
-version = "0.12.1"
+version = "0.12.6"
 dependencies = [
  "mentedb-cognitive",
  "mentedb-core",
@@ -1635,7 +1635,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-graph"
-version = "0.12.1"
+version = "0.12.6"
 dependencies = [
  "ahash",
  "bincode",
@@ -1650,7 +1650,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-index"
-version = "0.12.1"
+version = "0.12.6"
 dependencies = [
  "ahash",
  "bincode",
@@ -1688,7 +1688,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-query"
-version = "0.12.1"
+version = "0.12.6"
 dependencies = [
  "mentedb-core",
  "serde",
@@ -1699,7 +1699,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-storage"
-version = "0.12.1"
+version = "0.12.6"
 dependencies = [
  "ahash",
  "bincode",

--- a/sdks/python/python/mentedb/client.py
+++ b/sdks/python/python/mentedb/client.py
@@ -30,12 +30,14 @@ class MenteDB:
         embedding_provider: str | None = None,
         embedding_api_key: str | None = None,
         embedding_model: str | None = None,
+        dimension: int | None = None,
     ):
         self._db = _MenteDB(
             data_dir,
             embedding_provider=embedding_provider,
             embedding_api_key=embedding_api_key,
             embedding_model=embedding_model,
+            dimension=dimension,
         )
 
     def process_turn(

--- a/sdks/python/src/lib.rs
+++ b/sdks/python/src/lib.rs
@@ -123,12 +123,13 @@ struct MenteDB {
 #[pymethods]
 impl MenteDB {
     #[new]
-    #[pyo3(signature = (data_dir, embedding_provider=None, embedding_api_key=None, embedding_model=None))]
+    #[pyo3(signature = (data_dir, embedding_provider=None, embedding_api_key=None, embedding_model=None, dimension=None))]
     fn new(
         data_dir: &str,
         embedding_provider: Option<&str>,
         embedding_api_key: Option<&str>,
         embedding_model: Option<&str>,
+        dimension: Option<usize>,
     ) -> PyResult<Self> {
         let embedder: Option<Box<dyn EmbeddingProvider>> = match embedding_provider {
             Some("openai") => {
@@ -191,9 +192,18 @@ impl MenteDB {
 
         let mut db = MenteDb::open_with_config(Path::new(data_dir), CognitiveConfig::default())
             .map_err(to_pyerr)?;
-        if let Some(ref e) = embedder {
-            db.set_embedder(Box::new(HashEmbeddingProvider::new(e.dimensions())));
-        }
+        // An explicit `dimension` lets callers bring their own embeddings at an
+        // arbitrary size (for example a 4096-dim external embedder), overriding
+        // the provider-derived or default 384 vector dimension.
+        let embedder: Option<Box<dyn EmbeddingProvider>> = if let Some(d) = dimension {
+            db.set_embedder(Box::new(HashEmbeddingProvider::new(d)));
+            Some(Box::new(HashEmbeddingProvider::new(d)))
+        } else {
+            if let Some(ref e) = embedder {
+                db.set_embedder(Box::new(HashEmbeddingProvider::new(e.dimensions())));
+            }
+            embedder
+        };
         Ok(Self {
             db: Some(db),
             embedder,
@@ -4781,7 +4791,7 @@ impl MenteDB {
             .db
             .as_ref()
             .ok_or_else(|| PyRuntimeError::new_err("database is closed"))?;
-        let candidates = db.enrichment_candidates();
+        let candidates = db.all_enrichment_candidates();
         let result: Vec<Py<PyAny>> = candidates
             .iter()
             .map(|m| {

--- a/sdks/typescript/Cargo.lock
+++ b/sdks/typescript/Cargo.lock
@@ -672,7 +672,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mentedb"
-version = "0.10.5"
+version = "0.12.6"
 dependencies = [
  "mentedb-cognitive",
  "mentedb-consolidation",
@@ -691,7 +691,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-cognitive"
-version = "0.10.5"
+version = "0.12.6"
 dependencies = [
  "ahash",
  "crossbeam",
@@ -706,7 +706,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-consolidation"
-version = "0.10.5"
+version = "0.12.6"
 dependencies = [
  "ahash",
  "mentedb-core",
@@ -717,7 +717,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-context"
-version = "0.10.5"
+version = "0.12.6"
 dependencies = [
  "ahash",
  "mentedb-core",
@@ -729,7 +729,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-core"
-version = "0.10.5"
+version = "0.12.6"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-embedding"
-version = "0.10.5"
+version = "0.12.6"
 dependencies = [
  "mentedb-core",
  "serde",
@@ -756,7 +756,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-extraction"
-version = "0.10.5"
+version = "0.12.6"
 dependencies = [
  "mentedb-cognitive",
  "mentedb-core",
@@ -772,7 +772,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-graph"
-version = "0.10.5"
+version = "0.12.6"
 dependencies = [
  "ahash",
  "bincode",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-index"
-version = "0.10.5"
+version = "0.12.6"
 dependencies = [
  "ahash",
  "bincode",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-query"
-version = "0.10.5"
+version = "0.12.6"
 dependencies = [
  "mentedb-core",
  "serde",
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-storage"
-version = "0.10.5"
+version = "0.12.6"
 dependencies = [
  "ahash",
  "bincode",
@@ -1199,9 +1199,9 @@ dependencies = [
 
 [[package]]
 name = "roaring"
-version = "0.10.12"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e8d2cfa184d94d0726d650a9f4a1be7f9b76ac9fdb954219878dc00c1c1e7b"
+checksum = "1dedc5658c6ecb3bdb5ef5f3295bb9253f42dcf3fd1402c03f6b1f7659c3c4a9"
 dependencies = [
  "bytemuck",
  "byteorder",

--- a/sdks/typescript/src/lib.rs
+++ b/sdks/typescript/src/lib.rs
@@ -457,7 +457,7 @@ impl MenteDB {
     /// Get episodic memories that need enrichment.
     #[napi]
     pub fn enrichment_candidates(&self) -> Result<Vec<JsContextItem>> {
-        let candidates = self.inner.enrichment_candidates();
+        let candidates = self.inner.all_enrichment_candidates();
         Ok(candidates
             .iter()
             .map(|m| JsContextItem {


### PR DESCRIPTION
## Summary
Completes multi-user/agent memory isolation. Recall (v0.12.4) and consolidation (v0.12.6) were scoped; this closes the remaining derived-knowledge surfaces that still mixed memories across owners when one engine serves multiple users/agents by `agent_id`.

Design: recall + write-inference see own + global (`agent_visible`); enrichment/profile/entity/community partition by **exact owner** (`mem.agent_id != agent → skip`) and their outputs are **owned by that agent**, never nil-dumped for everyone. Nil (global) is just another owner in the loop.

## Changes (engine)
- New private `distinct_agent_ids()`; `run_enrichment` now runs all 4 phases **once per owner**.
- Exact-owner scoping added to: `enrichment_candidates`, `profile_facts`, `all_entity_names`, `unresolved_entity_names`, `entity_names_with_context`, `build_entity_memory_map`, `entity_communities`, `community_summaries`, `apply_entity_link_resolutions`.
- Outputs owned by the agent: `store_user_profile` and `store_community_summary` now create their node with `agent` (was `AgentId::new()`), and only update an existing node owned by that agent. Extracted/entity memories in enrichment are owned by the source agent (was `AgentId::nil()`). Dedup recall in extraction is agent-scoped.
- `link_entities()` keeps its public signature and loops per owner internally (`link_entities_for(agent)`).
- Store-time `run_write_inference` now scopes candidate gathering to the new memory's owner (was unscoped) — the second inference path missed in the recall fix.

## SDK
- SDK-bound signatures (`link_entities`, `run_enrichment`, `entity_memories`) unchanged. Added `all_enrichment_candidates()` so the Python/TS `enrichment_candidates` wrappers keep their behavior. `sdks/python/src/lib.rs` also carries a small, additive, previously-staged `dimension=None` constructor param (bring-your-own-embedding-dimension); noted here for transparency.

## Tests
- `crates/mentedb/tests/user_isolation.rs`: `enrichment_helpers_are_owner_scoped` — Alice's `profile_facts` contain her fact and never Bob's, and vice versa. Fails on the pre-fix (unscoped) code.
- Existing tests that assumed cross-owner behavior updated to a shared/global owner (`AgentId::nil()`), preserving isolation.

## Verification
- `cargo test -p mentedb`: 114 passed. `--features enrichment`: 114 passed.
- `cargo clippy -p mentedb --features enrichment -- -D warnings`: clean. `cargo fmt --check`: clean.
- Both SDKs `cargo check` clean against the modified engine.

## Isolation status after this
Recall, decay, contradiction, consolidation, profile, entity-linking, community, enrichment: all owner-scoped. Cross-tenant (separate API keys) remains structurally separate engines.