### PR TITLE
feat: orthogonal user_id isolation dimension (per-user scoping alongside agent_id)

### DIFF
--- a/crates/mentedb-consolidation/src/consolidation.rs
+++ b/crates/mentedb-consolidation/src/consolidation.rs
@@ -70,10 +70,14 @@ impl ConsolidationEngine {
 
         for i in 0..n {
             for j in (i + 1)..n {
-                // Never consolidate across owners: memories belonging to different
-                // agents (and agent-owned vs global) must never merge into one, or
-                // one user's content would leak into another's consolidated memory.
-                if memories[i].agent_id != memories[j].agent_id {
+                // Never consolidate across owners: memories belonging to
+                // different agents OR different users (and owned vs global on
+                // either axis) must never merge into one, or one owner's content
+                // would leak into another's consolidated memory. Both owner axes
+                // are checked independently.
+                if memories[i].agent_id != memories[j].agent_id
+                    || memories[i].user_id != memories[j].user_id
+                {
                     continue;
                 }
                 let sim = cosine_similarity(&memories[i].embedding, &memories[j].embedding);

--- a/crates/mentedb-consolidation/src/lib.rs
+++ b/crates/mentedb-consolidation/src/lib.rs
@@ -36,7 +36,7 @@ pub use forget::{ForgetEngine, ForgetRequest, ForgetResult};
 pub(crate) mod test_helpers {
     use mentedb_core::MemoryNode;
     use mentedb_core::memory::MemoryType;
-    use mentedb_core::types::{AgentId, Embedding, MemoryId, SpaceId};
+    use mentedb_core::types::{AgentId, Embedding, MemoryId, SpaceId, UserId};
     use std::collections::HashMap;
 
     /// Create a simple test memory with given content and embedding.
@@ -44,6 +44,7 @@ pub(crate) mod test_helpers {
         MemoryNode {
             id: MemoryId::new(),
             agent_id: AgentId::new(),
+            user_id: UserId::nil(),
             memory_type: MemoryType::Episodic,
             embedding,
             content: content.to_string(),

--- a/crates/mentedb-consolidation/tests/integration.rs
+++ b/crates/mentedb-consolidation/tests/integration.rs
@@ -4,7 +4,7 @@ use mentedb_consolidation::{
 };
 use mentedb_core::MemoryNode;
 use mentedb_core::memory::MemoryType;
-use mentedb_core::types::{AgentId, MemoryId, SpaceId};
+use mentedb_core::types::{AgentId, MemoryId, SpaceId, UserId};
 use std::collections::HashMap;
 
 const DAY_US: u64 = 24 * 3600 * 1_000_000;
@@ -13,6 +13,7 @@ fn make_memory(content: &str, embedding: Vec<f32>) -> MemoryNode {
     MemoryNode {
         id: MemoryId::new(),
         agent_id: AgentId::new(),
+        user_id: UserId::nil(),
         memory_type: MemoryType::Episodic,
         embedding,
         content: content.to_string(),

--- a/crates/mentedb-core/src/memory.rs
+++ b/crates/mentedb-core/src/memory.rs
@@ -3,7 +3,16 @@
 use serde::{Deserialize, Serialize};
 
 use crate::types::*;
-use crate::types::{AgentId, MemoryId, SpaceId};
+use crate::types::{AgentId, MemoryId, SpaceId, UserId};
+
+/// Default `user_id` for memories deserialized from data written before the
+/// `user_id` axis existed: the nil (shared/global) user. This must be an
+/// explicit function, not `#[serde(default)]`, because `UserId::default()`
+/// mints a fresh random id, which would make old memories look owned by a
+/// random user instead of shared.
+fn default_user_id() -> UserId {
+    UserId::nil()
+}
 
 /// The type classification of a memory.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -32,6 +41,13 @@ pub struct MemoryNode {
     pub id: MemoryId,
     /// The agent that owns this memory.
     pub agent_id: AgentId,
+    /// The end user that owns this memory (orthogonal to `agent_id`).
+    ///
+    /// A memory belongs to both a user and an agent; a scoped query sees it
+    /// only when it is visible on both axes. Defaults to the nil (shared)
+    /// user, both for `new()` and for data written before this field existed.
+    #[serde(default = "default_user_id")]
+    pub user_id: UserId,
     /// Memory type classification.
     pub memory_type: MemoryType,
     /// Embedding vector for semantic similarity search.
@@ -80,6 +96,7 @@ impl MemoryNode {
         Self {
             id: MemoryId::new(),
             agent_id,
+            user_id: UserId::nil(),
             memory_type,
             embedding,
             content,
@@ -94,6 +111,15 @@ impl MemoryNode {
             valid_from: None,
             valid_until: None,
         }
+    }
+
+    /// Set the owning end user, returning the node (builder style).
+    ///
+    /// Parallels the `agent_id` constructor argument on the orthogonal user
+    /// axis. Leave unset (nil) for shared/global memories.
+    pub fn with_user_id(mut self, user_id: UserId) -> Self {
+        self.user_id = user_id;
+        self
     }
 }
 
@@ -121,7 +147,7 @@ impl MemoryNode {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::AgentId;
+    use crate::types::{AgentId, UserId};
 
     #[test]
     fn new_memory_has_no_temporal_bounds() {
@@ -159,6 +185,27 @@ mod tests {
         assert_eq!(node.valid_from, None);
         assert_eq!(node.valid_until, None);
         assert!(node.is_valid_at(5000));
+        // Data written before the user_id axis existed must deserialize as the
+        // nil (shared) user, never a random one. A random default would make
+        // legacy memories look privately owned and vanish from every scoped
+        // query.
+        assert!(
+            node.user_id.is_nil(),
+            "legacy memory (no user_id) must default to the nil user"
+        );
+    }
+
+    #[test]
+    fn with_user_id_sets_owner() {
+        let user = UserId::new();
+        let node = MemoryNode::new(
+            AgentId::new(),
+            MemoryType::Semantic,
+            "test".to_string(),
+            vec![1.0],
+        )
+        .with_user_id(user);
+        assert_eq!(node.user_id, user);
     }
 }
 

--- a/crates/mentedb-core/src/types.rs
+++ b/crates/mentedb-core/src/types.rs
@@ -74,6 +74,15 @@ define_id!(
 );
 
 define_id!(
+    /// Unique identifier for an end user.
+    ///
+    /// An orthogonal owner axis alongside [`AgentId`]: a memory belongs to both
+    /// a user and an agent, and a scoped query only sees a memory when it is
+    /// visible on both axes. The nil user is shared/global (visible to all).
+    UserId
+);
+
+define_id!(
     /// Unique identifier for a memory space.
     SpaceId
 );

--- a/crates/mentedb-server/src/extraction_queue.rs
+++ b/crates/mentedb-server/src/extraction_queue.rs
@@ -8,7 +8,7 @@
 
 use std::sync::Arc;
 
-use mentedb_core::types::{AgentId, SpaceId};
+use mentedb_core::types::{AgentId, SpaceId, UserId};
 use mentedb_extraction::ExtractionConfig;
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
@@ -87,6 +87,7 @@ async fn process_extraction(req: ExtractionRequest) -> Result<(), String> {
         let node = MemoryNode {
             id,
             agent_id: req.agent_id,
+            user_id: UserId::nil(),
             memory_type,
             embedding: vec![],
             content: memory.content.clone(),

--- a/crates/mentedb-server/src/grpc.rs
+++ b/crates/mentedb-server/src/grpc.rs
@@ -24,7 +24,7 @@ pub mod pb {
     tonic::include_proto!("mentedb");
 }
 
-use mentedb_core::types::{AgentId, MemoryId, SpaceId};
+use mentedb_core::types::{AgentId, MemoryId, SpaceId, UserId};
 use pb::cognition_service_server::CognitionService;
 use pb::memory_service_server::MemoryService;
 
@@ -227,6 +227,7 @@ impl MemoryService for MemoryServiceImpl {
         let node = MemoryNode {
             id,
             agent_id,
+            user_id: UserId::nil(),
             memory_type,
             embedding: req.embedding,
             content: req.content,

--- a/crates/mentedb-server/src/handlers.rs
+++ b/crates/mentedb-server/src/handlers.rs
@@ -23,7 +23,7 @@ use uuid::Uuid;
 
 use crate::error::ApiError;
 use crate::state::AppState;
-use mentedb_core::types::{AgentId, MemoryId, SpaceId};
+use mentedb_core::types::{AgentId, MemoryId, SpaceId, UserId};
 
 // ---------------------------------------------------------------------------
 // GET /v1/health
@@ -121,6 +121,7 @@ pub async fn store_memory(
     let node = MemoryNode {
         id,
         agent_id,
+        user_id: UserId::nil(),
         memory_type,
         embedding,
         content: content.clone(),
@@ -453,6 +454,7 @@ async fn run_extraction(
         let node = MemoryNode {
             id,
             agent_id,
+            user_id: UserId::nil(),
             memory_type,
             embedding: vec![],
             content: memory.content.clone(),

--- a/crates/mentedb/src/enrichment.rs
+++ b/crates/mentedb/src/enrichment.rs
@@ -13,7 +13,7 @@ use std::collections::HashSet;
 use mentedb_cognitive::llm::{CognitiveLlmService, LlmJudge};
 use mentedb_core::MemoryNode;
 use mentedb_core::memory::MemoryType;
-use mentedb_core::types::AgentId;
+use mentedb_core::types::{AgentId, UserId};
 use mentedb_embedding::provider::EmbeddingProvider;
 use mentedb_extraction::{ExtractionConfig, ExtractionPipeline, HttpExtractionProvider};
 
@@ -63,17 +63,23 @@ pub async fn run_enrichment<J: LlmJudge>(
 ) -> EnrichmentResult {
     let mut result = EnrichmentResult::default();
 
-    // Enrichment runs once per owning agent (nil / global included, as just
-    // another owner). Each pass reads and writes only that owner's memories, so
-    // one user's derived knowledge (extracted facts, entities, communities,
-    // profile) never mixes with another's.
-    for agent in db.distinct_agent_ids() {
+    // Enrichment runs once per distinct (user, agent) owner pair (nil / global
+    // included on either axis, as just another owner). Each pass reads and
+    // writes only that pair's memories, so one owner's derived knowledge
+    // (extracted facts, entities, communities, profile) never mixes with
+    // another's across either the user or the agent axis.
+    for (user, agent) in db.distinct_owner_pairs() {
         if !skip_extraction {
-            let candidates = db.enrichment_candidates(agent);
+            let candidates = db.enrichment_candidates(user, agent);
             if candidates.is_empty() {
-                tracing::debug!(?agent, "enrichment: no candidates for owner, skipping");
+                tracing::debug!(
+                    ?user,
+                    ?agent,
+                    "enrichment: no candidates for owner, skipping"
+                );
             } else {
                 tracing::info!(
+                    ?user,
                     ?agent,
                     candidates = candidates.len(),
                     "starting sleeptime enrichment for owner"
@@ -108,8 +114,9 @@ pub async fn run_enrichment<J: LlmJudge>(
                     let source_ids: Vec<mentedb_core::types::MemoryId> =
                         batch.iter().map(|m| m.id).collect();
 
-                    // Get existing memories for dedup, scoped to this owner (plus
-                    // global) so dedup never compares against another user's data.
+                    // Get existing memories for dedup, scoped to this (user,
+                    // agent) pair (plus global) so dedup never compares against
+                    // another owner's data on either axis.
                     let existing: Vec<MemoryNode> = if let Ok(Some(emb)) =
                         db.embed_text(&conversation[..conversation.len().min(500)])
                     {
@@ -126,6 +133,7 @@ pub async fn run_enrichment<J: LlmJudge>(
                             false,
                             None,
                             Some(agent),
+                            Some(user),
                         )
                         .unwrap_or_default()
                         .into_iter()
@@ -163,7 +171,8 @@ pub async fn run_enrichment<J: LlmJudge>(
                                     mem_type,
                                     mem.content.clone(),
                                     embedding,
-                                );
+                                )
+                                .with_user_id(user);
                                 node.tags = mem.tags.clone();
                                 node.confidence = mem.confidence;
                                 nodes.push(node);
@@ -185,7 +194,8 @@ pub async fn run_enrichment<J: LlmJudge>(
                                     MemoryType::Semantic,
                                     content,
                                     embedding,
-                                );
+                                )
+                                .with_user_id(user);
                                 let name_lower = entity.name.to_lowercase();
                                 node.tags.push(format!("entity:{}", name_lower));
                                 node.tags
@@ -221,8 +231,8 @@ pub async fn run_enrichment<J: LlmJudge>(
             tracing::info!("enrichment: skipping Phase 1 extraction (skip_extraction=true)");
         }
 
-        // ── Phase 2: Entity Linking (this owner only) ──
-        let sync_link_result = match db.link_entities_for(agent) {
+        // ── Phase 2: Entity Linking (this owner pair only) ──
+        let sync_link_result = match db.link_entities_for(user, agent) {
             Ok(r) => r,
             Err(e) => {
                 tracing::error!(error = %e, "enrichment: sync entity linking failed");
@@ -233,19 +243,19 @@ pub async fn run_enrichment<J: LlmJudge>(
         result.edges_created += sync_link_result.edges_created;
 
         if let Some(llm) = cognitive_llm {
-            let llm_link = run_llm_entity_linking(db, llm, agent).await;
+            let llm_link = run_llm_entity_linking(db, llm, user, agent).await;
             result.llm_linked += llm_link.linked;
             result.edges_created += llm_link.edges_created;
         }
 
-        // ── Phase 3: Community Detection (this owner only) ──
+        // ── Phase 3: Community Detection (this owner pair only) ──
         if let Some(llm) = cognitive_llm {
-            result.communities_created += run_community_detection(db, llm, agent).await;
+            result.communities_created += run_community_detection(db, llm, user, agent).await;
         }
 
-        // ── Phase 4: User Model (this owner only) ──
+        // ── Phase 4: User Model (this owner pair only) ──
         if let Some(llm) = cognitive_llm
-            && run_user_model(db, llm, agent).await
+            && run_user_model(db, llm, user, agent).await
         {
             result.user_model_updated = true;
         }
@@ -270,14 +280,16 @@ pub async fn run_enrichment<J: LlmJudge>(
     result
 }
 
-/// Phase 2b: LLM entity resolution for unresolved entities owned by `agent`.
+/// Phase 2b: LLM entity resolution for unresolved entities owned by exactly
+/// this (`user`, `agent`) pair.
 async fn run_llm_entity_linking<J: LlmJudge>(
     db: &MenteDb,
     llm: &CognitiveLlmService<J>,
+    user: UserId,
     agent: AgentId,
 ) -> crate::EntityLinkResult {
-    let all_entities_with_context = db.entity_names_with_context(agent);
-    let unresolved = db.unresolved_entity_names(agent);
+    let all_entities_with_context = db.entity_names_with_context(user, agent);
+    let unresolved = db.unresolved_entity_names(user, agent);
 
     if unresolved.is_empty() {
         return crate::EntityLinkResult::default();
@@ -328,7 +340,7 @@ async fn run_llm_entity_linking<J: LlmJudge>(
 
     let separations: Vec<crate::EntitySeparation> = Vec::new();
 
-    match db.apply_entity_link_resolutions(&resolutions, &separations, agent) {
+    match db.apply_entity_link_resolutions(&resolutions, &separations, user, agent) {
         Ok(r) => r,
         Err(e) => {
             tracing::error!(error = %e, "enrichment: failed to apply entity resolutions");
@@ -337,16 +349,17 @@ async fn run_llm_entity_linking<J: LlmJudge>(
     }
 }
 
-/// Phase 3: Community detection — group this owner's entities by category,
-/// generate LLM summaries owned by `agent`.
+/// Phase 3: Community detection — group this owner pair's entities by category,
+/// generate LLM summaries owned by exactly this (`user`, `agent`) pair.
 async fn run_community_detection<J: LlmJudge>(
     db: &MenteDb,
     llm: &CognitiveLlmService<J>,
+    user: UserId,
     agent: AgentId,
 ) -> usize {
-    let communities = db.entity_communities(agent);
+    let communities = db.entity_communities(user, agent);
     let existing_summaries: HashSet<String> = db
-        .community_summaries(agent)
+        .community_summaries(user, agent)
         .iter()
         .flat_map(|m| {
             m.tags
@@ -372,7 +385,13 @@ async fn run_community_detection<J: LlmJudge>(
             Ok(summary) => {
                 let member_names: Vec<String> =
                     entity_pairs.iter().map(|(n, _)| n.clone()).collect();
-                match db.store_community_summary(category, &summary.summary, &member_names, agent) {
+                match db.store_community_summary(
+                    category,
+                    &summary.summary,
+                    &member_names,
+                    user,
+                    agent,
+                ) {
                     Ok(_) => {
                         created += 1;
                         tracing::info!(category = %category, members = members.len(), "community summary created");
@@ -392,15 +411,17 @@ async fn run_community_detection<J: LlmJudge>(
 }
 
 /// Phase 4: User model generation — synthesize an always-scoped profile for
-/// `agent` from that owner's facts and community summaries only.
+/// exactly this (`user`, `agent`) pair from that owner's facts and community
+/// summaries only.
 async fn run_user_model<J: LlmJudge>(
     db: &MenteDb,
     llm: &CognitiveLlmService<J>,
+    user: UserId,
     agent: AgentId,
 ) -> bool {
-    let facts = db.profile_facts(agent);
+    let facts = db.profile_facts(user, agent);
     let community_texts: Vec<String> = db
-        .community_summaries(agent)
+        .community_summaries(user, agent)
         .iter()
         .map(|m| m.content.clone())
         .collect();
@@ -410,7 +431,7 @@ async fn run_user_model<J: LlmJudge>(
     }
 
     match llm.generate_user_profile(&facts, &community_texts).await {
-        Ok(profile) => match db.store_user_profile(&profile.profile, agent) {
+        Ok(profile) => match db.store_user_profile(&profile.profile, user, agent) {
             Ok(_) => {
                 tracing::info!("user profile updated");
                 true

--- a/crates/mentedb/src/injection.rs
+++ b/crates/mentedb/src/injection.rs
@@ -27,7 +27,7 @@ use std::collections::HashSet;
 
 use mentedb_core::error::MenteResult;
 use mentedb_core::memory::{AttributeValue, MemoryNode, MemoryType};
-use mentedb_core::types::{AgentId, MemoryId};
+use mentedb_core::types::{AgentId, MemoryId, UserId};
 
 use crate::MenteDb;
 
@@ -88,6 +88,10 @@ pub struct InjectionQuery<'a> {
     /// Restrict recall to this agent's memories plus shared (nil owned)
     /// knowledge. None recalls globally.
     pub agent_id: Option<AgentId>,
+    /// Restrict recall to this user's memories plus shared (nil owned)
+    /// knowledge, orthogonal to `agent_id`. None recalls globally on the user
+    /// axis. A memory is injectable only when visible on BOTH axes.
+    pub user_id: Option<UserId>,
 }
 
 /// Why an item was selected, for introspection and client display.
@@ -191,6 +195,7 @@ impl MenteDb {
                 false,
                 None,
                 query.agent_id,
+                query.user_id,
             )
             .unwrap_or_default();
 
@@ -289,6 +294,7 @@ impl MenteDb {
                 && has_tag(&node, "scope:always")
                 && !excluded.contains(&node.id)
                 && crate::agent_visible(node.agent_id, query.agent_id)
+                && crate::user_visible(node.user_id, query.user_id)
             {
                 result.push(InjectionCandidate {
                     node,

--- a/crates/mentedb/src/lib.rs
+++ b/crates/mentedb/src/lib.rs
@@ -63,7 +63,7 @@ use mentedb_context::{AssemblyConfig, ContextAssembler, ContextWindow, ScoredMem
 use mentedb_core::edge::EdgeType;
 use mentedb_core::error::MenteResult;
 use mentedb_core::memory::MemoryType;
-use mentedb_core::types::{AgentId, MemoryId, Timestamp};
+use mentedb_core::types::{AgentId, MemoryId, Timestamp, UserId};
 use mentedb_core::{MemoryEdge, MemoryNode, MenteError};
 use mentedb_embedding::provider::EmbeddingProvider;
 use mentedb_graph::GraphManager;
@@ -347,6 +347,18 @@ pub(crate) fn agent_visible(owner: AgentId, scope: Option<AgentId>) -> bool {
     match scope {
         None => true,
         Some(a) => owner == a || owner.is_nil(),
+    }
+}
+
+/// User visibility rule for scoped retrieval, orthogonal to [`agent_visible`]:
+/// a node is visible to a user when it is owned by that user or owned by no
+/// user (nil, shared knowledge). No scope means global visibility. A scoped
+/// query at (user U, agent A) requires BOTH `user_visible(owner_user, U)` and
+/// `agent_visible(owner_agent, A)`.
+pub(crate) fn user_visible(owner: UserId, scope: Option<UserId>) -> bool {
+    match scope {
+        None => true,
+        Some(u) => owner == u || owner.is_nil(),
     }
 }
 
@@ -699,14 +711,16 @@ impl MenteDb {
         time_range: Option<(Timestamp, Timestamp)>,
     ) -> MenteResult<Vec<(MemoryId, f32)>> {
         self.recall_hybrid_scoped_at_mode(
-            embedding, query_text, k, at, tags, tags_or, time_range, None,
+            embedding, query_text, k, at, tags, tags_or, time_range, None, None,
         )
     }
 
-    /// Hybrid recall visible to one agent: nodes owned by `agent` or owned
-    /// by no agent (nil, shared knowledge) pass; other agents' memories are
-    /// invisible. `agent: None` recalls globally, preserving single agent
-    /// behavior.
+    /// Hybrid recall visible to one (user, agent) scope: a node passes only
+    /// when it is visible on BOTH axes, i.e. owned by `agent` or no agent AND
+    /// owned by `user` or no user (nil, shared knowledge). `agent: None` /
+    /// `user: None` recall globally on that axis, preserving single-owner
+    /// behavior. The two axes are orthogonal: agent scoping never widens or
+    /// narrows user scoping, and vice versa.
     #[allow(clippy::too_many_arguments)]
     pub fn recall_hybrid_scoped_at_mode(
         &self,
@@ -718,6 +732,7 @@ impl MenteDb {
         tags_or: bool,
         time_range: Option<(Timestamp, Timestamp)>,
         agent: Option<AgentId>,
+        user: Option<UserId>,
     ) -> MenteResult<Vec<(MemoryId, f32)>> {
         debug!(
             "Recall hybrid, k={}, at={}, bm25={}, tags_or={}",
@@ -759,8 +774,10 @@ impl MenteDb {
                     return Some((id, raw_score));
                 };
                 // Drop memories outside their validity window or not visible to
-                // this agent.
-                if !node.is_valid_at(at) || !agent_visible(node.agent_id, agent) {
+                // this (user, agent) scope. Both owner axes must pass.
+                let visible =
+                    agent_visible(node.agent_id, agent) && user_visible(node.user_id, user);
+                if !node.is_valid_at(at) || !visible {
                     return None;
                 }
                 // Decay at recall time: the index salience cache is frozen at
@@ -952,9 +969,10 @@ impl MenteDb {
                 .duration_since(std::time::UNIX_EPOCH)
                 .unwrap_or_default()
                 .as_micros() as u64;
-            // Scope to the new memory's owner: contradiction and relationship
-            // inference must never compare against another user's memories.
-            // Nil owned (shared/global) memories stay in scope.
+            // Scope to the new memory's owner on BOTH axes: contradiction and
+            // relationship inference must never compare against another user's
+            // or another agent's memories. Nil owned (shared/global) memories
+            // stay in scope.
             self.recall_hybrid_scoped_at_mode(
                 &new_memory.embedding,
                 None,
@@ -964,6 +982,7 @@ impl MenteDb {
                 false,
                 None,
                 Some(new_memory.agent_id),
+                Some(new_memory.user_id),
             )
             .unwrap_or_default()
         } else {
@@ -1306,26 +1325,36 @@ impl MenteDb {
             ));
         }
 
-        // Never merge across owners. find_candidates already groups by agent, but
-        // if a caller hands us a hand-built mixed cluster, refuse rather than leak
-        // one user's content into another's consolidated memory.
-        let owner = cluster[0].agent_id;
-        if cluster.iter().any(|m| m.agent_id != owner) {
+        // Never merge across owners. find_candidates already groups by both
+        // owner axes, but if a caller hands us a hand-built mixed cluster,
+        // refuse rather than leak one owner's content into another's
+        // consolidated memory. Both axes are checked independently.
+        let owner_agent = cluster[0].agent_id;
+        if cluster.iter().any(|m| m.agent_id != owner_agent) {
             return Err(MenteError::Query(
                 "consolidation cluster mixes agents; refusing to merge across owners".into(),
+            ));
+        }
+        let owner_user = cluster[0].user_id;
+        if cluster.iter().any(|m| m.user_id != owner_user) {
+            return Err(MenteError::Query(
+                "consolidation cluster mixes users; refusing to merge across owners".into(),
             ));
         }
 
         let result = self.consolidation.consolidate(&cluster);
 
-        // Create the consolidated memory node.
+        // Create the consolidated memory node, stamped with BOTH owner axes of
+        // the cluster so the derived memory stays scoped exactly as its sources.
         let agent_id = cluster[0].agent_id;
+        let user_id = cluster[0].user_id;
         let mut consolidated = MemoryNode::new(
             agent_id,
             result.new_type,
             result.summary,
             result.combined_embedding,
-        );
+        )
+        .with_user_id(user_id);
         consolidated.confidence = result.combined_confidence;
 
         let consolidated_id = consolidated.id;
@@ -1984,28 +2013,34 @@ impl MenteDb {
         *self.enrichment_pending.write() = true;
     }
 
-    /// Distinct agent ids that own at least one memory. Enrichment runs once per
-    /// owner so one user's derived knowledge never mixes with another's.
-    fn distinct_agent_ids(&self) -> Vec<AgentId> {
+    /// Distinct (user_id, agent_id) owner pairs that own at least one memory.
+    ///
+    /// Enrichment partitions by BOTH owner axes: it runs once per distinct pair
+    /// so derived knowledge (extracted facts, entities, communities, profile)
+    /// stays scoped to exactly the user AND agent that owned the source
+    /// memories, never mixing across either axis.
+    fn distinct_owner_pairs(&self) -> Vec<(UserId, AgentId)> {
         let page_ids: Vec<PageId> = self.page_map.read().values().copied().collect();
-        let mut agents: Vec<AgentId> = Vec::new();
+        let mut pairs: Vec<(UserId, AgentId)> = Vec::new();
         for pid in &page_ids {
-            if let Ok(mem) = self.storage.load_memory(*pid)
-                && !agents.contains(&mem.agent_id)
-            {
-                agents.push(mem.agent_id);
+            if let Ok(mem) = self.storage.load_memory(*pid) {
+                let pair = (mem.user_id, mem.agent_id);
+                if !pairs.contains(&pair) {
+                    pairs.push(pair);
+                }
             }
         }
-        agents
+        pairs
     }
 
     /// Get episodic memories that haven't been enriched yet.
     ///
     /// Returns all Episodic memories created after the last enrichment turn,
-    /// owned by `agent` (exact-owner match, so one user's episodics are never
-    /// enriched into another user's knowledge), sorted by creation time. These
-    /// are the candidates for LLM extraction.
-    pub fn enrichment_candidates(&self, agent: AgentId) -> Vec<MemoryNode> {
+    /// owned by exactly this (`user`, `agent`) pair (exact match on BOTH owner
+    /// axes, so one owner's episodics are never enriched into another's
+    /// knowledge), sorted by creation time. These are the candidates for LLM
+    /// extraction.
+    pub fn enrichment_candidates(&self, user: UserId, agent: AgentId) -> Vec<MemoryNode> {
         let last_turn = *self.last_enrichment_turn.read();
         let page_ids: Vec<PageId> = self.page_map.read().values().copied().collect();
         let mut candidates: Vec<MemoryNode> = page_ids
@@ -2013,6 +2048,7 @@ impl MenteDb {
             .filter_map(|pid| self.storage.load_memory(*pid).ok())
             .filter(|m| {
                 m.agent_id == agent
+                    && m.user_id == user
                     && m.memory_type == mentedb_core::memory::MemoryType::Episodic
                     && !m.tags.contains(&"source:enrichment".to_string())
                     && m.created_at > last_turn
@@ -2028,9 +2064,9 @@ impl MenteDb {
     /// exists so SDK callers can list pending work without an agent argument.
     pub fn all_enrichment_candidates(&self) -> Vec<MemoryNode> {
         let mut candidates: Vec<MemoryNode> = self
-            .distinct_agent_ids()
+            .distinct_owner_pairs()
             .into_iter()
-            .flat_map(|agent| self.enrichment_candidates(agent))
+            .flat_map(|(user, agent)| self.enrichment_candidates(user, agent))
             .collect();
         candidates.sort_by_key(|m| m.created_at);
         candidates
@@ -2113,12 +2149,12 @@ impl MenteDb {
     /// Returns deduplicated, normalized entity names extracted from
     /// `entity:{name}` tags across this agent's stored memories only, so one
     /// user's entities never bleed into another's resolution.
-    pub fn all_entity_names(&self, agent: AgentId) -> Vec<String> {
+    pub fn all_entity_names(&self, user: UserId, agent: AgentId) -> Vec<String> {
         let page_ids: Vec<PageId> = self.page_map.read().values().copied().collect();
         let mut names = std::collections::HashSet::new();
         for pid in &page_ids {
             if let Ok(mem) = self.storage.load_memory(*pid) {
-                if mem.agent_id != agent {
+                if mem.agent_id != agent || mem.user_id != user {
                     continue;
                 }
                 for tag in &mem.tags {
@@ -2137,8 +2173,8 @@ impl MenteDb {
     ///
     /// These are the entities that need LLM resolution. The EntityResolver
     /// cache handles known entities for free.
-    pub fn unresolved_entity_names(&self, agent: AgentId) -> Vec<String> {
-        let all_names = self.all_entity_names(agent);
+    pub fn unresolved_entity_names(&self, user: UserId, agent: AgentId) -> Vec<String> {
+        let all_names = self.all_entity_names(user, agent);
         self.entity_resolver.read().unresolved_names(&all_names)
     }
 
@@ -2147,13 +2183,17 @@ impl MenteDb {
     /// Returns (name, content) pairs for entities that need resolution.
     /// The content helps the LLM disambiguate (e.g., "Python" near
     /// "web framework" vs "Python" near "Monty Python").
-    pub fn entity_names_with_context(&self, agent: AgentId) -> Vec<(String, Option<String>)> {
+    pub fn entity_names_with_context(
+        &self,
+        user: UserId,
+        agent: AgentId,
+    ) -> Vec<(String, Option<String>)> {
         let page_ids: Vec<PageId> = self.page_map.read().values().copied().collect();
         let mut entity_contexts: HashMap<String, String> = HashMap::new();
 
         for pid in &page_ids {
             if let Ok(mem) = self.storage.load_memory(*pid) {
-                if mem.agent_id != agent {
+                if mem.agent_id != agent || mem.user_id != user {
                     continue;
                 }
                 for tag in &mem.tags {
@@ -2196,6 +2236,7 @@ impl MenteDb {
         &self,
         merge_groups: &[EntityLinkResolution],
         separations: &[EntitySeparation],
+        user: UserId,
         agent: AgentId,
     ) -> MenteResult<EntityLinkResult> {
         let mut result = EntityLinkResult::default();
@@ -2204,9 +2245,10 @@ impl MenteDb {
             .unwrap_or_default()
             .as_micros() as u64;
 
-        // Build a map: normalized entity name → list of memory IDs (this agent's
-        // entities only, so links never span owners).
-        let entity_memory_map = self.build_entity_memory_map(agent);
+        // Build a map: normalized entity name → list of memory IDs (this
+        // (user, agent) pair's entities only, so links never span either owner
+        // axis).
+        let entity_memory_map = self.build_entity_memory_map(user, agent);
 
         let mut resolver = self.entity_resolver.write();
 
@@ -2321,17 +2363,22 @@ impl MenteDb {
     /// (nil owned / global entities are linked among themselves).
     pub fn link_entities(&self) -> MenteResult<EntityLinkResult> {
         let mut total = EntityLinkResult::default();
-        for agent in self.distinct_agent_ids() {
-            let r = self.link_entities_for(agent)?;
+        for (user, agent) in self.distinct_owner_pairs() {
+            let r = self.link_entities_for(user, agent)?;
             total.linked += r.linked;
             total.edges_created += r.edges_created;
         }
         Ok(total)
     }
 
-    /// Sync entity linking scoped to a single owner. See [`Self::link_entities`].
-    pub(crate) fn link_entities_for(&self, agent: AgentId) -> MenteResult<EntityLinkResult> {
-        let entity_memory_map = self.build_entity_memory_map(agent);
+    /// Sync entity linking scoped to a single (user, agent) owner pair. See
+    /// [`Self::link_entities`].
+    pub(crate) fn link_entities_for(
+        &self,
+        user: UserId,
+        agent: AgentId,
+    ) -> MenteResult<EntityLinkResult> {
+        let entity_memory_map = self.build_entity_memory_map(user, agent);
         let resolver = self.entity_resolver.read();
 
         // Group entity names by their resolved canonical name
@@ -2421,14 +2468,18 @@ impl MenteDb {
     }
 
     /// Build a map of normalized entity name → list of MemoryIds, restricted to
-    /// entity memories owned by `agent` so links and community membership never
-    /// cross owners.
-    fn build_entity_memory_map(&self, agent: AgentId) -> HashMap<String, Vec<MemoryId>> {
+    /// entity memories owned by exactly this (`user`, `agent`) pair so links and
+    /// community membership never cross either owner axis.
+    fn build_entity_memory_map(
+        &self,
+        user: UserId,
+        agent: AgentId,
+    ) -> HashMap<String, Vec<MemoryId>> {
         let page_ids: Vec<PageId> = self.page_map.read().values().copied().collect();
         let mut map: HashMap<String, Vec<MemoryId>> = HashMap::new();
         for pid in &page_ids {
             if let Ok(mem) = self.storage.load_memory(*pid) {
-                if mem.agent_id != agent {
+                if mem.agent_id != agent || mem.user_id != user {
                     continue;
                 }
                 for tag in &mem.tags {
@@ -2458,14 +2509,19 @@ impl MenteDb {
     ///
     /// Returns a map of category → list of (entity_name, context_snippet).
     /// Categories come from `entity_type:` tags on entity memories.
-    pub fn entity_communities(&self, agent: AgentId) -> HashMap<String, Vec<(String, String)>> {
+    pub fn entity_communities(
+        &self,
+        user: UserId,
+        agent: AgentId,
+    ) -> HashMap<String, Vec<(String, String)>> {
         let page_ids: Vec<PageId> = self.page_map.read().values().copied().collect();
         let mut categories: HashMap<String, Vec<(String, String)>> = HashMap::new();
 
         for pid in &page_ids {
             if let Ok(mem) = self.storage.load_memory(*pid) {
-                // Only cluster this agent's entities so communities never mix owners.
-                if mem.agent_id != agent {
+                // Only cluster this (user, agent) pair's entities so communities
+                // never mix across either owner axis.
+                if mem.agent_id != agent || mem.user_id != user {
                     continue;
                 }
                 // Skip non-entity memories and existing community summaries
@@ -2510,6 +2566,7 @@ impl MenteDb {
         category: &str,
         summary: &str,
         member_names: &[String],
+        user: UserId,
         agent: AgentId,
     ) -> MenteResult<MemoryId> {
         if category.is_empty() {
@@ -2523,14 +2580,15 @@ impl MenteDb {
             .unwrap_or_default()
             .as_micros() as u64;
 
-        // Check if a community summary already exists for this category AND owner,
-        // so one user's summary never overwrites another's.
+        // Check if a community summary already exists for this category AND both
+        // owner axes, so one owner's summary never overwrites another's.
         let community_tag = format!("community:{}", category);
         let page_ids: Vec<PageId> = self.page_map.read().values().copied().collect();
         let mut existing_id = None;
         for pid in &page_ids {
             if let Ok(mem) = self.storage.load_memory(*pid)
                 && mem.agent_id == agent
+                && mem.user_id == user
                 && mem.tags.iter().any(|t| t == &community_tag)
             {
                 // Update existing summary content
@@ -2558,7 +2616,8 @@ impl MenteDb {
                 .unwrap_or_default();
 
             let mut node =
-                MemoryNode::new(agent, MemoryType::Semantic, summary.to_string(), embedding);
+                MemoryNode::new(agent, MemoryType::Semantic, summary.to_string(), embedding)
+                    .with_user_id(user);
             node.tags = vec![
                 "community_summary".to_string(),
                 community_tag,
@@ -2572,7 +2631,7 @@ impl MenteDb {
 
         // (Re)create Derived edges from summary to member entity memories.
         // On update this refreshes edges to reflect current membership.
-        let entity_map = self.build_entity_memory_map(agent);
+        let entity_map = self.build_entity_memory_map(user, agent);
         for name in member_names {
             let normalized = name.to_lowercase();
             if let Some(member_ids) = entity_map.get(&normalized) {
@@ -2594,29 +2653,34 @@ impl MenteDb {
         Ok(node_id)
     }
 
-    /// Get existing community summaries owned by `agent`, so each owner only sees
-    /// its own community summaries.
-    pub fn community_summaries(&self, agent: AgentId) -> Vec<MemoryNode> {
+    /// Get existing community summaries owned by exactly this (`user`, `agent`)
+    /// pair, so each owner only sees its own community summaries.
+    pub fn community_summaries(&self, user: UserId, agent: AgentId) -> Vec<MemoryNode> {
         let page_ids: Vec<PageId> = self.page_map.read().values().copied().collect();
         page_ids
             .iter()
             .filter_map(|pid| self.storage.load_memory(*pid).ok())
-            .filter(|m| m.agent_id == agent && m.tags.iter().any(|t| t == "community_summary"))
+            .filter(|m| {
+                m.agent_id == agent
+                    && m.user_id == user
+                    && m.tags.iter().any(|t| t == "community_summary")
+            })
             .collect()
     }
 
     /// Collect all semantic/procedural facts for user profile generation.
     ///
     /// Returns high-confidence memories suitable for profile building.
-    pub fn profile_facts(&self, agent: AgentId) -> Vec<String> {
+    pub fn profile_facts(&self, user: UserId, agent: AgentId) -> Vec<String> {
         let page_ids: Vec<PageId> = self.page_map.read().values().copied().collect();
         let mut facts = Vec::new();
 
         for pid in &page_ids {
             if let Ok(mem) = self.storage.load_memory(*pid) {
-                // Only this agent's facts, so a profile is built from one owner's
-                // knowledge and never mixes in another user's memories.
-                if mem.agent_id != agent {
+                // Only this (user, agent) pair's facts, so a profile is built
+                // from one owner's knowledge and never mixes in another owner's
+                // memories on either axis.
+                if mem.agent_id != agent || mem.user_id != user {
                     continue;
                 }
                 // Only semantic and procedural memories with decent confidence
@@ -2646,17 +2710,23 @@ impl MenteDb {
     }
 
     /// Store or update the user profile as an always-scoped memory owned by
-    /// `agent`.
+    /// exactly this (`user`, `agent`) pair.
     ///
     /// There is exactly one user profile memory (tagged `user_profile`) per
-    /// owner. If one already exists for this agent, it's replaced entirely; one
-    /// user's profile never overwrites another's.
-    pub fn store_user_profile(&self, profile: &str, agent: AgentId) -> MenteResult<MemoryId> {
-        // Find existing profile for this owner
+    /// owner pair. If one already exists for this pair, it's replaced entirely;
+    /// one owner's profile never overwrites another's.
+    pub fn store_user_profile(
+        &self,
+        profile: &str,
+        user: UserId,
+        agent: AgentId,
+    ) -> MenteResult<MemoryId> {
+        // Find existing profile for this owner pair
         let page_ids: Vec<PageId> = self.page_map.read().values().copied().collect();
         for pid in &page_ids {
             if let Ok(mem) = self.storage.load_memory(*pid)
                 && mem.agent_id == agent
+                && mem.user_id == user
                 && mem.tags.iter().any(|t| t == "user_profile")
             {
                 // Update in place, bumping created_at so it reflects when the
@@ -2686,7 +2756,8 @@ impl MenteDb {
             .and_then(|e| e.embed(profile).ok())
             .unwrap_or_default();
 
-        let mut node = MemoryNode::new(agent, MemoryType::Semantic, profile.to_string(), embedding);
+        let mut node = MemoryNode::new(agent, MemoryType::Semantic, profile.to_string(), embedding)
+            .with_user_id(user);
         node.tags = vec![
             "user_profile".to_string(),
             "scope:always".to_string(),
@@ -2714,14 +2785,15 @@ impl MenteDb {
 }
 
 #[cfg(test)]
-mod distinct_agent_tests {
+mod distinct_owner_tests {
     use super::*;
 
-    /// `distinct_agent_ids` must enumerate every owner that holds a memory, since
-    /// enrichment loops over its result to scope derived knowledge per owner. This
-    /// is a unit test (not an integration test) because the method is private.
+    /// `distinct_owner_pairs` must enumerate every (user, agent) pair that holds
+    /// a memory, since enrichment loops over its result to scope derived
+    /// knowledge per owner pair. This is a unit test (not an integration test)
+    /// because the method is private.
     #[test]
-    fn distinct_agent_ids_returns_all_owners() {
+    fn distinct_owner_pairs_returns_all_owner_agents() {
         let dir = tempfile::tempdir().unwrap();
         let db = MenteDb::open(dir.path()).unwrap();
         let alice = AgentId::new();
@@ -2742,11 +2814,60 @@ mod distinct_agent_tests {
         ))
         .unwrap();
 
-        let agents = db.distinct_agent_ids();
+        let pairs = db.distinct_owner_pairs();
+        let agents: Vec<AgentId> = pairs.iter().map(|(_, a)| *a).collect();
         assert!(
             agents.contains(&alice),
             "distinct owners must include alice"
         );
         assert!(agents.contains(&bob), "distinct owners must include bob");
+    }
+
+    /// Owner pairs are distinguished on BOTH axes: the same agent with two
+    /// different users yields two distinct pairs, so enrichment partitions per
+    /// user even under a shared agent.
+    #[test]
+    fn distinct_owner_pairs_splits_by_user_under_same_agent() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = MenteDb::open(dir.path()).unwrap();
+        let agent = AgentId::new();
+        let ua = UserId::new();
+        let ub = UserId::new();
+
+        db.store(
+            MemoryNode::new(
+                agent,
+                MemoryType::Semantic,
+                "user a fact".into(),
+                vec![0.1_f32; 8],
+            )
+            .with_user_id(ua),
+        )
+        .unwrap();
+        db.store(
+            MemoryNode::new(
+                agent,
+                MemoryType::Semantic,
+                "user b fact".into(),
+                vec![0.2_f32; 8],
+            )
+            .with_user_id(ub),
+        )
+        .unwrap();
+
+        let pairs = db.distinct_owner_pairs();
+        assert!(
+            pairs.contains(&(ua, agent)),
+            "must include (user a, agent) pair"
+        );
+        assert!(
+            pairs.contains(&(ub, agent)),
+            "must include (user b, agent) pair"
+        );
+        assert_ne!(
+            (ua, agent),
+            (ub, agent),
+            "same agent, different users are distinct owner pairs"
+        );
     }
 }

--- a/crates/mentedb/src/llm_consolidation.rs
+++ b/crates/mentedb/src/llm_consolidation.rs
@@ -19,7 +19,7 @@ use mentedb_cognitive::llm::{
 use mentedb_core::edge::EdgeType;
 use mentedb_core::error::MenteResult;
 use mentedb_core::memory::MemoryType;
-use mentedb_core::types::{AgentId, MemoryId};
+use mentedb_core::types::{AgentId, MemoryId, UserId};
 use mentedb_core::{MemoryEdge, MemoryNode};
 
 /// Tunables for LLM consolidation. Defaults mirror the contradiction sweep's
@@ -193,6 +193,7 @@ impl MenteDb {
                     continue;
                 };
                 if cand.agent_id != new_node.agent_id
+                    || cand.user_id != new_node.user_id
                     || cand.is_invalidated()
                     || scope_key(&cand.tags).map(|s| s.to_string()) != new_scope
                 {
@@ -218,7 +219,13 @@ impl MenteDb {
             let Ok(decision) = svc.consolidate(&members).await else {
                 continue; // fail soft on judge/parse error
             };
-            if self.apply_consolidation(&decision, &cluster, new_node.agent_id, params) {
+            if self.apply_consolidation(
+                &decision,
+                &cluster,
+                new_node.agent_id,
+                new_node.user_id,
+                params,
+            ) {
                 consolidated += 1;
             }
         }
@@ -233,6 +240,7 @@ impl MenteDb {
         decision: &ConsolidationDecision,
         cluster: &[MemoryNode],
         agent: AgentId,
+        user: UserId,
         params: &ConsolidationParams,
     ) -> bool {
         let in_cluster = |id: &str| -> Option<&MemoryNode> {
@@ -254,12 +262,13 @@ impl MenteDb {
                 if merged_content.is_empty() {
                     return false;
                 }
-                // Resolve + revalidate sources: in the cluster, same agent, still
-                // valid. Closes the window if a concurrent write invalidated one.
+                // Resolve + revalidate sources: in the cluster, same agent AND
+                // same user, still valid. Closes the window if a concurrent
+                // write invalidated one.
                 let sources: Vec<&MemoryNode> = remove_ids
                     .iter()
                     .filter_map(|id| in_cluster(id))
-                    .filter(|n| n.agent_id == agent && !n.is_invalidated())
+                    .filter(|n| n.agent_id == agent && n.user_id == user && !n.is_invalidated())
                     .collect();
                 if sources.len() < 2 {
                     return false;
@@ -280,7 +289,8 @@ impl MenteDb {
                     mtype_from(merged_type),
                     merged_content.to_string(),
                     embedding,
-                );
+                )
+                .with_user_id(user);
                 merged.tags = merged_tags(&sources);
                 let merged_id = merged.id;
                 if self.store(merged).is_err() {
@@ -300,13 +310,18 @@ impl MenteDb {
                 let Some(keep) = in_cluster(keep_id) else {
                     return false;
                 };
-                if keep.agent_id != agent || keep.is_invalidated() {
+                if keep.agent_id != agent || keep.user_id != user || keep.is_invalidated() {
                     return false;
                 }
                 let removes: Vec<&MemoryNode> = remove_ids
                     .iter()
                     .filter_map(|id| in_cluster(id))
-                    .filter(|n| n.agent_id == agent && !n.is_invalidated() && n.id != keep.id)
+                    .filter(|n| {
+                        n.agent_id == agent
+                            && n.user_id == user
+                            && !n.is_invalidated()
+                            && n.id != keep.id
+                    })
                     .collect();
                 if removes.is_empty() {
                     return false;
@@ -398,10 +413,11 @@ impl MenteDb {
                 let Ok(other) = self.get_memory(nid) else {
                     continue;
                 };
-                // Same agent + same scope + not already a duplicate string, and
-                // not already judged (a conflict edge exists).
+                // Same agent + same user + same scope + not already a duplicate
+                // string, and not already judged (a conflict edge exists).
                 if other.is_invalidated()
                     || other.agent_id != node.agent_id
+                    || other.user_id != node.user_id
                     || other.content == node.content
                     || scope_key(&other.tags).map(|s| s.to_string()) != scope
                     || self.has_conflict_edge(cid, nid)
@@ -617,6 +633,7 @@ mod tests {
             &decision,
             &cluster,
             agent,
+            UserId::nil(),
             &ConsolidationParams::default()
         ));
 
@@ -657,6 +674,7 @@ mod tests {
             &decision,
             &cluster,
             agent,
+            UserId::nil(),
             &ConsolidationParams::default()
         ));
         assert!(!db.get_memory(keep).unwrap().is_invalidated());
@@ -679,6 +697,7 @@ mod tests {
             &decision,
             &cluster,
             agent,
+            UserId::nil(),
             &ConsolidationParams::default()
         ));
         assert!(!db.get_memory(a).unwrap().is_invalidated());
@@ -715,6 +734,7 @@ mod tests {
             &decision,
             &cluster,
             agent,
+            UserId::nil(),
             &ConsolidationParams::default()
         ));
         assert!(!db.get_memory(e).unwrap().is_invalidated());

--- a/crates/mentedb/src/process_turn.rs
+++ b/crates/mentedb/src/process_turn.rs
@@ -25,7 +25,7 @@ use mentedb_consolidation::FactExtractor;
 use mentedb_context::{DeltaTracker, ScoredMemory};
 use mentedb_core::edge::EdgeType;
 use mentedb_core::memory::MemoryType;
-use mentedb_core::types::{AgentId, MemoryId, Timestamp};
+use mentedb_core::types::{AgentId, MemoryId, Timestamp, UserId};
 use mentedb_core::{MemoryEdge, MemoryNode};
 use tracing::{debug, warn};
 use uuid::Uuid;
@@ -45,6 +45,11 @@ pub struct ProcessTurnInput {
     pub project_context: Option<String>,
     /// Agent UUID (defaults to nil if not provided).
     pub agent_id: Option<Uuid>,
+    /// End-user UUID, orthogonal to `agent_id` (defaults to nil if not
+    /// provided). The stored turn is tagged with both owners, and internal
+    /// recalls are scoped to this user AND the agent so another user's private
+    /// memories can never surface or be linked.
+    pub user_id: Option<Uuid>,
     /// Originating session, tagged onto stored turns so injection recall
     /// can exclude memories already present in that session's context.
     pub session_id: Option<String>,
@@ -223,6 +228,7 @@ impl MenteDb {
         delta_tracker: &mut DeltaTracker,
     ) -> crate::MenteResult<ProcessTurnResult> {
         let agent_id = AgentId(input.agent_id.unwrap_or(Uuid::nil()));
+        let user_id = UserId(input.user_id.unwrap_or(Uuid::nil()));
         let assistant_resp = input.assistant_response.as_deref().unwrap_or("");
         let conversation = format!(
             "User: {}\nAssistant: {}",
@@ -237,6 +243,7 @@ impl MenteDb {
             &input.user_message,
             &query_embedding,
             input.agent_id.map(AgentId),
+            input.user_id.map(UserId),
             delta_tracker,
         )?;
 
@@ -251,25 +258,28 @@ impl MenteDb {
         let (stored_ids, episodic_id) = self.store_episodic(
             &conversation,
             agent_id,
+            user_id,
             &input.project_context,
             &input.session_id,
         )?;
 
-        // Scope internal recalls to the turn's agent so cross-user inference,
-        // fact linking, and proactive recall cannot surface or link another
-        // user's private memories. None (no agent) preserves global behavior.
+        // Scope internal recalls to the turn's owner on BOTH axes so cross-owner
+        // inference, fact linking, and proactive recall cannot surface or link
+        // another user's or agent's private memories. None on an axis preserves
+        // global behavior for that axis.
         let scope_agent = input.agent_id.map(AgentId);
+        let scope_user = input.user_id.map(UserId);
 
         // §4: Write inference on the episodic memory
         let inference_actions = if let Some(eid) = episodic_id {
-            self.run_explicit_write_inference(eid, scope_agent)?
+            self.run_explicit_write_inference(eid, scope_agent, scope_user)?
         } else {
             0
         };
 
         // §5: Extract facts + link edges
         let (facts_extracted, edges_created) = if let Some(eid) = episodic_id {
-            self.extract_and_link_facts(eid, scope_agent)?
+            self.extract_and_link_facts(eid, scope_agent, scope_user)?
         } else {
             (0, 0)
         };
@@ -279,7 +289,8 @@ impl MenteDb {
         let detected_actions = detect_actions(&combined_text);
 
         // §7: Proactive recall
-        let proactive_recalls = self.proactive_recall(&detected_actions, scope_agent)?;
+        let proactive_recalls =
+            self.proactive_recall(&detected_actions, scope_agent, scope_user)?;
 
         // §8: Auto-detect corrections (tags the episodic turn, never mints a node)
         let correction_id = self.auto_detect_correction(&input.user_message, episodic_id)?;
@@ -299,6 +310,7 @@ impl MenteDb {
         let predicted_topics = self.update_trajectory(
             input,
             agent_id,
+            user_id,
             &stored_ids,
             &detected_actions,
             &combined_text,
@@ -339,6 +351,7 @@ impl MenteDb {
         user_message: &str,
         query_embedding: &[f32],
         agent: Option<AgentId>,
+        user: Option<UserId>,
         _delta_tracker: &DeltaTracker,
     ) -> crate::MenteResult<(Vec<ScoredMemory>, Vec<MemoryId>, bool)> {
         // Try speculative cache first
@@ -347,7 +360,9 @@ impl MenteDb {
                 .memory_ids
                 .iter()
                 .filter_map(|id| self.get_memory(*id).ok())
-                .filter(|m| crate::agent_visible(m.agent_id, agent))
+                .filter(|m| {
+                    crate::agent_visible(m.agent_id, agent) && crate::user_visible(m.user_id, user)
+                })
                 .map(|m| ScoredMemory {
                     memory: m,
                     score: 0.9,
@@ -370,6 +385,7 @@ impl MenteDb {
             false,
             None,
             agent,
+            user,
         )?;
         let mut scored: Vec<ScoredMemory> = results
             .iter()
@@ -391,6 +407,7 @@ impl MenteDb {
                 && mem.tags.iter().any(|t| t == always_scope_tag)
                 && !hybrid_ids.contains(&mem.id)
                 && crate::agent_visible(mem.agent_id, agent)
+                && crate::user_visible(mem.user_id, user)
             {
                 scored.push(ScoredMemory {
                     memory: mem,
@@ -469,6 +486,7 @@ impl MenteDb {
         &self,
         conversation: &str,
         agent_id: AgentId,
+        user_id: UserId,
         project_context: &Option<String>,
         session_id: &Option<String>,
     ) -> crate::MenteResult<(Vec<MemoryId>, Option<MemoryId>)> {
@@ -478,7 +496,8 @@ impl MenteDb {
             MemoryType::Episodic,
             conversation.to_string(),
             embedding,
-        );
+        )
+        .with_user_id(user_id);
         node.tags.push("turn".to_string());
         if let Some(ctx) = project_context {
             node.tags.push(format!("scope:project:{}", ctx));
@@ -495,10 +514,12 @@ impl MenteDb {
         &self,
         id: MemoryId,
         agent: Option<AgentId>,
+        user: Option<UserId>,
     ) -> crate::MenteResult<u32> {
         let target = self.get_memory(id)?;
-        // Scope to the turn's agent: contradiction and dedup edges must not form
-        // across users. Nil owned (shared/global) memories remain in scope.
+        // Scope to the turn's owner on BOTH axes: contradiction and dedup edges
+        // must not form across users or agents. Nil owned (shared/global)
+        // memories remain in scope.
         let similar_ids = self
             .recall_hybrid_scoped_at_mode(
                 &target.embedding,
@@ -509,6 +530,7 @@ impl MenteDb {
                 false,
                 None,
                 agent,
+                user,
             )
             .unwrap_or_default();
         let existing: Vec<MemoryNode> = similar_ids
@@ -654,6 +676,7 @@ impl MenteDb {
         &self,
         id: MemoryId,
         agent: Option<AgentId>,
+        user: Option<UserId>,
     ) -> crate::MenteResult<(usize, u32)> {
         let target = self.get_memory(id)?;
         let extractor = FactExtractor::new();
@@ -662,8 +685,9 @@ impl MenteDb {
             return Ok((0, 0));
         }
 
-        // Scope to the turn's agent: "related" edges must not link one user's
-        // memory to another's. Nil owned (shared/global) memories remain in scope.
+        // Scope to the turn's owner on BOTH axes: "related" edges must not link
+        // one user's or agent's memory to another's. Nil owned (shared/global)
+        // memories remain in scope.
         let similar_ids = self
             .recall_hybrid_scoped_at_mode(
                 &target.embedding,
@@ -674,6 +698,7 @@ impl MenteDb {
                 false,
                 None,
                 agent,
+                user,
             )
             .unwrap_or_default();
         let nearby: Vec<MemoryNode> = similar_ids
@@ -716,6 +741,7 @@ impl MenteDb {
         &self,
         actions: &[DetectedAction],
         agent: Option<AgentId>,
+        user: Option<UserId>,
     ) -> crate::MenteResult<Vec<ProactiveRecall>> {
         let mut recalls = Vec::new();
         for action in actions {
@@ -723,10 +749,21 @@ impl MenteDb {
             let Some(emb) = self.embed_text(&search_query)? else {
                 continue;
             };
-            // Scope to the turn's agent so proactive recall never surfaces
-            // another user's private memories (nil owned/global still pass).
+            // Scope to the turn's owner on BOTH axes so proactive recall never
+            // surfaces another user's or agent's private memories (nil
+            // owned/global still pass).
             let results = self
-                .recall_hybrid_scoped_at_mode(&emb, None, 3, now_us(), None, false, None, agent)
+                .recall_hybrid_scoped_at_mode(
+                    &emb,
+                    None,
+                    3,
+                    now_us(),
+                    None,
+                    false,
+                    None,
+                    agent,
+                    user,
+                )
                 .unwrap_or_default();
             for (mid, score) in &results {
                 if let Ok(mem) = self.get_memory(*mid) {
@@ -826,6 +863,7 @@ impl MenteDb {
         &self,
         input: &ProcessTurnInput,
         agent_id: AgentId,
+        user_id: UserId,
         stored_ids: &[MemoryId],
         detected_actions: &[DetectedAction],
         combined_text: &str,
@@ -869,7 +907,8 @@ impl MenteDb {
             );
             if let Ok(Some(ghost_emb)) = self.embed_text(&ghost_content) {
                 let mut ghost_node =
-                    MemoryNode::new(agent_id, MemoryType::Semantic, ghost_content, ghost_emb);
+                    MemoryNode::new(agent_id, MemoryType::Semantic, ghost_content, ghost_emb)
+                        .with_user_id(user_id);
                 ghost_node.confidence = 0.3;
                 ghost_node.tags = vec!["ghost-memory".to_string(), "unconfirmed".to_string()];
                 if let Some(ctx) = &input.project_context {

--- a/crates/mentedb/tests/agent_isolation.rs
+++ b/crates/mentedb/tests/agent_isolation.rs
@@ -78,6 +78,7 @@ fn scoped_recall_isolates_agents() {
             false,
             None,
             Some(coder),
+            None,
         )
         .unwrap();
     let ids: Vec<MemoryId> = hits.iter().map(|(id, _)| *id).collect();
@@ -93,7 +94,17 @@ fn scoped_recall_isolates_agents() {
 
     // No scope: global visibility, everything is recallable.
     let hits = db
-        .recall_hybrid_scoped_at_mode(&query, Some("rust"), 10, now_us(), None, false, None, None)
+        .recall_hybrid_scoped_at_mode(
+            &query,
+            Some("rust"),
+            10,
+            now_us(),
+            None,
+            false,
+            None,
+            None,
+            None,
+        )
         .unwrap();
     let ids: Vec<MemoryId> = hits.iter().map(|(id, _)| *id).collect();
     assert!(ids.contains(&coder_mem));
@@ -115,6 +126,7 @@ fn process_turn_context_is_agent_scoped() {
         turn_id: 0,
         project_context: None,
         agent_id: Some(coder),
+        user_id: None,
         session_id: None,
     };
     db.process_turn(&input, &mut delta).unwrap();
@@ -126,6 +138,7 @@ fn process_turn_context_is_agent_scoped() {
         turn_id: 1,
         project_context: None,
         agent_id: Some(researcher),
+        user_id: None,
         session_id: None,
     };
     let result = db.process_turn(&input, &mut delta).unwrap();
@@ -144,6 +157,7 @@ fn process_turn_context_is_agent_scoped() {
         turn_id: 2,
         project_context: None,
         agent_id: None,
+        user_id: None,
         session_id: None,
     };
     let result = db.process_turn(&input, &mut delta).unwrap();
@@ -192,6 +206,7 @@ fn injection_respects_agent_scope() {
             max_items: 6,
             max_episodic: 2,
             agent_id: Some(coder),
+            user_id: None,
         })
         .unwrap();
 
@@ -229,6 +244,7 @@ fn ghost_memories_never_inject() {
             max_items: 6,
             max_episodic: 2,
             agent_id: None,
+            user_id: None,
         })
         .unwrap();
     let contents: Vec<&str> = selected.iter().map(|c| c.node.content.as_str()).collect();

--- a/crates/mentedb/tests/integration.rs
+++ b/crates/mentedb/tests/integration.rs
@@ -1489,6 +1489,7 @@ mod injection_attention {
             max_items: 6,
             max_episodic: 2,
             agent_id: None,
+            user_id: None,
         };
         let out = db.recall_for_injection(&query).unwrap();
 
@@ -1573,6 +1574,7 @@ mod injection_attention {
             max_items: 1,
             max_episodic: 0,
             agent_id: None,
+            user_id: None,
         };
         let out = db.recall_for_injection(&query).unwrap();
         let relevant: Vec<_> = out
@@ -1594,11 +1596,11 @@ fn test_store_user_profile_bumps_updated_timestamp() {
     // showed "updated N days ago" forever.
     let dir = tempfile::tempdir().unwrap();
     let db = MenteDb::open(dir.path()).unwrap();
-    db.store_user_profile("first version", AgentId::nil())
+    db.store_user_profile("first version", UserId::nil(), AgentId::nil())
         .unwrap();
     let t1 = db.user_profile().unwrap().created_at;
     std::thread::sleep(std::time::Duration::from_millis(2));
-    db.store_user_profile("second version", AgentId::nil())
+    db.store_user_profile("second version", UserId::nil(), AgentId::nil())
         .unwrap();
     let node = db.user_profile().unwrap();
     assert_eq!(

--- a/crates/mentedb/tests/process_turn.rs
+++ b/crates/mentedb/tests/process_turn.rs
@@ -35,6 +35,7 @@ fn test_process_turn_basic() {
         turn_id: 0,
         project_context: Some("test-project".to_string()),
         agent_id: None,
+        user_id: None,
         session_id: None,
     };
 
@@ -61,6 +62,7 @@ fn test_process_turn_detects_actions() {
         turn_id: 1,
         project_context: None,
         agent_id: None,
+        user_id: None,
         session_id: None,
     };
 
@@ -87,6 +89,7 @@ fn test_process_turn_detects_corrections() {
         turn_id: 1,
         project_context: None,
         agent_id: None,
+        user_id: None,
         session_id: None,
     };
 
@@ -114,6 +117,7 @@ fn test_assistant_prose_does_not_trigger_correction() {
         turn_id: 1,
         project_context: None,
         agent_id: None,
+        user_id: None,
         session_id: None,
     };
 
@@ -135,6 +139,7 @@ fn test_process_turn_sentiment() {
         turn_id: 0,
         project_context: None,
         agent_id: None,
+        user_id: None,
         session_id: None,
     };
 
@@ -151,6 +156,7 @@ fn test_process_turn_sentiment() {
         turn_id: 1,
         project_context: None,
         agent_id: None,
+        user_id: None,
         session_id: None,
     };
 
@@ -174,6 +180,7 @@ fn test_process_turn_multi_turn_context() {
         turn_id: 0,
         project_context: Some("shopflow".to_string()),
         agent_id: None,
+        user_id: None,
         session_id: None,
     };
     let r0 = db.process_turn(&input0, &mut delta).unwrap();
@@ -186,6 +193,7 @@ fn test_process_turn_multi_turn_context() {
         turn_id: 1,
         project_context: Some("shopflow".to_string()),
         agent_id: None,
+        user_id: None,
         session_id: None,
     };
     let r1 = db.process_turn(&input1, &mut delta).unwrap();
@@ -222,6 +230,7 @@ fn test_process_turn_pain_signals() {
         turn_id: 0,
         project_context: None,
         agent_id: None,
+        user_id: None,
         session_id: None,
     };
 
@@ -246,6 +255,7 @@ fn test_process_turn_delta_tracking() {
         turn_id: 0,
         project_context: None,
         agent_id: None,
+        user_id: None,
         session_id: None,
     };
     let r0 = db.process_turn(&input0, &mut delta).unwrap();
@@ -260,6 +270,7 @@ fn test_process_turn_delta_tracking() {
         turn_id: 1,
         project_context: None,
         agent_id: None,
+        user_id: None,
         session_id: None,
     };
     let _r1 = db.process_turn(&input1, &mut delta).unwrap();
@@ -278,6 +289,7 @@ fn test_process_turn_maintenance_intervals() {
         turn_id: 0,
         project_context: None,
         agent_id: None,
+        user_id: None,
         session_id: None,
     };
     let _ = db.process_turn(&input, &mut delta).unwrap();
@@ -289,6 +301,7 @@ fn test_process_turn_maintenance_intervals() {
         turn_id: 50,
         project_context: None,
         agent_id: None,
+        user_id: None,
         session_id: None,
     };
     let _ = db.process_turn(&input50, &mut delta).unwrap();
@@ -300,6 +313,7 @@ fn test_process_turn_maintenance_intervals() {
         turn_id: 200,
         project_context: None,
         agent_id: None,
+        user_id: None,
         session_id: None,
     };
     let _ = db.process_turn(&input200, &mut delta).unwrap();
@@ -311,8 +325,11 @@ fn test_enrichment_disabled_by_default() {
     assert!(!db.needs_enrichment());
     assert_eq!(db.last_enrichment_turn(), 0);
     assert!(
-        db.enrichment_candidates(mentedb_core::types::AgentId::nil())
-            .is_empty()
+        db.enrichment_candidates(
+            mentedb_core::types::UserId::nil(),
+            mentedb_core::types::AgentId::nil()
+        )
+        .is_empty()
     );
 }
 
@@ -329,6 +346,7 @@ fn test_enrichment_trigger_after_interval() {
             turn_id: i,
             project_context: None,
             agent_id: None,
+            user_id: None,
             session_id: None,
         };
         let result = db.process_turn(&input, &mut delta).unwrap();
@@ -342,6 +360,7 @@ fn test_enrichment_trigger_after_interval() {
         turn_id: 5,
         project_context: None,
         agent_id: None,
+        user_id: None,
         session_id: None,
     };
     let result = db.process_turn(&input5, &mut delta).unwrap();
@@ -362,12 +381,16 @@ fn test_enrichment_candidates_returns_episodics() {
             turn_id: i as u64,
             project_context: None,
             agent_id: None,
+            user_id: None,
             session_id: None,
         };
         db.process_turn(&input, &mut delta).unwrap();
     }
 
-    let candidates = db.enrichment_candidates(mentedb_core::types::AgentId::nil());
+    let candidates = db.enrichment_candidates(
+        mentedb_core::types::UserId::nil(),
+        mentedb_core::types::AgentId::nil(),
+    );
     assert!(
         candidates.len() >= 3,
         "should have at least 3 episodic candidates"
@@ -391,6 +414,7 @@ fn test_enrichment_store_results() {
         turn_id: 1,
         project_context: None,
         agent_id: None,
+        user_id: None,
         session_id: None,
     };
     let result = db.process_turn(&input, &mut delta).unwrap();
@@ -412,7 +436,10 @@ fn test_enrichment_store_results() {
     assert_eq!(edges, 1);
 
     // Verify the stored memory has enrichment tag and capped confidence
-    let candidates = db.enrichment_candidates(mentedb_core::types::AgentId::nil());
+    let candidates = db.enrichment_candidates(
+        mentedb_core::types::UserId::nil(),
+        mentedb_core::types::AgentId::nil(),
+    );
     // The enrichment memory should NOT show up as a candidate (it has source:enrichment tag)
     for c in &candidates {
         assert!(
@@ -435,6 +462,7 @@ fn test_enrichment_mark_complete_resets_pending() {
             turn_id: i,
             project_context: None,
             agent_id: None,
+            user_id: None,
             session_id: None,
         };
         db.process_turn(&input, &mut delta).unwrap();
@@ -454,6 +482,7 @@ fn test_enrichment_mark_complete_resets_pending() {
             turn_id: i,
             project_context: None,
             agent_id: None,
+            user_id: None,
             session_id: None,
         };
         let result = db.process_turn(&input, &mut delta).unwrap();
@@ -467,6 +496,7 @@ fn test_enrichment_mark_complete_resets_pending() {
         turn_id: 6,
         project_context: None,
         agent_id: None,
+        user_id: None,
         session_id: None,
     };
     let result = db.process_turn(&input6, &mut delta).unwrap();
@@ -495,6 +525,7 @@ fn test_always_scope_in_retrieve_context() {
         turn_id: 1,
         project_context: None,
         agent_id: None,
+        user_id: None,
         session_id: None,
     };
     let result = db.process_turn(&input, &mut delta).unwrap();
@@ -622,6 +653,7 @@ fn test_apply_entity_link_resolutions() {
         .apply_entity_link_resolutions(
             &resolutions,
             &separations,
+            mentedb_core::types::UserId::nil(),
             mentedb_core::types::AgentId::nil(),
         )
         .unwrap();
@@ -675,13 +707,17 @@ fn test_entity_separation_negative_cache() {
     db.apply_entity_link_resolutions(
         &resolutions,
         &separations,
+        mentedb_core::types::UserId::nil(),
         mentedb_core::types::AgentId::nil(),
     )
     .unwrap();
 
     // Verify: "java" and "java programming" should show as unresolved
     // (negative cache prevents future LLM calls for this pair)
-    let unresolved = db.unresolved_entity_names(mentedb_core::types::AgentId::nil());
+    let unresolved = db.unresolved_entity_names(
+        mentedb_core::types::UserId::nil(),
+        mentedb_core::types::AgentId::nil(),
+    );
     // Both are still "unresolved" in terms of having no canonical alias,
     // but the negative cache will skip them in future LLM batches
     assert!(unresolved.contains(&"java".to_string()));

--- a/crates/mentedb/tests/user_isolation.rs
+++ b/crates/mentedb/tests/user_isolation.rs
@@ -107,6 +107,7 @@ fn other_users_memory_never_leaks_into_a_turn() {
         turn_id: 0,
         project_context: None,
         agent_id: Some(bob),
+        user_id: None,
         session_id: None,
     };
     let bob_result = db.process_turn(&input, &mut delta).unwrap();
@@ -139,6 +140,7 @@ fn scoped_user_still_sees_own_and_global() {
             false,
             None,
             Some(bob),
+            None,
         )
         .unwrap();
     let ids: Vec<MemoryId> = hits.iter().map(|(id, _)| *id).collect();
@@ -173,6 +175,7 @@ fn scoped_recall_excludes_other_users_even_as_top_match() {
             false,
             None,
             Some(bob),
+            None,
         )
         .unwrap();
     let ids: Vec<MemoryId> = hits.iter().map(|(id, _)| *id).collect();
@@ -206,7 +209,7 @@ fn enrichment_helpers_are_owner_scoped() {
     );
     db.store(b).unwrap();
 
-    let alice_facts = db.profile_facts(alice);
+    let alice_facts = db.profile_facts(UserId::nil(), alice);
     assert!(
         alice_facts.iter().any(|f| f.contains("falcons")),
         "alice sees her own fact"
@@ -216,7 +219,7 @@ fn enrichment_helpers_are_owner_scoped() {
         "alice must NOT see bob's fact in her profile facts"
     );
 
-    let bob_facts = db.profile_facts(bob);
+    let bob_facts = db.profile_facts(UserId::nil(), bob);
     assert!(
         !bob_facts.iter().any(|f| f.contains("falcons")),
         "bob must NOT see alice's fact"
@@ -224,5 +227,107 @@ fn enrichment_helpers_are_owner_scoped() {
     assert!(
         bob_facts.iter().any(|f| f.contains("turtles")),
         "bob sees his own fact"
+    );
+}
+
+/// The user axis is orthogonal to the agent axis: under one shared agent, two
+/// different users must never see each other's memories. This is the core
+/// user-isolation security boundary.
+#[test]
+fn user_scoping_is_orthogonal_to_agent() {
+    // Same agent id, different users: user A must never see user B's memory.
+    let (db, _dir) = open_db();
+    let agent = AgentId::new();
+    let ua = UserId::new();
+    let ub = UserId::new();
+    let a = MemoryNode::new(
+        agent,
+        MemoryType::Semantic,
+        "user A secret plan".into(),
+        emb("user A secret plan"),
+    )
+    .with_user_id(ua);
+    let a_id = a.id;
+    db.store(a).unwrap();
+    let b = MemoryNode::new(
+        agent,
+        MemoryType::Semantic,
+        "user B secret plan".into(),
+        emb("user B secret plan"),
+    )
+    .with_user_id(ub);
+    db.store(b).unwrap();
+    // Recall scoped to (user A, agent): sees A's, never B's.
+    let hits = db
+        .recall_hybrid_scoped_at_mode(
+            &emb("secret plan"),
+            Some("secret plan"),
+            10,
+            now_us(),
+            None,
+            false,
+            None,
+            Some(agent),
+            Some(ua),
+        )
+        .unwrap();
+    let ids: Vec<MemoryId> = hits.iter().map(|(id, _)| *id).collect();
+    assert!(ids.contains(&a_id), "user A sees own memory");
+    // B's memory (same agent, different user) must be excluded:
+    assert!(
+        hits.iter()
+            .filter_map(|(id, _)| db.get_memory(*id).ok())
+            .all(|m| !m.content.contains("user B")),
+        "user A must never see user B's memory under the same agent"
+    );
+}
+
+/// The enrichment/profile path is also user-orthogonal: `profile_facts` scoped
+/// to (user, agent) must never surface another user's facts under a shared
+/// agent, so one user's profile is never built from another's knowledge.
+#[test]
+fn profile_facts_are_orthogonal_to_agent() {
+    let (db, _dir) = open_db();
+    let agent = AgentId::new();
+    let ua = UserId::new();
+    let ub = UserId::new();
+
+    let a = MemoryNode::new(
+        agent,
+        MemoryType::Semantic,
+        "user A likes falcons".into(),
+        emb("user A likes falcons"),
+    )
+    .with_user_id(ua);
+    db.store(a).unwrap();
+    let b = MemoryNode::new(
+        agent,
+        MemoryType::Semantic,
+        "user B likes turtles".into(),
+        emb("user B likes turtles"),
+    )
+    .with_user_id(ub);
+    db.store(b).unwrap();
+
+    // User A's profile facts under the shared agent: own fact only.
+    let a_facts = db.profile_facts(ua, agent);
+    assert!(
+        a_facts.iter().any(|f| f.contains("falcons")),
+        "user A sees own fact"
+    );
+    assert!(
+        !a_facts.iter().any(|f| f.contains("turtles")),
+        "user A must NOT see user B's fact under the same agent"
+    );
+
+    // And the reverse.
+    let b_facts = db.profile_facts(ub, agent);
+    assert!(
+        b_facts.iter().any(|f| f.contains("turtles")),
+        "user B sees own fact"
+    );
+    assert!(
+        !b_facts.iter().any(|f| f.contains("falcons")),
+        "user B must NOT see user A's fact under the same agent"
     );
 }

--- a/sdks/python/Cargo.lock
+++ b/sdks/python/Cargo.lock
@@ -1525,7 +1525,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb"
-version = "0.12.6"
+version = "0.13.0"
 dependencies = [
  "mentedb-cognitive",
  "mentedb-consolidation",
@@ -1545,7 +1545,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-cognitive"
-version = "0.12.6"
+version = "0.13.0"
 dependencies = [
  "ahash",
  "crossbeam",
@@ -1560,7 +1560,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-consolidation"
-version = "0.12.6"
+version = "0.13.0"
 dependencies = [
  "ahash",
  "mentedb-core",
@@ -1571,7 +1571,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-context"
-version = "0.12.6"
+version = "0.13.0"
 dependencies = [
  "ahash",
  "mentedb-core",
@@ -1583,7 +1583,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-core"
-version = "0.12.6"
+version = "0.13.0"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1598,7 +1598,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-embedding"
-version = "0.12.6"
+version = "0.13.0"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -1619,7 +1619,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-extraction"
-version = "0.12.6"
+version = "0.13.0"
 dependencies = [
  "mentedb-cognitive",
  "mentedb-core",
@@ -1635,7 +1635,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-graph"
-version = "0.12.6"
+version = "0.13.0"
 dependencies = [
  "ahash",
  "bincode",
@@ -1650,7 +1650,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-index"
-version = "0.12.6"
+version = "0.13.0"
 dependencies = [
  "ahash",
  "bincode",
@@ -1688,7 +1688,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-query"
-version = "0.12.6"
+version = "0.13.0"
 dependencies = [
  "mentedb-core",
  "serde",
@@ -1699,7 +1699,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-storage"
-version = "0.12.6"
+version = "0.13.0"
 dependencies = [
  "ahash",
  "bincode",

--- a/sdks/python/python/mentedb/client.py
+++ b/sdks/python/python/mentedb/client.py
@@ -48,6 +48,7 @@ class MenteDB:
         project_context: str | None = None,
         agent_id: str | None = None,
         session_id: str | None = None,
+        user_id: str | None = None,
     ):
         """Process a conversation turn through the full cognitive pipeline.
 
@@ -56,6 +57,10 @@ class MenteDB:
         attention-ordered context plus what was learned. Returns an object with
         ``context`` (memories for your prompt), ``facts_extracted``,
         ``contradiction_count``, and more.
+
+        ``agent_id`` and ``user_id`` are orthogonal owner scopes: the turn's
+        memories are owned by that (user_id, agent_id), and recall for one owner
+        never returns another's. Leave both unset for a single-owner (global) app.
         """
         result = self._db.process_turn(
             user_message,
@@ -64,6 +69,7 @@ class MenteDB:
             project_context,
             agent_id,
             session_id,
+            user_id,
         )
         return SimpleNamespace(**result) if isinstance(result, dict) else result
 

--- a/sdks/python/python/mentedb/hosted.py
+++ b/sdks/python/python/mentedb/hosted.py
@@ -128,6 +128,7 @@ class MenteDBClient:
         project_context: Optional[str] = None,
         agent_id: Optional[str] = None,
         session_id: Optional[str] = None,
+        user_id: Optional[str] = None,
     ):
         """Process one conversation turn through the managed cognitive pipeline.
 
@@ -135,6 +136,9 @@ class MenteDBClient:
         runs hybrid recall, extracts facts, and returns attention-ordered
         ``context`` for your next prompt (each item exposes ``.content``), plus the
         other fields the service reports.
+
+        ``agent_id`` and ``user_id`` are orthogonal owner scopes: recall for one
+        (user_id, agent_id) never returns another owner's memories.
         """
         payload: dict[str, Any] = {
             "user_message": user_message,
@@ -147,6 +151,8 @@ class MenteDBClient:
             payload["agent_id"] = agent_id
         if session_id is not None:
             payload["session_id"] = session_id
+        if user_id is not None:
+            payload["user_id"] = user_id
         return _ns(self._post("/v1/process_turn", payload))
 
     def search(

--- a/sdks/python/src/lib.rs
+++ b/sdks/python/src/lib.rs
@@ -4611,7 +4611,7 @@ impl MenteDB {
     /// cache_hit, inference_actions, detected_actions, proactive_recalls,
     /// correction_id, sentiment, phantom_count, contradiction_count,
     /// predicted_topics, facts_extracted, edges_created.
-    #[pyo3(signature = (user_message, assistant_response=None, turn_id=0, project_context=None, agent_id=None, session_id=None))]
+    #[pyo3(signature = (user_message, assistant_response=None, turn_id=0, project_context=None, agent_id=None, session_id=None, user_id=None))]
     #[allow(clippy::too_many_arguments)]
     fn process_turn(
         &self,
@@ -4622,6 +4622,7 @@ impl MenteDB {
         project_context: Option<String>,
         agent_id: Option<&str>,
         session_id: Option<String>,
+        user_id: Option<&str>,
     ) -> PyResult<Py<PyAny>> {
         let db = self
             .db
@@ -4633,12 +4634,20 @@ impl MenteDB {
             None => None,
         };
 
+        // Orthogonal user owner axis; defaults to None (nil / global user) so
+        // existing callers that pass only agent_id are unaffected.
+        let uid = match user_id {
+            Some(s) => Some(parse_uuid(s)?),
+            None => None,
+        };
+
         let input = ProcessTurnInput {
             user_message: user_message.to_string(),
             assistant_response,
             turn_id,
             project_context,
             agent_id: aid,
+            user_id: uid,
             session_id,
         };
 

--- a/sdks/typescript/Cargo.lock
+++ b/sdks/typescript/Cargo.lock
@@ -672,7 +672,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mentedb"
-version = "0.12.6"
+version = "0.13.0"
 dependencies = [
  "mentedb-cognitive",
  "mentedb-consolidation",
@@ -691,7 +691,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-cognitive"
-version = "0.12.6"
+version = "0.13.0"
 dependencies = [
  "ahash",
  "crossbeam",
@@ -706,7 +706,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-consolidation"
-version = "0.12.6"
+version = "0.13.0"
 dependencies = [
  "ahash",
  "mentedb-core",
@@ -717,7 +717,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-context"
-version = "0.12.6"
+version = "0.13.0"
 dependencies = [
  "ahash",
  "mentedb-core",
@@ -729,7 +729,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-core"
-version = "0.12.6"
+version = "0.13.0"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-embedding"
-version = "0.12.6"
+version = "0.13.0"
 dependencies = [
  "mentedb-core",
  "serde",
@@ -756,7 +756,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-extraction"
-version = "0.12.6"
+version = "0.13.0"
 dependencies = [
  "mentedb-cognitive",
  "mentedb-core",
@@ -772,7 +772,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-graph"
-version = "0.12.6"
+version = "0.13.0"
 dependencies = [
  "ahash",
  "bincode",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-index"
-version = "0.12.6"
+version = "0.13.0"
 dependencies = [
  "ahash",
  "bincode",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-query"
-version = "0.12.6"
+version = "0.13.0"
 dependencies = [
  "mentedb-core",
  "serde",
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-storage"
-version = "0.12.6"
+version = "0.13.0"
 dependencies = [
  "ahash",
  "bincode",

--- a/sdks/typescript/src/lib.rs
+++ b/sdks/typescript/src/lib.rs
@@ -338,6 +338,7 @@ impl MenteDB {
     /// Returns context, stored memories, pain warnings, detected actions,
     /// sentiment, phantom count, predictions, and more.
     #[napi]
+    #[allow(clippy::too_many_arguments)]
     pub fn process_turn(
         &self,
         user_message: String,
@@ -346,8 +347,16 @@ impl MenteDB {
         project_context: Option<String>,
         agent_id: Option<String>,
         session_id: Option<String>,
+        user_id: Option<String>,
     ) -> Result<JsProcessTurnResult> {
         let aid = match agent_id {
+            Some(ref s) => Some(parse_uuid(s)?),
+            None => None,
+        };
+
+        // Orthogonal user owner axis; defaults to None (nil / global user) so
+        // existing callers that pass only agent_id are unaffected.
+        let uid = match user_id {
             Some(ref s) => Some(parse_uuid(s)?),
             None => None,
         };
@@ -358,6 +367,7 @@ impl MenteDB {
             turn_id: turn_id as u64,
             project_context,
             agent_id: aid,
+            user_id: uid,
             session_id,
         };
 


### PR DESCRIPTION
## Summary
Adds an orthogonal `user_id` owner axis. `agent_id` stays the main scope; `user_id` is an additional axis. A memory belongs to `(user_id, agent_id)`, and a query scoped to (user U, agent A) sees a memory only when `user_visible(mem.user_id, U) && agent_visible(mem.agent_id, A)`. So one user never sees another's memories even under the same agent, across recall, profile, entities, communities, consolidation, and contradiction.

## Changes
- `UserId` type (`define_id!`), `MemoryNode.user_id` with `#[serde(default = "default_user_id")]` -> nil (migration-safe for pre-existing data), `with_user_id` builder.
- `user_visible` combined with `agent_visible` in the recall filter; `recall_hybrid_scoped_at_mode` + `InjectionQuery` gain a `user` param.
- `process_turn`: `ProcessTurnInput.user_id`; stamps stored memories; threads user into recall / proactive / write-inference / enrichment.
- Enrichment + consolidation partition by `(user_id, agent_id)` (`distinct_owner_pairs`); `llm_consolidation` guarded too.
- SDK wrappers (Python native + embedded client + hosted client, Node native) accept an optional trailing `user_id` (default None -> nil, backward compatible).

## Tests
- `user_scoping_is_orthogonal_to_agent`: same agent, two users, adversarial recall, A's memory present and B's excluded (fails without the fix).
- `profile_facts_are_orthogonal_to_agent`, `distinct_owner_pairs_*`, and a backward-compat serde test (legacy data -> nil user).

## Verification
- `cargo test -p mentedb`: 117 passed (default and `--features enrichment`). Full `cargo test --workspace`: 615 passed.
- `cargo clippy --workspace -- -D warnings`: clean. `cargo fmt --all --check`: clean. Both SDKs `cargo check`: clean.

Backward compatible: no `user_id` passed => nil => behaves exactly as before. The hosted gateway (separate repo) is updated in a follow-up to forward `user_id`.