### PR TITLE
docs: add Scaling section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -581,6 +581,26 @@ let result = run_enrichment(&db, config, &embedder, Some(&cognitive_llm), turn_i
 println!("Stored {} memories, linked {} entities", result.memories_stored, result.sync_linked + result.llm_linked);
 ```
 
+## Scaling
+
+Each user's memory is its own embedded database with exactly one writer. An
+exclusive cross-process lock (OFD locks, safe over NFSv4 and EFS) guarantees only
+one process ever holds a given database open, so there is no split-brain and no
+corruption: a second opener fails loudly with a "locked by another process" error
+rather than silently double-writing.
+
+- **Vertical first.** One node comfortably serves hundreds of users with tens
+  active at once. Reads and idle connections are effectively free; fsync-bound
+  writes (~30/s aggregate per node) are the ceiling. More CPU and memory extend
+  this several times before any architectural change is needed.
+- **Horizontal by sharding.** When a node's write ceiling is reached, shard users
+  across N nodes by a stable hash of the user id. Each user is owned by exactly
+  one node (enforced by the lock), so the write ceiling scales linearly with N,
+  bounded only by the filesystem's aggregate throughput. A routing mistake
+  produces the loud "locked" error, never corruption.
+- **Self-host and hosted both use this model:** one binary or container per node,
+  single-writer-per-user throughout.
+
 ## Crates
 
 MenteDB is organized as a Cargo workspace with 13 crates:

--- a/README.md
+++ b/README.md
@@ -194,14 +194,14 @@ The result: a clean, curated memory that actually helps the AI perform better.
 - **Hybrid Retrieval** Vector similarity (HNSW) fused with BM25 keyword search via reciprocal rank fusion, plus tag, temporal, and validity filtering
 - **Write Time Intelligence** Quality filter, deduplication, and contradiction detection at ingest
 - **LLM Powered Cognitive Inference** CognitiveLlmService judges whether new memories invalidate, update, or are compatible with existing ones (supports Anthropic, OpenAI, Ollama)
-- **Bi-Temporal Validity** Memories and edges carry `valid_from`/`valid_until` timestamps. Temporal invalidation instead of deletion. Point-in-time queries via `recall_similar_at(embedding, k, timestamp)`
+- **Bi-Temporal Validity** Memories and edges carry `valid_from`/`valid_until` timestamps. Temporal invalidation instead of deletion. Point-in-time queries via `recall_similar_at(embedding, k, timestamp)` or in MQL with `RECALL ... AS OF <timestamp>`
 - **Attention Optimized Context Assembly** Respects the U curve (critical data at start/end of context)
 - **Belief Propagation** When facts change, downstream beliefs are flagged for re evaluation
 - **Delta Aware Serving** Only sends what changed since last turn (90% reduction in memory retrieval tokens over 20 turns)
 - **Cognitive Memory Tiers** Working, Episodic, Semantic, Procedural, Archival
 - **Knowledge Graph** CSR/CSC graph with BFS/DFS traversal and contradiction detection
 - **Memory Spaces** Multi agent isolation with per space ACLs
-- **MQL** Mente Query Language with full boolean logic (AND, OR, NOT) and ordering (ASC/DESC)
+- **MQL** Mente Query Language with full boolean logic (AND, OR, NOT), ordering (ASC/DESC), and point-in-time recall (`AS OF <timestamp>`)
 - **Type Safe IDs** MemoryId, AgentId, SpaceId newtypes prevent accidental mixing
 - **Binary Embeddings** Base64 encoded storage, 65% smaller than JSON arrays
 - **Local Candle Embeddings** Zero config semantic search using all-MiniLM-L6-v2 (384 dims), no API key required (Docker image includes it; source builds need `--features local-embeddings`)
@@ -443,8 +443,11 @@ decayed = salience × 2^(-Δt / half_life) + boost × ln(1 + access_count)
 
 - **Half-life:** 7 days (configurable)
 - **Access boost:** Frequently accessed memories resist decay
+- **Reinforcement:** Recalling a memory refreshes its decay clock (it counts as an access), so memories you keep using stay healthy
+- **Derive-on-read:** The decayed score is computed from the last-access time on every read, never re-persisted, so a memory decays with real elapsed time regardless of how often the sweep runs
 - **Retrieval blending:** Final score = 70% similarity + 30% decayed salience
 - **Floor:** Memories never decay below 0.01
+- **Never destructive by decay:** Decay only reorders results. Curated (non-episodic) memories are demoted but never deleted; only stale, low-salience episodic memories are archived
 
 ### Memory Consolidation (on-demand)
 
@@ -647,6 +650,11 @@ RECALL memories WHERE NOT tag = "archived" ORDER BY salience DESC
 
 -- Content similarity
 RECALL memories WHERE content ~> "database migration strategies" LIMIT 10
+
+-- Point-in-time recall (bitemporal AS OF): only memories whose validity
+-- window contained the timestamp. A fact superseded after t is still
+-- returned when you ask "as of" a moment it was true.
+RECALL memories WHERE type = semantic AS OF 1700000000 LIMIT 10
 
 -- Graph traversal
 TRAVERSE 550e8400-e29b-41d4-a716-446655440000 DEPTH 3 WHERE edge_type = caused


### PR DESCRIPTION
Adds a Scaling section to the engine README (single-writer-per-user + cross-process lock, vertical-first, horizontal sharding), matching what the docs site now shows. README previously had only a benchmark blurb, no scaling explanation.