### PR TITLE
chore: run release and publish workflows on Node 24

### DIFF
--- a/.github/workflows/publish-sdks.yml
+++ b/.github/workflows/publish-sdks.yml
@@ -93,7 +93,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
@@ -137,7 +137,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           registry-url: https://registry.npmjs.org
       - name: Sync SDK version from workspace Cargo.toml
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           registry-url: https://registry.npmjs.org
       - run: cd sdks/typescript && npm publish --access public --provenance
         env:


### PR DESCRIPTION
## Summary
- Standardize the SDK release/publish CI on Node 24 (was Node 22).

## Changes
- `release.yml`: `node-version: 22` -> `24`.
- `publish-sdks.yml`: both `setup-node` steps `22` -> `24`.

## Verification
- YAML-only change; workflows still `setup-node@v6`. Takes effect on the next release/publish run.