### PR TITLE
feat: pluggable reranker stage (opt-in)

### DIFF
--- a/crates/mentedb/src/lib.rs
+++ b/crates/mentedb/src/lib.rs
@@ -109,6 +109,9 @@ pub use llm_consolidation::ConsolidationParams;
 #[cfg(feature = "enrichment")]
 pub mod enrichment;
 
+/// Optional second-pass reranking of recall results (off by default).
+pub mod reranker;
+
 /// Lease-based elastic sharding: places each account on exactly one node and
 /// coordinates ownership so a fleet can scale horizontally. The engine owns the
 /// placement and coordination logic; the embedder supplies the lease and
@@ -645,6 +648,45 @@ impl MenteDb {
         let config = AssemblyConfig::default();
         let window = ContextAssembler::assemble(scored, vec![], &config);
         Ok(window)
+    }
+
+    /// Like [`recall`](Self::recall), but runs an optional second pass through a
+    /// [`Reranker`](crate::reranker::Reranker) before assembling the context
+    /// window. The reranker reorders the first-pass candidates by `query_text`
+    /// (typically the natural-language query behind the MQL), so exact-term or
+    /// model-scored relevance can lift results that pure vector/BM25 ranking
+    /// buried. Reranking is entirely opt-in: plain `recall` never invokes it.
+    pub fn recall_reranked(
+        &self,
+        query: &str,
+        query_text: &str,
+        reranker: &dyn crate::reranker::Reranker,
+    ) -> MenteResult<ContextWindow> {
+        use crate::reranker::RerankCandidate;
+        let plan = Mql::parse(query)?;
+        let mut scored = self.execute_plan(&plan)?;
+
+        let candidates: Vec<RerankCandidate<'_>> = scored
+            .iter()
+            .map(|s| RerankCandidate {
+                id: s.memory.id,
+                content: &s.memory.content,
+                score: s.score,
+            })
+            .collect();
+        let new_scores: std::collections::HashMap<MemoryId, f32> = reranker
+            .rerank(query_text, &candidates)
+            .into_iter()
+            .collect();
+        for s in &mut scored {
+            if let Some(&ns) = new_scores.get(&s.memory.id) {
+                s.score = ns;
+            }
+        }
+        scored.sort_by(|a, b| b.score.total_cmp(&a.score));
+
+        let config = AssemblyConfig::default();
+        Ok(ContextAssembler::assemble(scored, vec![], &config))
     }
 
     /// Shortcut for vector similarity search.

