### PR TITLE
feat: lease-based elastic sharding in the engine (placement + coordinator + traits)

### DIFF
--- a/README.md
+++ b/README.md
@@ -595,11 +595,11 @@ horizontal scaling safe to add incrementally.
   and idle connections are effectively free, fsync-bound writes (~30/s aggregate
   per node) are the ceiling. Add CPU and memory, and raise `MENTEDB_MAX_OPEN_DBS`,
   to extend this several times over.
-- **Shard across nodes.** When one node's write throughput is the limit, run N
-  instances and route each user to a fixed one by a stable hash of the user id. A
-  user's directory is only ever opened by its own instance; the lock catches any
-  routing mistake before it can corrupt data. Write throughput then scales
-  linearly with N.
+- **Shard across nodes (DIY today).** When one node's write throughput is the
+  limit, you can run N instances and route each user to a fixed one by a stable
+  hash of the user id. A user's directory is only ever opened by its own instance;
+  the lock catches any routing mistake before it can corrupt data. Write
+  throughput then scales linearly with N.
 
 ```python
 # N MenteDB instances, each with its own data volume
@@ -609,6 +609,12 @@ def instance_for(user_id: str) -> str:
     # Stable hash: the same user always lands on the same instance
     return INSTANCES[hash(user_id) % len(INSTANCES)]
 ```
+
+The fixed hash above is a deliberate DIY option, not the ceiling. Automatic,
+elastic placement, consistent-hash rebalancing behind a lease coordinator so
+capacity scales 1->N and users are placed and moved for you, is the direction; you
+should not have to route by hand. For most self-hosted deployments a single
+well-provisioned node is already plenty.
 
 ## Crates
 

--- a/crates/mentedb-replication/src/lib.rs
+++ b/crates/mentedb-replication/src/lib.rs
@@ -21,6 +21,7 @@ pub mod network;
 /// Raft node wrapper with MenteDB specific types.
 pub mod raft_node;
 /// Log store and state machine backed by MenteDB storage.
+pub mod sharding;
 pub mod store;
 
 pub use cluster::MenteCluster;

