### PR TITLE
feat: engine-native standing-rules cleanup (prune_standing_rules)

### DIFF
--- a/crates/mentedb/src/lib.rs
+++ b/crates/mentedb/src/lib.rs
@@ -193,6 +193,20 @@ pub struct EntityLinkResult {
     pub edges_created: usize,
 }
 
+/// Outcome of a standing-rules (`scope:always`) cleanup pass.
+#[derive(Debug, Clone, Default)]
+pub struct PruneReport {
+    /// Total `scope:always` memories found before cleanup.
+    pub total_always: usize,
+    /// Number of exact-content duplicate groups collapsed.
+    pub duplicate_groups: usize,
+    /// Exact-duplicate always-rules removed (the healthiest copy was kept).
+    pub pruned: Vec<MemoryId>,
+    /// Auto-pinned always-rules un-pinned (the `scope:always` tag removed, the
+    /// memory kept so it is still recalled by relevance).
+    pub unpinned: Vec<MemoryId>,
+}
+
 /// A confirmed entity resolution from an external resolver (LLM).
 ///
 /// Used to feed LLM entity resolution results back into the engine
@@ -934,6 +948,81 @@ impl MenteDb {
         self.graph.remove_memory(id);
         self.page_map.write().remove(&id);
         Ok(())
+    }
+
+    /// Clean up the standing-rules (`scope:always`) set: remove exact-content
+    /// duplicates (keeping the healthiest copy) and un-pin every auto-pinned
+    /// always-rule, keeping only rules the user explicitly pinned
+    /// (`source:manual`) and the user profile (which the engine pins deliberately
+    /// so it injects every session).
+    ///
+    /// `scope:always` force-injects a memory into every assembled context
+    /// regardless of relevance, so the set must stay tiny; distilled facts belong
+    /// in relevance-based recall, not a fixed always-list. This is the single
+    /// source of truth for the policy, shared by the hosted platform, the local
+    /// daemon, and any SDK consumer, so behavior cannot drift between them.
+    pub fn prune_standing_rules(&self) -> MenteResult<PruneReport> {
+        use std::collections::{HashMap, HashSet};
+
+        let always: Vec<MemoryNode> = self
+            .memory_ids()
+            .into_iter()
+            .filter_map(|id| self.get_memory(id).ok())
+            .filter(|n| n.tags.iter().any(|t| t == "scope:always"))
+            .collect();
+
+        let mut report = PruneReport {
+            total_always: always.len(),
+            ..Default::default()
+        };
+
+        // Collapse exact-content duplicates: keep the healthiest copy, forget
+        // the rest.
+        let mut by_content: HashMap<&str, Vec<&MemoryNode>> = HashMap::new();
+        for n in &always {
+            by_content.entry(n.content.as_str()).or_default().push(n);
+        }
+        let mut prune_ids: HashSet<MemoryId> = HashSet::new();
+        for (_content, mut group) in by_content {
+            if group.len() > 1 {
+                report.duplicate_groups += 1;
+                group.sort_by(|a, b| {
+                    b.salience
+                        .partial_cmp(&a.salience)
+                        .unwrap_or(std::cmp::Ordering::Equal)
+                });
+                for n in group.into_iter().skip(1) {
+                    prune_ids.insert(n.id);
+                }
+            }
+        }
+
+        // Un-pin every auto-pinned always-rule (not source:manual, not the
+        // profile). Keep the memory, drop the pin.
+        let mut to_unpin: Vec<MemoryNode> = Vec::new();
+        for n in &always {
+            if prune_ids.contains(&n.id) {
+                continue;
+            }
+            let is_manual = n.tags.iter().any(|t| t == "source:manual");
+            let is_profile = n.tags.iter().any(|t| t == "user_profile");
+            if !is_manual && !is_profile {
+                to_unpin.push(n.clone());
+            }
+        }
+
+        for id in prune_ids {
+            self.forget(id)?;
+            report.pruned.push(id);
+        }
+        for mut n in to_unpin {
+            n.tags.retain(|t| t != "scope:always");
+            let id = n.id;
+            self.store(n)?;
+            report.unpinned.push(id);
+        }
+
+        Ok(report)
     }
 
     /// Returns a reference to the underlying graph manager.

