### PR TITLE
feat: reset_decay_state to repair compounding-decay corruption

### DIFF
--- a/crates/mentedb/src/lib.rs
+++ b/crates/mentedb/src/lib.rs
@@ -1340,6 +1340,39 @@ impl MenteDb {
         Ok(0)
     }
 
+    /// One-time repair for databases whose stored salience was corrupted by the
+    /// old compounding decay pass, which overwrote each memory's base salience
+    /// with a repeatedly re-decayed value. Reset every memory's salience to the
+    /// configured maximum and restart its decay clock (`accessed_at = now`), in
+    /// place, without re-running write inference, so every surviving memory gets
+    /// a fresh, correct decay lease from now. Access counts and every other field
+    /// are preserved. Returns the number of memories reset.
+    ///
+    /// This is idempotent in effect (running it twice just resets an already
+    /// healthy base again) and safe to gate behind a one-shot migration flag.
+    pub fn reset_decay_state(&self) -> MenteResult<usize> {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_micros() as u64;
+        let max_salience = self.decay.config.max_salience;
+        let page_ids: Vec<PageId> = self.page_map.read().values().copied().collect();
+
+        let mut reset = 0;
+        for pid in &page_ids {
+            if let Ok(mut node) = self.storage.load_memory(*pid) {
+                node.salience = max_salience;
+                node.accessed_at = now;
+                self.storage.update_memory(*pid, &node)?;
+                reset += 1;
+            }
+        }
+        if reset > 0 {
+            info!("Reset decay state for {} memories", reset);
+        }
+        Ok(reset)
+    }
+
     // -----------------------------------------------------------------------
     // Cognitive Engine: Consolidation
     // -----------------------------------------------------------------------

--- a/crates/mentedb/tests/integration.rs
+++ b/crates/mentedb/tests/integration.rs
@@ -780,8 +780,50 @@ fn test_decay_global_applies_to_all_memories() {
 
     // apply_decay_global should not error.
     let updated = db.apply_decay_global().unwrap();
-    // For fresh memories, salience won't change much so updated may be 0.
-    assert!(updated <= 10, "Should not update more memories than exist");
+    // Decay is derived on read now, so the global pass persists nothing.
+    assert_eq!(updated, 0, "apply_decay_global no longer persists decay");
+
+    db.close().unwrap();
+}
+
+#[test]
+fn test_reset_decay_state_repairs_corrupted_salience() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = MenteDb::open(dir.path()).unwrap();
+    let agent = AgentId::new();
+
+    // Simulate a memory whose base salience was cratered by the old compounding
+    // decay pass and whose decay clock is stale.
+    let mut m = MemoryNode::new(
+        agent,
+        MemoryType::Semantic,
+        "important but over-decayed".to_string(),
+        vec![1.0, 0.0, 0.0, 0.0],
+    );
+    m.salience = 0.02;
+    m.accessed_at = 1_000; // long ago
+    m.access_count = 1; // access bonus 0.1*ln(2) ~ 0.069, so derived stays under 0.1
+    db.store(m).unwrap();
+
+    let id = db.memory_ids()[0];
+    let before = db.get_memory(id).unwrap();
+    assert!(db.compute_decayed_salience(&before) < 0.1);
+
+    let reset = db.reset_decay_state().unwrap();
+    assert_eq!(reset, 1);
+
+    let after = db.get_memory(id).unwrap();
+    assert!(
+        after.salience > 0.99,
+        "salience should be reset to full, got {}",
+        after.salience
+    );
+    assert!(
+        db.compute_decayed_salience(&after) > 0.99,
+        "a just-reset memory should read as fully healthy"
+    );
+    // Access count is preserved, not wiped.
+    assert_eq!(after.access_count, 1);
 
     db.close().unwrap();
 }


### PR DESCRIPTION
## Summary
- The old compounding decay pass overwrote each memory's base salience with a re-decayed value, so upgraded databases carry corrupted (too-low) salience that derive-on-read cannot recover.
- reset_decay_state resets salience to max + restarts the decay clock in place (no write inference, access counts preserved) so every surviving memory gets a fresh correct lease. One-shot migration.

## Verification
- cargo clippy -p mentedb: clean
- New test test_reset_decay_state_repairs_corrupted_salience passes; apply_decay_global-persists-nothing test updated