--- a/crates/mentedb/src/reranker.rs
+++ b/crates/mentedb/src/reranker.rs
@@ -1,0 +1,133 @@
+//! Pluggable reranking: an optional second pass that reorders recall candidates
+//! by a signal beyond the first-pass vector/BM25 score.
+//!
+//! Off by default. The engine ships a dependency-free [`LexicalReranker`], and the
+//! [`Reranker`] trait lets an embedder plug a stronger model (a cross-encoder, or
+//! an LLM judge) without the engine taking on that dependency. Apply it with
+//! [`crate::MenteDb::recall_reranked`].
+
+use std::collections::HashSet;
+
+use mentedb_core::types::MemoryId;
+
+/// One candidate handed to a reranker: its id, text, and first-pass score.
+pub struct RerankCandidate<'a> {
+    pub id: MemoryId,
+    pub content: &'a str,
+    pub score: f32,
+}
+
+/// Reorders recall candidates for a query by returning a new score per id (higher
+/// is more relevant). The caller sorts descending by the returned score.
+pub trait Reranker: Send + Sync {
+    fn rerank(&self, query: &str, candidates: &[RerankCandidate<'_>]) -> Vec<(MemoryId, f32)>;
+}
+
+/// A dependency-free lexical reranker: blends the first-pass score with the
+/// fraction of query terms that appear in the candidate. Cheap and deterministic,
+/// a reasonable default when no model is available, and it lifts exact-term matches
+/// that pure vector similarity can bury.
+pub struct LexicalReranker {
+    /// Weight on lexical overlap versus the first-pass score, clamped to `[0, 1]`.
+    overlap_weight: f32,
+}
+
+impl Default for LexicalReranker {
+    fn default() -> Self {
+        Self {
+            overlap_weight: 0.5,
+        }
+    }
+}
+
+impl LexicalReranker {
+    pub fn new(overlap_weight: f32) -> Self {
+        Self {
+            overlap_weight: overlap_weight.clamp(0.0, 1.0),
+        }
+    }
+}
+
+fn tokens(s: &str) -> HashSet<String> {
+    s.to_lowercase()
+        .split(|c: char| !c.is_alphanumeric())
+        .filter(|t| !t.is_empty())
+        .map(|t| t.to_string())
+        .collect()
+}
+
+impl Reranker for LexicalReranker {
+    fn rerank(&self, query: &str, candidates: &[RerankCandidate<'_>]) -> Vec<(MemoryId, f32)> {
+        let q = tokens(query);
+        candidates
+            .iter()
+            .map(|c| {
+                let ct = tokens(c.content);
+                let overlap = if q.is_empty() {
+                    0.0
+                } else {
+                    // Fraction of query terms present in the candidate.
+                    q.intersection(&ct).count() as f32 / q.len() as f32
+                };
+                let blended = (1.0 - self.overlap_weight) * c.score + self.overlap_weight * overlap;
+                (c.id, blended)
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn id(n: u128) -> MemoryId {
+        uuid::Uuid::from_u128(n).into()
+    }
+
+    #[test]
+    fn lexical_reranker_lifts_exact_term_matches() {
+        // Candidate B has the lower first-pass score but contains both query terms;
+        // with enough overlap weight it should overtake A.
+        let a = id(1);
+        let b = id(2);
+        let cands = vec![
+            RerankCandidate {
+                id: a,
+                content: "a note about gardening tools",
+                score: 0.9,
+            },
+            RerankCandidate {
+                id: b,
+                content: "the espresso machine broke",
+                score: 0.6,
+            },
+        ];
+        let rr = LexicalReranker::new(0.8);
+        let mut scored = rr.rerank("espresso machine", &cands);
+        scored.sort_by(|x, y| y.1.total_cmp(&x.1));
+        assert_eq!(scored[0].0, b, "exact-term candidate should rank first");
+    }
+
+    #[test]
+    fn empty_query_leaves_first_pass_order() {
+        let a = id(1);
+        let b = id(2);
+        let cands = vec![
+            RerankCandidate {
+                id: a,
+                content: "alpha",
+                score: 0.8,
+            },
+            RerankCandidate {
+                id: b,
+                content: "beta",
+                score: 0.5,
+            },
+        ];
+        let rr = LexicalReranker::default();
+        let scored = rr.rerank("", &cands);
+        // With no query terms, overlap is 0 for all, so scores scale the first pass
+        // uniformly and preserve order.
+        assert!(scored[0].1 > scored[1].1);
+    }
+}


### PR DESCRIPTION
## Summary
Adds an optional second-pass reranker to the recall pipeline, off by default.
- `mentedb::reranker::Reranker` trait: reorders first-pass candidates for a query.
- `LexicalReranker` (dependency-free built-in): blends the first-pass vector/BM25 score with the fraction of query terms present in the candidate, lifting exact-term matches that pure vector similarity buries.
- `MenteDb::recall_reranked(query, query_text, reranker)` applies it before context assembly. Plain `recall` never invokes it, so there is no hot-path cost unless you opt in. The trait lets an embedder plug a cross-encoder or LLM reranker without the engine taking on that dependency.

## Verification
- `cargo test -p mentedb reranker`: 2 passed (exact-term lift; empty-query order preserved).
- `cargo clippy --workspace -- -D warnings`: clean.