### PR TITLE
fix: recall refreshes decay clock (not only echoed memories)

### DIFF
--- a/crates/mentedb/src/injection.rs
+++ b/crates/mentedb/src/injection.rs
@@ -334,13 +334,23 @@ impl MenteDb {
             };
             bump_attr(&mut node, ATTR_INJECTION_SHOWN);
 
+            // Retrieval reinforcement: being surfaced at all is an access. Refresh
+            // the decay clock and bump the access count for every shown memory, not
+            // only the ones the reply echoed, so anything that keeps getting
+            // recalled stays alive instead of decaying to the forget threshold while
+            // it is actively in use. Memories that are never recalled still get no
+            // touch here, so they decay and are forgotten as intended; only what
+            // retrieval keeps surfacing survives.
+            node.access_count = node.access_count.saturating_add(1);
+            node.accessed_at = now;
+
             let used = reply_embedding
                 .map(|re| cosine_similarity(&node.embedding, re) >= cfg.used_similarity)
                 .unwrap_or(false);
             if used {
+                // The reply actually drew on it: a stronger signal than mere
+                // exposure, so add a salience boost on top of the access refresh.
                 bump_attr(&mut node, ATTR_INJECTION_USED);
-                node.access_count = node.access_count.saturating_add(1);
-                node.accessed_at = now;
                 node.salience = (node.salience + cfg.use_reinforcement).min(1.0);
                 used_total += 1;
             }

--- a/crates/mentedb/tests/integration.rs
+++ b/crates/mentedb/tests/integration.rs
@@ -1589,6 +1589,39 @@ mod injection_attention {
             used_node.salience > before_salience,
             "used memory reinforced"
         );
+        // Retrieval reinforcement: the shown-but-not-echoed memory still had its
+        // decay clock and access count refreshed, so being recalled keeps it alive
+        // even though it did not earn the salience boost.
+        assert_eq!(count(&ignored_node, ATTR_INJECTION_USED), 0);
+        assert_eq!(
+            ignored_node.access_count, 1,
+            "shown memory's access count bumped even without echo"
+        );
+    }
+
+    #[test]
+    fn retrieval_refreshes_decay_clock_for_shown_not_echoed() {
+        // A memory surfaced by recall but not echoed by the reply must still have
+        // its decay clock refreshed, so anything actively recalled resists decay
+        // and is not forgotten while in use.
+        let dir = tempfile::tempdir().unwrap();
+        let db = MenteDb::open(dir.path()).unwrap();
+        let mut m = semantic(vec![1.0, 0.0, 0.0, 0.0], "recalled, never echoed", vec![]);
+        m.accessed_at = 1_000; // stale decay clock
+        m.access_count = 0;
+        let id = m.id;
+        db.store(m).unwrap();
+
+        // Reply embedding is orthogonal, so cosine < used_similarity: not "used".
+        db.record_injection_outcome(&[id], Some(&[0.0, 1.0, 0.0, 0.0]))
+            .unwrap();
+
+        let n = db.get_memory(id).unwrap();
+        assert_eq!(n.access_count, 1, "recall bumps access count");
+        assert!(
+            n.accessed_at > 1_000,
+            "recall refreshes the decay clock even without an echo"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- record_injection_outcome only refreshed the decay clock for memories the reply echoed. Recalled-but-not-echoed memories decayed even while actively retrieved.
- Now every shown memory gets accessed_at + access_count refreshed; the echo branch keeps its extra salience boost. Injection-ranking demotion is unchanged and independent, so chronically-unused memories are still shown less but not forgotten.

## Verification
- clippy clean; 53 integration tests pass incl. new retrieval_refreshes_decay_clock_for_shown_not_echoed and unchanged chronically_ignored_memories_are_demoted