### PR TITLE
fix: truncate text on char boundaries to avoid UTF-8 panics

### DIFF
--- a/crates/mentedb-core/src/lib.rs
+++ b/crates/mentedb-core/src/lib.rs
@@ -22,6 +22,7 @@ pub mod memory;
 pub mod metrics;
 pub mod mvcc;
 pub mod space;
+pub mod text;
 pub mod tier;
 pub mod types;
 

--- a/crates/mentedb-core/src/text.rs
+++ b/crates/mentedb-core/src/text.rs
@@ -1,0 +1,65 @@
+//! Small string helpers shared across the workspace.
+
+/// Truncate `s` to at most `max_bytes`, snapping the cut down to the nearest
+/// UTF-8 character boundary so a multi-byte character is never split.
+///
+/// Byte-index slicing like `&s[..s.len().min(n)]` panics when byte `n` lands in
+/// the middle of a multi-byte character (Cyrillic, CJK, emoji, accents). This
+/// returns a valid `&str` in every case, at the cost of up to three fewer bytes.
+pub fn truncate_on_char_boundary(s: &str, max_bytes: usize) -> &str {
+    if s.len() <= max_bytes {
+        return s;
+    }
+    let mut end = max_bytes;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    &s[..end]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ascii_truncates_exactly() {
+        assert_eq!(truncate_on_char_boundary("hello world", 5), "hello");
+    }
+
+    #[test]
+    fn short_strings_pass_through() {
+        assert_eq!(truncate_on_char_boundary("hi", 100), "hi");
+        assert_eq!(truncate_on_char_boundary("", 5), "");
+    }
+
+    #[test]
+    fn never_splits_a_multibyte_char() {
+        // Each Cyrillic char is 2 bytes; boundaries fall on even byte offsets.
+        // Naive `&s[..5]` would panic; we snap down to 4.
+        let s = "Привет";
+        let out = truncate_on_char_boundary(s, 5);
+        assert_eq!(out, "Пр");
+        assert!(s.starts_with(out));
+    }
+
+    #[test]
+    fn handles_emoji_boundaries() {
+        // 'a'(1) + emoji(4) + 'b'(1) = 6 bytes; boundaries at 0,1,5,6.
+        let s = "a😀b";
+        assert_eq!(truncate_on_char_boundary(s, 1), "a");
+        assert_eq!(truncate_on_char_boundary(s, 3), "a"); // mid-emoji -> snap to 1
+        assert_eq!(truncate_on_char_boundary(s, 5), "a😀");
+        assert_eq!(truncate_on_char_boundary(s, 6), "a😀b");
+    }
+
+    #[test]
+    fn cjk_at_a_splitting_offset_does_not_panic() {
+        // Each CJK char is 3 bytes; a 500-byte cut lands mid-char two times in
+        // three. This is the exact prod case behind the enrichment fix.
+        let s = "记忆".repeat(400); // 2400 bytes, boundaries every 3
+        let out = truncate_on_char_boundary(&s, 500);
+        assert!(out.len() <= 500);
+        assert!(s.starts_with(out));
+        assert!(s.is_char_boundary(out.len()));
+    }
+}

