### PR TITLE
fix: derive salience decay on read (stop compounding, cadence-independent)

### DIFF
--- a/crates/mentedb-consolidation/src/archival.rs
+++ b/crates/mentedb-consolidation/src/archival.rs
@@ -45,17 +45,36 @@ impl ArchivalPipeline {
         Self { config }
     }
 
-    /// Evaluate a single memory for archival.
+    /// Evaluate a single memory for archival using its stored salience.
+    ///
+    /// Prefer `evaluate_effective` from the facade, which passes the salience
+    /// decayed to `now`. The stored `salience` field is the base value as of the
+    /// last reinforcement, not the current one, so judging archival on it alone
+    /// is only correct when the caller has no decay engine.
     pub fn evaluate(&self, memory: &MemoryNode, now: Timestamp) -> ArchivalDecision {
-        let age = now.saturating_sub(memory.created_at);
+        self.evaluate_effective(memory.salience, memory.created_at, memory.access_count, now)
+    }
+
+    /// Evaluate archival against an externally computed effective (decayed)
+    /// salience, so lifecycle decisions reflect the memory's current strength
+    /// rather than a stored base that decay never re-reads. Takes only the three
+    /// fields the decision needs, so the caller need not clone the whole node.
+    pub fn evaluate_effective(
+        &self,
+        effective_salience: f32,
+        created_at: Timestamp,
+        access_count: u32,
+        now: Timestamp,
+    ) -> ArchivalDecision {
+        let age = now.saturating_sub(created_at);
 
         // Delete: very low salience, very old, rarely accessed
-        if memory.salience < 0.05 && age > THIRTY_DAYS_US && memory.access_count < 2 {
+        if effective_salience < 0.05 && age > THIRTY_DAYS_US && access_count < 2 {
             return ArchivalDecision::Delete;
         }
 
         // Archive: low salience and older than 7 days
-        if memory.salience < 0.1 && age > SEVEN_DAYS_US {
+        if effective_salience < 0.1 && age > SEVEN_DAYS_US {
             return ArchivalDecision::Archive;
         }
 
@@ -137,5 +156,45 @@ mod tests {
         assert_eq!(results.len(), 2);
         assert_eq!(results[0].1, ArchivalDecision::Keep);
         assert_eq!(results[1].1, ArchivalDecision::Archive);
+    }
+
+    // Regression: archival must judge on the salience decayed to `now`, not on a
+    // stored base that decay no longer materializes. A full-strength memory a
+    // week old is still strong (~0.45) and must be kept; a month-old one has
+    // decayed past the floor and should go. Before the fix, a compounding decay
+    // pass drove the stored base under 0.1 within a week and force-forgot it.
+    #[test]
+    fn effective_salience_governs_archival_not_stored_base() {
+        use crate::decay::DecayEngine;
+        let decay = DecayEngine::default();
+        let pipe = ArchivalPipeline::default();
+
+        // 8 days old, base 1.0, never reinforced. Derived ~0.45 > 0.1 archive
+        // threshold, so keep, even though it is older than the 7-day min age.
+        let now = 30 * DAY_US;
+        let created = now - 8 * DAY_US;
+        let eff = decay.compute_decay(1.0, created, created, 0, now);
+        assert!(
+            eff > 0.1,
+            "derived salience {eff} should clear archive threshold"
+        );
+        assert_eq!(
+            pipe.evaluate_effective(eff, created, 0, now),
+            ArchivalDecision::Keep,
+        );
+
+        // 40 days old, never reinforced: derived salience decays under the floor
+        // and, being 30d+ old and barely accessed, is deleted.
+        let now = 60 * DAY_US;
+        let created = now - 40 * DAY_US;
+        let eff = decay.compute_decay(1.0, created, created, 0, now);
+        assert!(
+            eff < 0.05,
+            "derived salience {eff} should fall under delete threshold"
+        );
+        assert_eq!(
+            pipe.evaluate_effective(eff, created, 0, now),
+            ArchivalDecision::Delete,
+        );
     }
 }

--- a/crates/mentedb/src/lib.rs
+++ b/crates/mentedb/src/lib.rs
@@ -1323,38 +1323,21 @@ impl MenteDb {
         )
     }
 
-    /// Apply decay globally: recompute salience for all memories and persist.
+    /// Retained for API compatibility. Does nothing and persists nothing.
     ///
-    /// This is an expensive operation intended for periodic maintenance.
-    /// For real-time use, prefer `apply_decay` on retrieved memories.
+    /// Salience decay is derived on read, not materialized. The stored
+    /// `salience` field is the base value as of a memory's last reinforcement
+    /// (`accessed_at`); the current, decayed strength is computed on demand via
+    /// `compute_decayed_salience` (used by recall scoring and archival).
+    ///
+    /// This method previously recomputed decay from the stored salience and
+    /// wrote the result back. That fed each pass's output in as the next pass's
+    /// input, so the effective decay rate scaled with how often maintenance ran
+    /// rather than with elapsed time: frequent passes aged and forgot memories
+    /// far faster than the configured half-life. Deriving on read removes that
+    /// coupling entirely, so it is safe to run maintenance at any cadence.
     pub fn apply_decay_global(&self) -> MenteResult<usize> {
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_micros() as u64;
-        let page_ids: Vec<PageId> = self.page_map.read().values().copied().collect();
-
-        let mut updated = 0;
-        for pid in &page_ids {
-            if let Ok(mut node) = self.storage.load_memory(*pid) {
-                let new_salience = self.decay.compute_decay(
-                    node.salience,
-                    node.created_at,
-                    node.accessed_at,
-                    node.access_count,
-                    now,
-                );
-                if (new_salience - node.salience).abs() > 0.001 {
-                    node.salience = new_salience;
-                    self.storage.update_memory(*pid, &node)?;
-                    updated += 1;
-                }
-            }
-        }
-        if updated > 0 {
-            info!("Decay pass updated {} memories", updated);
-        }
-        Ok(updated)
+        Ok(0)
     }
 
     // -----------------------------------------------------------------------
@@ -2145,7 +2128,18 @@ impl MenteDb {
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
             .as_micros() as u64;
-        self.archival.evaluate(memory, now)
+        // Judge on the salience decayed to `now`, not the stored base. Stored
+        // salience only changes on reinforcement, so a never-reinforced memory
+        // keeps its base value and archival must derive the current strength.
+        let effective = self.decay.compute_decay(
+            memory.salience,
+            memory.created_at,
+            memory.accessed_at,
+            memory.access_count,
+            now,
+        );
+        self.archival
+            .evaluate_effective(effective, memory.created_at, memory.access_count, now)
     }
 
     /// Evaluate archival decisions for a batch of memories.
@@ -2163,7 +2157,23 @@ impl MenteDb {
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
             .as_micros() as u64;
-        self.archival.evaluate_batch(memories, now)
+        memories
+            .iter()
+            .map(|m| {
+                let effective = self.decay.compute_decay(
+                    m.salience,
+                    m.created_at,
+                    m.accessed_at,
+                    m.access_count,
+                    now,
+                );
+                (
+                    m.id,
+                    self.archival
+                        .evaluate_effective(effective, m.created_at, m.access_count, now),
+                )
+            })
+            .collect()
     }
 
     /// Run archival evaluation on all memories in the database.
@@ -2171,17 +2181,15 @@ impl MenteDb {
     /// Returns decisions for each memory. Does NOT apply them — call
     /// `invalidate_memory` or `forget` to act on the decisions.
     pub fn evaluate_archival_global(&self) -> MenteResult<Vec<(MemoryId, ArchivalDecision)>> {
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_micros() as u64;
         let pm = self.page_map.read();
         let memories: Vec<MemoryNode> = pm
             .values()
             .filter_map(|pid| self.storage.load_memory(*pid).ok())
             .collect();
         drop(pm);
-        Ok(self.archival.evaluate_batch(&memories, now))
+        // Delegate so decisions use each memory's salience decayed to now, not
+        // its stored base (see evaluate_archival_batch).
+        Ok(self.evaluate_archival_batch(&memories))
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- apply_decay_global persisted a re-decayed salience each pass, feeding its own output back in, so decay rate scaled with maintenance frequency rather than elapsed time. Never-reinforced memories crossed the archival threshold within a week and were force-forgotten; only the newest memories stayed healthy.
- Stored salience is now the base at last reinforcement; current strength is derived on read. apply_decay_global persists nothing. Archival judges on salience decayed to now (new ArchivalPipeline::evaluate_effective). Decay is now independent of how often maintenance runs.

## Verification
- cargo clippy -p mentedb-consolidation -p mentedb: clean
- cargo test -p mentedb-consolidation: 29 pass; cargo test -p mentedb --test integration: 51 pass
- New regression test: week-old full-strength memory kept, month-old unreinforced deleted, both on derived salience