### PR TITLE
feat: associative recall via graph expansion (gated)

### DIFF
--- a/crates/mentedb/src/injection.rs
+++ b/crates/mentedb/src/injection.rs
@@ -54,6 +54,15 @@ pub struct InjectionConfig {
     pub used_similarity: f32,
     /// Salience reinforcement applied when a memory is actually used.
     pub use_reinforcement: f32,
+    /// Associative recall: how many 1-hop graph neighbors of the top vector hits
+    /// to fold into the candidate pool, so a memory linked to a strong hit can
+    /// surface even when it is not itself vector-similar to the query. 0 (the
+    /// default) disables expansion, leaving pure vector/hybrid recall unchanged.
+    pub graph_expansion_max: usize,
+    /// Score a neighbor inherits from the hit it was reached through, as a
+    /// fraction of that hit's score times the edge weight. Keeps neighbors below
+    /// direct hits so they only win a slot when there is room after them.
+    pub graph_expansion_decay: f32,
 }
 
 impl Default for InjectionConfig {
@@ -66,6 +75,8 @@ impl Default for InjectionConfig {
             demotion_factor: 0.5,
             used_similarity: 0.6,
             use_reinforcement: 0.05,
+            graph_expansion_max: 0,
+            graph_expansion_decay: 0.5,
         }
     }
 }
@@ -237,6 +248,59 @@ impl MenteDb {
         scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
         let scores: Vec<f32> = scored.iter().map(|(_, s)| *s).collect();
         scored.truncate(knee_cutoff(&scores, cfg.knee_gap_ratio));
+
+        // Associative recall: after the vector-tail knee, fold in 1-hop graph
+        // neighbors of the surviving hits, so a memory linked to a relevant hit
+        // can surface even when it is not itself vector-similar to the query.
+        // Runs after the knee (which is for weak vector tails, a different signal
+        // than an explicit edge) so a neighbor's decayed score is not mistaken
+        // for a tail and cut. Disabled by default (graph_expansion_max == 0),
+        // leaving pure vector/hybrid recall intact. Neighbors inherit a decayed
+        // share of the hit's score so they never outrank direct hits, pass the
+        // same gates, and are bounded by graph_expansion_max; MMR then picks the
+        // final set within max_items.
+        if cfg.graph_expansion_max > 0 && !scored.is_empty() {
+            let now = now_us();
+            let mut present: HashSet<MemoryId> = scored.iter().map(|(n, _)| n.id).collect();
+            present.extend(excluded.iter().copied());
+            let seeds: Vec<(MemoryId, f32)> = scored.iter().map(|(n, s)| (n.id, *s)).collect();
+
+            let g = self.graph.graph();
+            let mut added = 0usize;
+            'seeds: for (seed_id, seed_score) in seeds {
+                let mut edges = g.outgoing(seed_id);
+                edges.extend(g.incoming(seed_id));
+                for (nbr_id, edge) in edges {
+                    if added >= cfg.graph_expansion_max {
+                        break 'seeds;
+                    }
+                    if present.contains(&nbr_id) {
+                        continue;
+                    }
+                    let Ok(node) = self.get_memory(nbr_id) else {
+                        continue;
+                    };
+                    if has_tag(&node, "action")
+                        || has_tag(&node, "scope:always")
+                        || has_tag(&node, "ghost-memory")
+                        || !node.is_valid_at(now)
+                        || !crate::agent_visible(node.agent_id, query.agent_id)
+                        || !crate::user_visible(node.user_id, query.user_id)
+                    {
+                        continue;
+                    }
+                    if let Some(ref st) = session_tag
+                        && has_tag(&node, st)
+                    {
+                        continue;
+                    }
+                    let score = seed_score * edge.weight * cfg.graph_expansion_decay;
+                    present.insert(nbr_id);
+                    scored.push((node, score));
+                    added += 1;
+                }
+            }
+        }
 
         // MMR selection with type quotas.
         let top_score = scored

--- a/crates/mentedb/tests/integration.rs
+++ b/crates/mentedb/tests/integration.rs
@@ -1552,6 +1552,70 @@ mod injection_attention {
     }
 
     #[test]
+    fn graph_expansion_surfaces_linked_neighbors() {
+        // A matches the query; B does not, but is linked to A by an edge. With a
+        // candidate pool of 1, only A is a direct hit, so B can appear ONLY via
+        // associative graph expansion. Disabled, B stays out; enabled, B rides in.
+        let a_emb = vec![1.0, 0.0, 0.0, 0.0];
+        let b_emb = vec![0.0, 1.0, 0.0, 0.0];
+
+        let build = |expansion: usize| {
+            let dir = tempfile::tempdir().unwrap();
+            let config = mentedb::CognitiveConfig {
+                write_inference: false,
+                injection_config: mentedb::injection::InjectionConfig {
+                    candidate_pool: 1,
+                    graph_expansion_max: expansion,
+                    ..Default::default()
+                },
+                ..Default::default()
+            };
+            let db = MenteDb::open_with_config(dir.path(), config).unwrap();
+            let a = semantic(a_emb.clone(), "user prefers dark mode", vec![]);
+            let b = semantic(b_emb.clone(), "user is colorblind", vec![]);
+            let (aid, bid) = (a.id, b.id);
+            db.store(a).unwrap();
+            db.store(b).unwrap();
+            db.relate(MemoryEdge {
+                source: aid,
+                target: bid,
+                edge_type: EdgeType::Related,
+                weight: 0.9,
+                created_at: 0,
+                valid_from: None,
+                valid_until: None,
+                label: None,
+            })
+            .unwrap();
+            let query = InjectionQuery {
+                embedding: &a_emb,
+                query_text: None,
+                session_id: None,
+                exclude_ids: &[],
+                max_items: 5,
+                max_episodic: 0,
+                agent_id: None,
+                user_id: None,
+            };
+            let ids: Vec<_> = db
+                .recall_for_injection(&query)
+                .unwrap()
+                .iter()
+                .map(|c| c.node.id)
+                .collect();
+            (aid, bid, ids)
+        };
+
+        let (aid, bid, off) = build(0);
+        assert!(off.contains(&aid), "A is the direct hit");
+        assert!(!off.contains(&bid), "B stays out with expansion disabled");
+
+        let (aid, bid, on) = build(4);
+        assert!(on.contains(&aid), "A is still the direct hit");
+        assert!(on.contains(&bid), "B pulled in by graph expansion");
+    }
+
+    #[test]
     fn injection_excludes_session_actions_and_ledger_and_pins_always() {
         let dir = tempfile::tempdir().unwrap();
         let db = MenteDb::open(dir.path()).unwrap();


### PR DESCRIPTION
Optional 1-hop graph expansion in recall_for_injection: a memory linked to a strong hit surfaces even without direct vector similarity. Gated (graph_expansion_max default 0) so default recall is unchanged. Runs after the knee, neighbors score below direct hits, same gates, bounded. New test proves off=excluded, on=pulled-in. 55 integration + 14 lib tests pass.