--- a/crates/mentedb-extraction/src/pipeline.rs
+++ b/crates/mentedb-extraction/src/pipeline.rs
@@ -206,7 +206,8 @@ impl<P: ExtractionProvider> ExtractionPipeline<P> {
         let value: serde_json::Value = serde_json::from_str(json_str).map_err(|e| {
             tracing::error!(
                 error = %e,
-                response_preview = &json_str[..json_str.len().min(200)],
+                response_preview =
+                    mentedb_core::text::truncate_on_char_boundary(json_str, 200),
                 "failed to parse LLM extraction response as JSON"
             );
             ExtractionError::ParseError(format!("Failed to parse extraction JSON: {e}"))

--- a/crates/mentedb-extraction/src/provider.rs
+++ b/crates/mentedb-extraction/src/provider.rs
@@ -456,7 +456,8 @@ impl HttpExtractionProvider {
             None => {
                 tracing::warn!(
                     model = %self.config.model,
-                    response_preview = &text[..text.len().min(300)],
+                    response_preview =
+                        mentedb_core::text::truncate_on_char_boundary(&text, 300),
                     "No text block found in Anthropic response"
                 );
                 Ok("{\"memories\": []}".to_string())
@@ -555,7 +556,8 @@ impl HttpExtractionProvider {
         if content_text.trim().is_empty() {
             tracing::warn!(
                 model = %self.config.model,
-                response_preview = &text[..text.len().min(300)],
+                response_preview =
+                    mentedb_core::text::truncate_on_char_boundary(&text, 300),
                 "No text block found in Bedrock response"
             );
             return Ok("{\"memories\": []}".to_string());

--- a/crates/mentedb/src/enrichment.rs
+++ b/crates/mentedb/src/enrichment.rs
@@ -117,9 +117,9 @@ pub async fn run_enrichment<J: LlmJudge>(
                     // Get existing memories for dedup, scoped to this (user,
                     // agent) pair (plus global) so dedup never compares against
                     // another owner's data on either axis.
-                    let existing: Vec<MemoryNode> = if let Ok(Some(emb)) =
-                        db.embed_text(&conversation[..conversation.len().min(500)])
-                    {
+                    let existing: Vec<MemoryNode> = if let Ok(Some(emb)) = db.embed_text(
+                        mentedb_core::text::truncate_on_char_boundary(&conversation, 500),
+                    ) {
                         let now_us = std::time::SystemTime::now()
                             .duration_since(std::time::UNIX_EPOCH)
                             .unwrap_or_default()

--- a/crates/mentedb/src/lib.rs
+++ b/crates/mentedb/src/lib.rs
@@ -2505,12 +2505,17 @@ impl MenteDb {
                                 if existing.len() < 300 {
                                     existing.push_str(" | ");
                                     let remaining = 500usize.saturating_sub(existing.len());
-                                    existing
-                                        .push_str(&mem.content[..mem.content.len().min(remaining)]);
+                                    existing.push_str(
+                                        mentedb_core::text::truncate_on_char_boundary(
+                                            &mem.content,
+                                            remaining,
+                                        ),
+                                    );
                                 }
                             })
                             .or_insert_with(|| {
-                                mem.content[..mem.content.len().min(300)].to_string()
+                                mentedb_core::text::truncate_on_char_boundary(&mem.content, 300)
+                                    .to_string()
                             });
                         break;
                     }


### PR DESCRIPTION
## Summary
- Fixes a real panic: byte-index slicing like `&s[..s.len().min(500)]` panics when the cut lands mid-character (CJK, Cyrillic, emoji, accents). The enrichment embed path hit this, so any non-ASCII user whose conversation exceeds the cutoff would fail enrichment on roughly two of every three runs.
- Fixes the whole class, not one site, via a shared helper.

## Changes
- New `mentedb_core::text::truncate_on_char_boundary(s, max_bytes)` that snaps the cut down to the nearest UTF-8 boundary.
- Applied at every unsafe string-slice truncation:
  - `mentedb/src/enrichment.rs` (embed input for dedup) — the primary bug.
  - `mentedb/src/lib.rs` (memory-content merge, 2 sites).
  - `mentedb-extraction/src/provider.rs` (Anthropic + Bedrock response previews).
  - `mentedb-extraction/src/pipeline.rs` (JSON parse-error preview).
- (Byte-buffer slices in storage and ASCII UUID slices in context are safe and left alone.)

## Verification
- `cargo test -p mentedb-core text`: 5 tests pass, including a CJK 500-byte-cut case that reproduces the prod panic.
- `cargo clippy` clean, `cargo fmt` applied, touched crates build.