### PR TITLE
feat: cross-host single-writer lock (fcntl OFD) for horizontal scale

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2459,6 +2459,7 @@ dependencies = [
  "crc32fast",
  "crossbeam",
  "fs2",
+ "libc",
  "lz4_flex",
  "mentedb-core",
  "parking_lot",

--- a/crates/mentedb-storage/Cargo.toml
+++ b/crates/mentedb-storage/Cargo.toml
@@ -26,6 +26,12 @@ uuid = { workspace = true }
 fs2 = { workspace = true }
 bincode = "1"
 
+# Cross-host single-writer lock (fcntl byte-range locks are enforced across
+# hosts on NFSv4/EFS, unlike flock). Unix only; Windows keeps fs2/flock, which
+# is fine there since the multi-host EFS case is Linux.
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [dev-dependencies]
 tempfile = { workspace = true }
 

--- a/crates/mentedb-storage/src/engine.rs
+++ b/crates/mentedb-storage/src/engine.rs
@@ -77,12 +77,24 @@ impl StorageEngine {
             .truncate(false)
             .write(true)
             .open(&lock_path)?;
-        fs2::FileExt::try_lock_exclusive(&lock_file).map_err(|_| {
-            MenteError::Storage(format!(
-                "database directory {} is locked by another process",
-                path.display()
-            ))
-        })?;
+        // Cross-host lock: fcntl OFD lock on Linux (enforced across hosts on
+        // EFS), flock elsewhere. This is what makes single-writer safe when the
+        // directory lives on shared storage mounted by multiple tasks.
+        match crate::lock::try_lock_exclusive(&lock_file) {
+            Ok(true) => {}
+            Ok(false) => {
+                return Err(MenteError::Storage(format!(
+                    "database directory {} is locked by another process",
+                    path.display()
+                )));
+            }
+            Err(e) => {
+                return Err(MenteError::Storage(format!(
+                    "failed to lock database directory {}: {e}",
+                    path.display()
+                )));
+            }
+        }
 
         let page_manager = PageManager::open(path)?;
         let buffer_pool = BufferPool::new(DEFAULT_BUFFER_POOL_SIZE);
@@ -213,7 +225,7 @@ impl StorageEngine {
         // Release the process lock so the directory can be reopened, by this
         // process or another, without waiting for us to exit.
         if let Some(lock_file) = self.process_lock.lock().take() {
-            let _ = fs2::FileExt::unlock(&lock_file);
+            let _ = crate::lock::unlock(&lock_file);
         }
         info!("storage engine closed");
         Ok(())
@@ -226,7 +238,7 @@ impl StorageEngine {
     #[doc(hidden)]
     pub fn release_process_lock(&self) {
         if let Some(lock_file) = self.process_lock.lock().take() {
-            let _ = fs2::FileExt::unlock(&lock_file);
+            let _ = crate::lock::unlock(&lock_file);
         }
     }
 

--- a/crates/mentedb-storage/src/lib.rs
+++ b/crates/mentedb-storage/src/lib.rs
@@ -43,6 +43,8 @@ pub mod backup;
 pub mod buffer;
 /// Unified storage facade for memory persistence.
 pub mod engine;
+/// Cross-host single-writer lock (fcntl OFD locks on Linux/EFS).
+mod lock;
 /// File backed 64KB page manager with free list allocation.
 pub mod page;
 /// Append only write ahead log with CRC checks and LZ4 compression.

--- a/crates/mentedb-storage/src/lock.rs
+++ b/crates/mentedb-storage/src/lock.rs
@@ -1,0 +1,112 @@
+//! Cross-host single-writer lock for a database directory.
+//!
+//! The engine permits exactly one writer per directory. On a single host
+//! `flock` (fs2) is enough, but MenteDB's hosted deployment keeps each tenant's
+//! directory on a shared NFSv4 filesystem (Amazon EFS) that several hosts mount.
+//! `flock` on NFS is host-local: a second host does not observe the lock, so two
+//! tasks could open the same tenant and corrupt it.
+//!
+//! POSIX `fcntl` byte-range locks are enforced ACROSS hosts by the NFSv4 lock
+//! manager. On Linux we use open-file-description locks (`F_OFD_SETLK`), which
+//! keep the per-open-file-description semantics `flock` has (so a second open of
+//! the same directory is refused even within one process, which the engine and
+//! its tests rely on) while also being enforced across hosts on EFS. The lock is
+//! released when the fd is closed or the process dies, so a crashed task frees
+//! the tenant once the NFS lease expires; a merely paused task keeps the lock,
+//! so there is no zombie-write window.
+//!
+//! Non-Linux platforms (macOS dev, Windows) keep `flock`: they are never on EFS,
+//! and `flock` gives the same per-open-file-description exclusion.
+
+use std::fs::File;
+use std::io;
+
+/// Try to take an exclusive whole-file lock without blocking.
+///
+/// `Ok(true)` = acquired, `Ok(false)` = another holder has it, `Err` = a real
+/// error trying to lock.
+#[cfg(target_os = "linux")]
+pub fn try_lock_exclusive(file: &File) -> io::Result<bool> {
+    ofd_set(file, libc::F_WRLCK)
+}
+
+/// Release the lock held on this file descriptor.
+#[cfg(target_os = "linux")]
+pub fn unlock(file: &File) -> io::Result<()> {
+    ofd_set(file, libc::F_UNLCK).map(|_| ())
+}
+
+#[cfg(target_os = "linux")]
+fn ofd_set(file: &File, l_type: libc::c_int) -> io::Result<bool> {
+    use std::os::unix::io::AsRawFd;
+    // l_len == 0 means "to the end of the file", i.e. the whole file.
+    let fl = libc::flock {
+        l_type: l_type as libc::c_short,
+        l_whence: libc::SEEK_SET as libc::c_short,
+        l_start: 0,
+        l_len: 0,
+        l_pid: 0,
+    };
+    // F_OFD_SETLK never blocks; it returns EAGAIN/EACCES when the range is
+    // already locked by a conflicting open file description (possibly on another
+    // host, via the NFSv4 lock manager).
+    let ret =
+        unsafe { libc::fcntl(file.as_raw_fd(), libc::F_OFD_SETLK, &fl as *const libc::flock) };
+    if ret == 0 {
+        return Ok(true);
+    }
+    let err = io::Error::last_os_error();
+    match err.raw_os_error() {
+        Some(libc::EACCES) | Some(libc::EAGAIN) => Ok(false),
+        _ => Err(err),
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn try_lock_exclusive(file: &File) -> io::Result<bool> {
+    use fs2::FileExt;
+    match FileExt::try_lock_exclusive(file) {
+        Ok(()) => Ok(true),
+        Err(e) if e.kind() == io::ErrorKind::WouldBlock => Ok(false),
+        Err(e) => Err(e),
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn unlock(file: &File) -> io::Result<()> {
+    use fs2::FileExt;
+    FileExt::unlock(file)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exclusive_lock_excludes_a_second_open_of_the_same_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("LOCK");
+        let a = std::fs::OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .write(true)
+            .open(&path)
+            .unwrap();
+        assert!(try_lock_exclusive(&a).unwrap(), "first lock acquires");
+
+        // A second open (separate open file description) must be refused while
+        // the first is held, even in this one process.
+        let b = std::fs::OpenOptions::new().write(true).open(&path).unwrap();
+        assert!(
+            !try_lock_exclusive(&b).unwrap(),
+            "second open must not acquire while the first holds the lock"
+        );
+
+        // After releasing the first, the second can acquire.
+        unlock(&a).unwrap();
+        assert!(
+            try_lock_exclusive(&b).unwrap(),
+            "lock is free after the holder releases"
+        );
+    }
+}

--- a/crates/mentedb-storage/src/lock.rs
+++ b/crates/mentedb-storage/src/lock.rs
@@ -50,8 +50,13 @@ fn ofd_set(file: &File, l_type: libc::c_int) -> io::Result<bool> {
     // F_OFD_SETLK never blocks; it returns EAGAIN/EACCES when the range is
     // already locked by a conflicting open file description (possibly on another
     // host, via the NFSv4 lock manager).
-    let ret =
-        unsafe { libc::fcntl(file.as_raw_fd(), libc::F_OFD_SETLK, &fl as *const libc::flock) };
+    let ret = unsafe {
+        libc::fcntl(
+            file.as_raw_fd(),
+            libc::F_OFD_SETLK,
+            &fl as *const libc::flock,
+        )
+    };
     if ret == 0 {
         return Ok(true);
     }

--- a/docs/HORIZONTAL_SCALE.md
+++ b/docs/HORIZONTAL_SCALE.md
@@ -1,0 +1,79 @@
+# Horizontal scale: design
+
+MenteDB's engine is **single-writer per database directory**. Each tenant is a
+directory (WAL, page store, HNSW index, in-memory page map). One process may
+hold a tenant at a time; two writers on one directory interleave cached state
+and corrupt it. This is by design, not a bug: making the storage engine
+multi-writer would mean rebuilding the WAL, buffer pool, and index for
+cross-process concurrency.
+
+So "horizontal scale" does **not** mean many writers per tenant. It means many
+*tenants* spread across many *tasks*, each tenant owned by exactly one task at a
+time. Three things are required.
+
+## 1. Safety: a cross-host single-writer lock (DONE, this repo)
+
+The hosted deployment stores tenant directories on Amazon EFS (NFSv4) mounted by
+several Fargate tasks. The old lock was `flock` (`fs2`), which is **host-local**
+on NFS: a second host does not see it, so two tasks could open one tenant and
+corrupt it.
+
+`crates/mentedb-storage/src/lock.rs` now uses **`fcntl` open-file-description
+locks (`F_OFD_SETLK`) on Linux**, which the NFSv4 lock manager enforces **across
+hosts** on EFS, while keeping the per-open-file-description semantics `flock`
+had. The lock releases on fd close or process death (a crashed task frees the
+tenant after the NFS lease expires); a merely paused task keeps it, so there is
+no zombie-write window. macOS/Windows keep `flock` (never on EFS).
+
+This makes running >1 task **safe** (no corruption). It does **not** by itself
+make it *functional*: a task that does not own a tenant simply fails to open it.
+Which is why routing is required.
+
+## 2. Functionality: tenant → task routing (platform, TODO)
+
+Each request must reach the task that owns (or can acquire) that tenant.
+
+- **Ownership map**: a DynamoDB table `tenant -> {task_id, address, lease_expiry,
+  fence}`. A task writes its row when it acquires a tenant's engine lock and
+  heartbeats `lease_expiry`; it deletes the row on release. Conditional writes
+  make acquisition atomic.
+- **Routing**: an incoming request for tenant `T` on task `A`:
+  1. `A` reads the ownership map. If `A` owns `T` (or the row is absent/expired),
+     `A` acquires the engine lock (authoritative) and serves it.
+  2. If task `B` owns `T`, `A` forwards the request to `B`'s address (internal
+     HTTP), or returns a redirect the ALB/consistent-hash layer follows.
+- **Placement**: consistent-hash the tenant id onto the live task ring so most
+  requests land on the owner directly and only rebalancing needs forwarding.
+
+The engine lock is the source of truth; the DynamoDB map is a routing hint. If
+they disagree (stale map), the engine lock still prevents double-open, so the
+worst case is a failed open + retry, never corruption.
+
+## 3. Elasticity: rebalancing on scale up/down (platform, TODO)
+
+On scale-out/in, tenants move. Handoff must be **release-before-acquire**: the
+losing task flushes, `close()`s (releasing the OFD lock and deleting its map
+row), and only then may the gaining task acquire. The OFD lock guarantees the
+gaining task cannot open until the losing one has released, so a botched handoff
+degrades to unavailability, not corruption. Drain with the ALB dereg delay as
+today.
+
+## Validation gates (before enabling >1 task in prod)
+
+1. **Cross-host lock test on real EFS**: two tasks on two hosts, same EFS mount;
+   task B's open of a tenant task A holds must fail with "locked by another
+   process". (Cannot be tested on a single host or in CI; OFD-over-NFS must be
+   confirmed on EFS specifically.)
+2. **Crash recovery**: kill task A holding tenant T; confirm B can acquire after
+   the NFS lock lease expires, and measure that window (sets the failover SLO).
+3. **Routing correctness** under a rebalance: no request for T is served by two
+   tasks in the same window.
+
+## Why this is staged, not shipped at once
+
+Step 1 (the lock) is the corruption boundary and is safe to ship now: it is
+behavior-preserving on one task and only *adds* cross-host enforcement. Steps 2
+and 3 are a distributed-systems build where a routing/handoff bug is a
+data-availability problem, not a corruption one (the lock protects correctness),
+so they can be rolled out incrementally behind a flag once the EFS validation
+above passes.


### PR DESCRIPTION
## Why
The single-writer lock was `flock` (host-local on NFS/EFS), so a 2nd task on another host would not see it -> two writers on one tenant -> corruption. This is what blocked running >1 gateway task.

## What
- `lock.rs`: exclusive lock via `fcntl` **OFD locks** (`F_OFD_SETLK`) on Linux, enforced **across hosts** by the NFSv4 lock manager on EFS; keeps flock's per-open-file-description exclusion. Released on fd close / process death; a paused task keeps it (no zombie-write window). macOS/Windows keep flock.
- `engine.rs`: process lock uses it. Behavior-preserving on one task.
- `docs/HORIZONTAL_SCALE.md`: the full design — the lock is safety; routing (tenant->task via a DynamoDB ownership map) and rebalancing (release-before-acquire) are the remaining platform pieces, plus the **EFS cross-host validation gates** before enabling >1 task.

## Testing
- Single-host: lock unit test + `second_open_of_live_database_is_rejected` pass (macOS flock path locally; Linux OFD path in CI).
- **Not** tested: cross-host OFD-over-NFS on real EFS — that is the named gate before multi-task, since it can't be exercised on one host or in CI.

## Safety framing
Safe to ship now: it only *adds* cross-host enforcement and is identical on a single task. It does not enable multi-task by itself (routing is required) and must pass the EFS validation before >1 task runs.