### PR TITLE
feat: reembed_all (embedding-dimension migration primitive)

### DIFF
--- a/crates/mentedb/Cargo.toml
+++ b/crates/mentedb/Cargo.toml
@@ -32,6 +32,7 @@ enrichment = ["dep:mentedb-extraction"]
 
 [dev-dependencies]
 tempfile = { workspace = true }
+mentedb-embedding = { workspace = true }
 criterion = { workspace = true }
 uuid = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/mentedb/src/lib.rs
+++ b/crates/mentedb/src/lib.rs
@@ -1373,6 +1373,56 @@ impl MenteDb {
         Ok(reset)
     }
 
+    /// Re-embed every memory at the embedder's current dimension and reindex it.
+    ///
+    /// This migrates a database whose stored vectors were produced by an
+    /// embedder of a different dimension (for example 256 to 1024): each memory's
+    /// content is re-embedded with the currently configured embedder, its stored
+    /// vector is replaced, and it is removed from and re-added to the vector
+    /// index. Memories already at the current dimension are skipped, so it is
+    /// idempotent and safe to re-run.
+    ///
+    /// The migration is safe to run on a live database: the HNSW index checks
+    /// vector dimension at query time, so a memory that has not been re-embedded
+    /// yet is simply skipped by recall (never returned, never crashing) until
+    /// this reaches it. Runs synchronously and re-embeds one memory at a time;
+    /// the caller should run it on a blocking pool.
+    pub fn reembed_all(&self) -> MenteResult<usize> {
+        let target = self.embedding_dim;
+        if target == 0 {
+            return Ok(0);
+        }
+        let page_ids: Vec<PageId> = self.page_map.read().values().copied().collect();
+
+        let mut reembedded = 0usize;
+        for pid in &page_ids {
+            let Ok(mut node) = self.storage.load_memory(*pid) else {
+                continue;
+            };
+            // Already at the target dimension: nothing to do.
+            if node.embedding.len() == target || node.content.is_empty() {
+                continue;
+            }
+            let Some(embedding) = self.embed_text(&node.content)? else {
+                continue;
+            };
+            // The embedder is not yet producing the target dimension; leave the
+            // memory as-is rather than store a second wrong-dimension vector.
+            if embedding.len() != target {
+                continue;
+            }
+            self.index.remove_vector_only(node.id);
+            node.embedding = embedding;
+            self.storage.update_memory(*pid, &node)?;
+            self.index.index_memory(&node);
+            reembedded += 1;
+        }
+        if reembedded > 0 {
+            info!("Re-embedded {reembedded} memories at dimension {target}");
+        }
+        Ok(reembedded)
+    }
+
     // -----------------------------------------------------------------------
     // Cognitive Engine: Consolidation
     // -----------------------------------------------------------------------

--- a/crates/mentedb/tests/integration.rs
+++ b/crates/mentedb/tests/integration.rs
@@ -829,6 +829,54 @@ fn test_reset_decay_state_repairs_corrupted_salience() {
 }
 
 #[test]
+fn reembed_all_embeds_and_indexes_and_is_idempotent() {
+    // Models the embedding-dimension migration: a memory whose stored vector is
+    // not at the current dimension (here, missing entirely) is unrecallable
+    // until reembed_all re-embeds it at the embedder's dimension and indexes it.
+    let dir = tempfile::tempdir().unwrap();
+    let db = MenteDb::open_with_embedder(
+        dir.path(),
+        Box::new(mentedb_embedding::hash_provider::HashEmbeddingProvider::new(8)),
+    )
+    .unwrap();
+    let agent = AgentId::new();
+
+    let target = db.embed_text("probe").unwrap().unwrap().len();
+    assert_eq!(target, 8);
+
+    let m = MemoryNode::new(
+        agent,
+        MemoryType::Semantic,
+        "the deploy runs on github actions".to_string(),
+        Vec::new(), // no vector, as if from an incompatible prior embedder
+    );
+    let id = m.id;
+    db.store(m).unwrap();
+
+    let n = db.reembed_all().unwrap();
+    assert_eq!(n, 1, "the vectorless memory is re-embedded");
+    let node = db.get_memory(id).unwrap();
+    assert_eq!(
+        node.embedding.len(),
+        target,
+        "re-embedded at the current embedder dimension"
+    );
+
+    // Idempotent: nothing left to migrate.
+    assert_eq!(db.reembed_all().unwrap(), 0);
+
+    // Now retrievable.
+    let q = db.embed_text("github actions deploy").unwrap().unwrap();
+    let hits = db.recall_similar(&q, 5).unwrap();
+    assert!(
+        hits.iter().any(|(hid, _)| *hid == id),
+        "the re-embedded memory is retrievable"
+    );
+
+    db.close().unwrap();
+}
+
+#[test]
 fn test_consolidation_api_empty_db() {
     let dir = tempfile::tempdir().unwrap();
     let db = MenteDb::open(dir.path()).unwrap();


### PR DESCRIPTION
Re-embeds every memory at the embedder's current dimension + reindexes, for 256->1024 migration. Idempotent, safe on a live DB (HNSW dim-checks at query time so un-migrated memories are skipped not lost). Synthetic test passes.