--- a/crates/mentedb-replication/src/sharding.rs
+++ b/crates/mentedb-replication/src/sharding.rs
@@ -1,0 +1,354 @@
+//! Lease-based elastic sharding.
+//!
+//! A different scaling model from the Raft cluster in this crate: instead of
+//! replicating one dataset, it shards accounts across nodes so each account's
+//! single-writer database lives on exactly one node. This module owns the
+//! placement math and the coordination logic; the concrete lease and membership
+//! backends are provided by the embedder (the engine takes no external database
+//! dependency), via the [`LeaseStore`] and [`NodeRegistry`] traits.
+
+use std::collections::HashMap;
+use std::future::Future;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use parking_lot::Mutex;
+
+pub mod placement;
+
+/// A held ownership lease. `epoch` is the fence token that must accompany writes,
+/// so a node that lost ownership is rejected even if it does not notice.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Lease {
+    pub key: String,
+    pub node: String,
+    pub epoch: u64,
+    /// Unix seconds at which the lease lapses unless renewed.
+    pub expiry: u64,
+}
+
+/// A live node and the base URL peers reach it at.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Node {
+    pub id: String,
+    pub addr: String,
+}
+
+#[derive(Debug)]
+pub enum LeaseError {
+    /// Another node currently holds a valid lease on this key.
+    Held { owner: String, expiry: u64 },
+    /// We no longer own this lease (a renew or release found a different owner).
+    Lost,
+    /// A backend failure.
+    Backend(String),
+}
+
+impl std::fmt::Display for LeaseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LeaseError::Held { owner, expiry } => write!(f, "lease held by {owner} until {expiry}"),
+            LeaseError::Lost => write!(f, "lease lost"),
+            LeaseError::Backend(e) => write!(f, "lease backend error: {e}"),
+        }
+    }
+}
+impl std::error::Error for LeaseError {}
+
+/// Where an account should be served.
+#[derive(Debug, PartialEq, Eq)]
+pub enum Resolution {
+    /// This node owns it; serve locally. `epoch` fences writes.
+    Local { epoch: u64 },
+    /// Another node owns it; forward to this base URL.
+    Remote { addr: String },
+}
+
+/// A backend that grants exactly-one-owner leases, fenced by an epoch and
+/// expiring on a TTL. Implemented by the embedder (for example over DynamoDB
+/// conditional writes) so the engine stays dependency-free.
+pub trait LeaseStore: Send + Sync {
+    /// Take ownership of `key` if it is free or expired, bumping the epoch; if we
+    /// already hold a valid lease, return it unchanged.
+    fn acquire(&self, key: &str) -> impl Future<Output = Result<Lease, LeaseError>> + Send;
+    /// Extend a lease we hold, keeping its epoch; errors [`LeaseError::Lost`] if we
+    /// no longer own it.
+    fn renew(&self, lease: &Lease) -> impl Future<Output = Result<Lease, LeaseError>> + Send;
+    /// Give up ownership so another node can take over immediately.
+    fn release(&self, lease: &Lease) -> impl Future<Output = Result<(), LeaseError>> + Send;
+    /// The current live lease for a key, if any.
+    fn current(&self, key: &str) -> impl Future<Output = Result<Option<Lease>, LeaseError>> + Send;
+}
+
+/// A backend that tracks the live node set. Implemented by the embedder.
+pub trait NodeRegistry: Send + Sync {
+    fn heartbeat(&self) -> impl Future<Output = Result<(), String>> + Send;
+    fn live_nodes(&self) -> impl Future<Output = Result<Vec<Node>, String>> + Send;
+    fn node_id(&self) -> &str;
+}
+
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+/// Ties placement to leases and membership: decides whether this node serves a key
+/// locally (fenced by the lease epoch) or forwards to its owner, and keeps the live
+/// node set and held leases fresh. Generic over the backends so the engine owns the
+/// logic while the embedder owns the storage.
+pub struct Coordinator<L: LeaseStore, R: NodeRegistry> {
+    enabled: bool,
+    node: String,
+    leases: L,
+    registry: R,
+    nodes: Mutex<Vec<Node>>,
+    held: Mutex<HashMap<String, Lease>>,
+}
+
+impl<L: LeaseStore, R: NodeRegistry> Coordinator<L, R> {
+    pub fn new(enabled: bool, node: impl Into<String>, leases: L, registry: R) -> Self {
+        Self {
+            enabled,
+            node: node.into(),
+            leases,
+            registry,
+            nodes: Mutex::new(Vec::new()),
+            held: Mutex::new(HashMap::new()),
+        }
+    }
+
+    pub fn enabled(&self) -> bool {
+        self.enabled
+    }
+
+    /// Decide where `key` is served. When disabled, or when we are the only live
+    /// node, resolves `Local` without contacting the lease store on the hot path.
+    pub async fn resolve(&self, key: &str) -> Result<Resolution, LeaseError> {
+        if !self.enabled {
+            return Ok(Resolution::Local { epoch: 0 });
+        }
+        let nodes = self.nodes.lock().clone();
+        let ids: Vec<String> = nodes.iter().map(|n| n.id.clone()).collect();
+        let owner = placement::owner(key, &ids)
+            .map(str::to_string)
+            .unwrap_or_else(|| self.node.clone());
+
+        if owner == self.node {
+            // Serve a cached, still-valid lease without a round trip. Clone out of
+            // the guard so no lock is held across the await.
+            let cached = self.held.lock().get(key).cloned();
+            if let Some(l) = cached
+                && l.expiry > now_secs() + 5
+            {
+                return Ok(Resolution::Local { epoch: l.epoch });
+            }
+            let lease = self.leases.acquire(key).await?;
+            let epoch = lease.epoch;
+            self.held.lock().insert(key.to_string(), lease);
+            Ok(Resolution::Local { epoch })
+        } else {
+            let addr = nodes
+                .iter()
+                .find(|n| n.id == owner)
+                .map(|n| n.addr.clone())
+                .ok_or_else(|| LeaseError::Backend(format!("owner {owner} has no address")))?;
+            Ok(Resolution::Remote { addr })
+        }
+    }
+
+    /// Background upkeep: heartbeat membership, refresh the live node set, and renew
+    /// (or drop) held leases. A no-op when disabled.
+    pub async fn maintain(&self) {
+        if !self.enabled {
+            return;
+        }
+        if let Err(e) = self.registry.heartbeat().await {
+            tracing::warn!(error = %e, "sharding: heartbeat failed");
+        }
+        match self.registry.live_nodes().await {
+            Ok(live) => *self.nodes.lock() = live,
+            Err(e) => tracing::warn!(error = %e, "sharding: live-nodes refresh failed"),
+        }
+        let held: Vec<Lease> = self.held.lock().values().cloned().collect();
+        for lease in held {
+            match self.leases.renew(&lease).await {
+                Ok(fresh) => {
+                    self.held.lock().insert(fresh.key.clone(), fresh);
+                }
+                Err(LeaseError::Lost) => {
+                    tracing::info!(key = %lease.key, "sharding: lease lost, releasing");
+                    self.held.lock().remove(&lease.key);
+                }
+                Err(e) => tracing::warn!(key = %lease.key, error = %e, "sharding: renew failed"),
+            }
+        }
+    }
+
+    /// Renew interval, comfortably shorter than the lease TTL.
+    pub fn maintain_interval() -> Duration {
+        Duration::from_secs(5)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex as StdMutex;
+
+    /// In-memory lease store, enough to exercise the coordinator logic.
+    struct MemLeases {
+        node: String,
+        rows: StdMutex<HashMap<String, Lease>>,
+    }
+
+    impl MemLeases {
+        fn new(node: &str) -> Self {
+            Self {
+                node: node.to_string(),
+                rows: StdMutex::new(HashMap::new()),
+            }
+        }
+    }
+
+    impl LeaseStore for MemLeases {
+        async fn acquire(&self, key: &str) -> Result<Lease, LeaseError> {
+            let mut rows = self.rows.lock().unwrap();
+            match rows.get(key).cloned() {
+                Some(l) if l.expiry > now_secs() && l.node != self.node => Err(LeaseError::Held {
+                    owner: l.node,
+                    expiry: l.expiry,
+                }),
+                Some(l) if l.expiry > now_secs() && l.node == self.node => Ok(l),
+                other => {
+                    let epoch = other.map(|l| l.epoch).unwrap_or(0) + 1;
+                    let lease = Lease {
+                        key: key.to_string(),
+                        node: self.node.clone(),
+                        epoch,
+                        expiry: now_secs() + 30,
+                    };
+                    rows.insert(key.to_string(), lease.clone());
+                    Ok(lease)
+                }
+            }
+        }
+        async fn renew(&self, lease: &Lease) -> Result<Lease, LeaseError> {
+            let mut rows = self.rows.lock().unwrap();
+            match rows.get(&lease.key) {
+                Some(l) if l.node == self.node && l.epoch == lease.epoch => {
+                    let fresh = Lease {
+                        expiry: now_secs() + 30,
+                        ..lease.clone()
+                    };
+                    rows.insert(lease.key.clone(), fresh.clone());
+                    Ok(fresh)
+                }
+                _ => Err(LeaseError::Lost),
+            }
+        }
+        async fn release(&self, lease: &Lease) -> Result<(), LeaseError> {
+            self.rows.lock().unwrap().remove(&lease.key);
+            Ok(())
+        }
+        async fn current(&self, key: &str) -> Result<Option<Lease>, LeaseError> {
+            Ok(self.rows.lock().unwrap().get(key).cloned())
+        }
+    }
+
+    struct MemRegistry {
+        node: String,
+        nodes: Vec<Node>,
+    }
+    impl NodeRegistry for MemRegistry {
+        async fn heartbeat(&self) -> Result<(), String> {
+            Ok(())
+        }
+        async fn live_nodes(&self) -> Result<Vec<Node>, String> {
+            Ok(self.nodes.clone())
+        }
+        fn node_id(&self) -> &str {
+            &self.node
+        }
+    }
+
+    fn nodes() -> Vec<Node> {
+        (0..3)
+            .map(|i| Node {
+                id: format!("node-{i}"),
+                addr: format!("10.0.0.{i}:8080"),
+            })
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn disabled_always_resolves_local() {
+        let c = Coordinator::new(
+            false,
+            "node-0",
+            MemLeases::new("node-0"),
+            MemRegistry {
+                node: "node-0".into(),
+                nodes: vec![],
+            },
+        );
+        assert_eq!(
+            c.resolve("acct").await.unwrap(),
+            Resolution::Local { epoch: 0 }
+        );
+    }
+
+    #[tokio::test]
+    async fn owner_serves_local_and_takes_a_lease() {
+        let ns = nodes();
+        // Find an account this node owns.
+        let owned = (0..1000)
+            .map(|i| format!("acct-{i}"))
+            .find(|a| {
+                placement::owner(a, &ns.iter().map(|n| n.id.clone()).collect::<Vec<_>>())
+                    == Some("node-0")
+            })
+            .unwrap();
+        let c = Coordinator::new(
+            true,
+            "node-0",
+            MemLeases::new("node-0"),
+            MemRegistry {
+                node: "node-0".into(),
+                nodes: ns,
+            },
+        );
+        c.maintain().await; // load the node set
+        match c.resolve(&owned).await.unwrap() {
+            Resolution::Local { epoch } => assert_eq!(epoch, 1),
+            other => panic!("expected Local, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn non_owner_forwards_to_the_owning_node() {
+        let ns = nodes();
+        let ids: Vec<String> = ns.iter().map(|n| n.id.clone()).collect();
+        // An account owned by some other node.
+        let remote = (0..1000)
+            .map(|i| format!("acct-{i}"))
+            .find(|a| placement::owner(a, &ids) != Some("node-0"))
+            .unwrap();
+        let owner = placement::owner(&remote, &ids).unwrap().to_string();
+        let want_addr = ns.iter().find(|n| n.id == owner).unwrap().addr.clone();
+        let c = Coordinator::new(
+            true,
+            "node-0",
+            MemLeases::new("node-0"),
+            MemRegistry {
+                node: "node-0".into(),
+                nodes: ns,
+            },
+        );
+        c.maintain().await;
+        assert_eq!(
+            c.resolve(&remote).await.unwrap(),
+            Resolution::Remote { addr: want_addr }
+        );
+    }
+}

--- a/crates/mentedb-replication/src/sharding/placement.rs
+++ b/crates/mentedb-replication/src/sharding/placement.rs
@@ -1,0 +1,116 @@
+//! Rendezvous (highest-random-weight) placement.
+//!
+//! Maps a key to exactly one node from the live set. Unlike `hash(key) % N`,
+//! adding or removing a node re-homes only the keys that node owned (about 1/N of
+//! the population), not everyone, so the fleet can scale without reshuffling the
+//! whole keyspace.
+
+/// FNV-1a 64. A fixed, stable hash so every node in the fleet computes the same
+/// owner for a key; a randomized hasher (like the stdlib default) would place keys
+/// differently per process and break agreement.
+fn weight(key: &str, node: &str) -> u64 {
+    const OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
+    const PRIME: u64 = 0x0000_0100_0000_01b3;
+    let mut hash = OFFSET;
+    for &b in node.as_bytes() {
+        hash = (hash ^ b as u64).wrapping_mul(PRIME);
+    }
+    // Separator so ("ab", "c") and ("a", "bc") do not collide.
+    hash = (hash ^ 0x1f).wrapping_mul(PRIME);
+    for &b in key.as_bytes() {
+        hash = (hash ^ b as u64).wrapping_mul(PRIME);
+    }
+    hash
+}
+
+/// The node that owns `key`, or `None` if the node set is empty. Ties on equal
+/// weight break on node id, so the result is fully deterministic.
+pub fn owner<'a>(key: &str, nodes: &'a [String]) -> Option<&'a str> {
+    nodes
+        .iter()
+        .map(|n| (weight(key, n), n))
+        .max_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(b.1)))
+        .map(|(_, n)| n.as_str())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn nodes(n: usize) -> Vec<String> {
+        (0..n).map(|i| format!("node-{i}")).collect()
+    }
+
+    #[test]
+    fn empty_set_has_no_owner() {
+        assert_eq!(owner("k1", &[]), None);
+    }
+
+    #[test]
+    fn single_node_owns_everyone() {
+        let ns = nodes(1);
+        for k in ["a", "b", "c"] {
+            assert_eq!(owner(k, &ns), Some("node-0"));
+        }
+    }
+
+    #[test]
+    fn deterministic() {
+        let ns = nodes(5);
+        assert_eq!(owner("alice", &ns), owner("alice", &ns));
+    }
+
+    #[test]
+    fn removing_a_non_owner_never_moves_a_key() {
+        let full = nodes(6);
+        for i in 0..500 {
+            let k = format!("key-{i}");
+            let owns = owner(&k, &full).unwrap().to_string();
+            for drop in &full {
+                if *drop == owns {
+                    continue;
+                }
+                let reduced: Vec<String> = full.iter().filter(|n| *n != drop).cloned().collect();
+                assert_eq!(
+                    owner(&k, &reduced).unwrap(),
+                    owns,
+                    "key {k} moved when non-owner {drop} was removed"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn removing_a_node_rehomes_only_its_own_keys() {
+        let full = nodes(4);
+        let reduced: Vec<String> = full.iter().filter(|n| *n != "node-0").cloned().collect();
+        let total = 4000;
+        let mut moved = 0;
+        for i in 0..total {
+            let k = format!("key-{i}");
+            if owner(&k, &full) != owner(&k, &reduced) {
+                moved += 1;
+            }
+        }
+        assert!(
+            moved < total / 2,
+            "removing one of four nodes moved {moved}/{total} keys, expected ~{}",
+            total / 4
+        );
+    }
+
+    #[test]
+    fn distribution_is_roughly_balanced() {
+        let ns = nodes(4);
+        let mut counts = [0u32; 4];
+        for i in 0..8000 {
+            let k = format!("key-{i}");
+            let o = owner(&k, &ns).unwrap();
+            let idx: usize = o.strip_prefix("node-").unwrap().parse().unwrap();
+            counts[idx] += 1;
+        }
+        for c in counts {
+            assert!(c > 1200 && c < 2800, "unbalanced: {counts:?}");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Moves the elastic auto-sharding logic into the engine (`mentedb-replication`) so placement and coordination are engine concerns, not platform-specific glue. The embedder supplies only the storage backends.
- A different scaling model from the crate's Raft cluster: instead of replicating one dataset, it shards accounts across nodes so each account's single-writer database lives on exactly one node.
- No new external dependency: the engine defines the `LeaseStore` / `NodeRegistry` traits and owns the logic; the concrete lease/membership stores (for example DynamoDB) are provided by the embedder.

## Changes
- `sharding/placement.rs`: rendezvous (highest-random-weight) placement over a stable FNV-1a hash. Adding or removing a node re-homes only ~1/N of keys, not the whole keyspace like `hash % N`.
- `sharding.rs`: `LeaseStore` and `NodeRegistry` traits (async-fn-in-trait, Send-correct), fenced `Lease` (epoch token), and a generic `Coordinator<L, R>` that resolves each account to `Local { epoch }` or `Remote { addr }` and renews/drops held leases in the background.
- Disabled (single node) it resolves `Local` without ever touching the lease store, so it is a true no-op until a fleet is running.
- `lib.rs`: expose `pub mod sharding;`.

## Verification
- `cargo clippy --workspace -- -D warnings`: clean.
- `cargo test -p mentedb-replication sharding`: 9 passed (placement determinism/balance/minimal-rehome; coordinator disabled-local, owner-local+lease-epoch, non-owner-forward).