--- a/crates/mentedb/tests/standing_rules.rs
+++ b/crates/mentedb/tests/standing_rules.rs
@@ -1,0 +1,90 @@
+//! The standing-rules (`scope:always`) cleanup policy lives in the engine so the
+//! hosted platform, the local daemon, and every SDK share one behavior and it
+//! cannot drift between them.
+
+use mentedb::MenteDb;
+use mentedb::prelude::*;
+use mentedb_core::types::AgentId;
+
+fn pinned(content: &str, extra_tags: &[&str]) -> MemoryNode {
+    let mut node = MemoryNode::new(
+        AgentId::nil(),
+        MemoryType::Semantic,
+        content.to_string(),
+        vec![],
+    );
+    node.tags = std::iter::once("scope:always".to_string())
+        .chain(extra_tags.iter().map(|t| t.to_string()))
+        .collect();
+    node
+}
+
+#[test]
+fn prune_unpins_auto_keeps_manual_and_profile_and_dedups() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = MenteDb::open(dir.path()).expect("open");
+
+    // Auto-pinned (enrichment): must be un-pinned, memory kept.
+    let auto = pinned("a distilled fact about deploys", &["source:enrichment"]);
+    let auto_id = auto.id;
+    db.store(auto).expect("store");
+
+    // Explicitly pinned by the user: must be kept as scope:always.
+    let manual = pinned("never add Co-Authored-By", &["source:manual"]);
+    let manual_id = manual.id;
+    db.store(manual).expect("store");
+
+    // The user profile: engine-pinned deliberately, must be kept.
+    let profile = pinned(
+        "Nam is a technical founder",
+        &["user_profile", "source:enrichment"],
+    );
+    let profile_id = profile.id;
+    db.store(profile).expect("store");
+
+    // Two exact-content duplicates: one is removed (healthiest kept).
+    let dup1 = pinned("always use rtk", &["source:enrichment"]);
+    let dup1_id = dup1.id;
+    db.store(dup1).expect("store");
+    let dup2 = pinned("always use rtk", &["source:enrichment"]);
+    let dup2_id = dup2.id;
+    db.store(dup2).expect("store");
+
+    let report = db.prune_standing_rules().expect("prune");
+
+    assert_eq!(report.total_always, 5);
+
+    // Exactly one duplicate collapsed and forgotten.
+    assert_eq!(report.duplicate_groups, 1);
+    assert_eq!(report.pruned.len(), 1);
+    let removed = report.pruned[0];
+    assert!(removed == dup1_id || removed == dup2_id);
+    assert!(
+        db.get_memory(removed).is_err(),
+        "removed duplicate must be forgotten"
+    );
+
+    let is_always = |id: MemoryId| {
+        db.get_memory(id)
+            .map(|n| n.tags.iter().any(|t| t == "scope:always"))
+            .unwrap_or(false)
+    };
+
+    // Auto-pinned rule un-pinned but still present (recalled by relevance).
+    assert!(!is_always(auto_id), "auto-pinned rule must be un-pinned");
+    assert!(db.get_memory(auto_id).is_ok(), "un-pinned memory is kept");
+
+    // The surviving duplicate is enrichment-sourced, so also un-pinned.
+    let surviving_dup = if removed == dup1_id { dup2_id } else { dup1_id };
+    assert!(!is_always(surviving_dup));
+
+    // Manual pin and the profile survive with scope:always intact.
+    assert!(is_always(manual_id), "manual pin must be kept pinned");
+    assert!(is_always(profile_id), "profile must stay pinned");
+
+    // The report reflects exactly what was un-pinned.
+    assert!(report.unpinned.contains(&auto_id));
+    assert!(report.unpinned.contains(&surviving_dup));
+    assert!(!report.unpinned.contains(&manual_id));
+    assert!(!report.unpinned.contains(&profile_id));
+}


### PR DESCRIPTION
## Why
The scope:always standing-rules policy (what stays pinned, and cleanup of over-pinned rules) was reimplemented in the hosted platform. It drifted from the engine and once nearly un-pinned the engine-created user profile. The policy belongs in the engine so cloud, the local daemon, and every SDK share it.

## What
- `MenteDb::prune_standing_rules() -> PruneReport`: collapse exact-content duplicates (keep the healthiest), un-pin every auto-pinned always-rule, keep only `source:manual` pins and the `user_profile`.
- `PruneReport` (total, duplicate_groups, pruned ids, unpinned ids).
- Test covers: auto un-pinned + kept, manual kept pinned, profile kept pinned, dedup removes one.

## Follow-through
After this publishes (release-plz -> crates.io), the platform bumps its `mentedb` dep and replaces its duplicate `prune_standing_rules` with `db.prune_standing_rules()`.

## Verification
- `cargo clippy --workspace -- -D warnings` clean, `cargo test -p mentedb --test standing_rules` passes.