### PR TITLE
feat: structured export (schema-fill from memories via pluggable LLM)

### DIFF
--- a/crates/mentedb/Cargo.toml
+++ b/crates/mentedb/Cargo.toml
@@ -26,6 +26,7 @@ tracing = { workspace = true }
 thiserror = { workspace = true }
 parking_lot.workspace = true
 serde = { workspace = true }
+serde_json = { workspace = true }
 
 [features]
 default = []

--- a/crates/mentedb/src/export.rs
+++ b/crates/mentedb/src/export.rs
@@ -1,0 +1,130 @@
+//! Structured export: fill a caller-provided JSON schema from a set of memories
+//! using an LLM the embedder supplies.
+//!
+//! This mirrors the consolidation `LlmJudge` pattern: the cognitive logic and the
+//! prompt live in the engine, but the model call is a trait the embedder plugs in
+//! (for example AWS Bedrock in the hosted platform), so the engine core takes on no
+//! LLM dependency. Instead of dumping raw memories, the model reads them and
+//! populates a structure the caller defines, so an app gets, say, a typed
+//! `UserProfile` rather than a list of sentences.
+
+use mentedb_core::MemoryNode;
+use mentedb_core::error::{MenteError, MenteResult};
+
+/// The model the embedder plugs in for export. Given a system and user prompt,
+/// return the model's raw text (expected to be JSON).
+pub trait ExportModel: Send + Sync {
+    fn complete(&self, system: &str, user: &str) -> MenteResult<String>;
+}
+
+const EXPORT_SYSTEM: &str = "You are a data extraction engine. Read the user's memories and output a single JSON value that conforms exactly to the provided JSON schema. Use only information supported by the memories; for any field with no support, use null. Do not invent values. Output only the JSON, with no prose or code fences.";
+
+/// Fill `schema` from `memories` via `model`. `schema` is the JSON Schema (or an
+/// example shape) the caller wants populated; `instructions` optionally steers
+/// conflict resolution or formatting. Returns the parsed JSON value, or an error
+/// if the model does not return valid JSON.
+pub fn export_structured(
+    memories: &[MemoryNode],
+    schema: &str,
+    instructions: Option<&str>,
+    model: &dyn ExportModel,
+) -> MenteResult<serde_json::Value> {
+    let mut user = String::with_capacity(256 + memories.len() * 64);
+    user.push_str("JSON schema to fill:\n");
+    user.push_str(schema.trim());
+    if let Some(i) = instructions {
+        user.push_str("\n\nAdditional instructions:\n");
+        user.push_str(i.trim());
+    }
+    user.push_str("\n\nMemories:\n");
+    for m in memories {
+        user.push_str("- ");
+        user.push_str(m.content.trim());
+        user.push('\n');
+    }
+
+    let raw = model.complete(EXPORT_SYSTEM, &user)?;
+    let cleaned = strip_code_fences(&raw);
+    serde_json::from_str(cleaned).map_err(|e| {
+        MenteError::Serialization(format!(
+            "structured export: model did not return valid JSON: {e}"
+        ))
+    })
+}
+
+/// Strip an optional ```json ... ``` fence some models wrap JSON in.
+fn strip_code_fences(s: &str) -> &str {
+    let t = s.trim();
+    let t = t
+        .strip_prefix("```json")
+        .or_else(|| t.strip_prefix("```"))
+        .unwrap_or(t);
+    let t = t.strip_suffix("```").unwrap_or(t);
+    t.trim()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mentedb_core::memory::MemoryType;
+
+    struct MockModel {
+        reply: String,
+        seen_user: std::sync::Mutex<String>,
+    }
+    impl ExportModel for MockModel {
+        fn complete(&self, _system: &str, user: &str) -> MenteResult<String> {
+            *self.seen_user.lock().unwrap() = user.to_string();
+            Ok(self.reply.clone())
+        }
+    }
+
+    fn mem(content: &str) -> MemoryNode {
+        MemoryNode::new(
+            mentedb_core::types::AgentId::nil(),
+            MemoryType::Semantic,
+            content.to_string(),
+            vec![],
+        )
+    }
+
+    #[test]
+    fn fills_schema_and_includes_memories_in_prompt() {
+        let model = MockModel {
+            reply: r#"{"name":"Nam","city":"NYC"}"#.to_string(),
+            seen_user: std::sync::Mutex::new(String::new()),
+        };
+        let memories = [mem("User's name is Nam"), mem("User lives in NYC")];
+        let out = export_structured(
+            &memories,
+            r#"{"name": "string", "city": "string"}"#,
+            None,
+            &model,
+        )
+        .unwrap();
+        assert_eq!(out["name"], "Nam");
+        assert_eq!(out["city"], "NYC");
+        let prompt = model.seen_user.lock().unwrap().clone();
+        assert!(prompt.contains("User lives in NYC"));
+        assert!(prompt.contains("JSON schema to fill"));
+    }
+
+    #[test]
+    fn tolerates_code_fenced_json() {
+        let model = MockModel {
+            reply: "```json\n{\"ok\": true}\n```".to_string(),
+            seen_user: std::sync::Mutex::new(String::new()),
+        };
+        let out = export_structured(&[mem("x")], "{}", None, &model).unwrap();
+        assert_eq!(out["ok"], true);
+    }
+
+    #[test]
+    fn invalid_json_is_an_error() {
+        let model = MockModel {
+            reply: "not json at all".to_string(),
+            seen_user: std::sync::Mutex::new(String::new()),
+        };
+        assert!(export_structured(&[mem("x")], "{}", None, &model).is_err());
+    }
+}

--- a/crates/mentedb/src/lib.rs
+++ b/crates/mentedb/src/lib.rs
@@ -112,6 +112,9 @@ pub mod enrichment;
 /// Optional second-pass reranking of recall results (off by default).
 pub mod reranker;
 
+/// Structured export: fill a JSON schema from memories via an embedder-supplied LLM.
+pub mod export;
+
 /// Lease-based elastic sharding: places each account on exactly one node and
 /// coordinates ownership so a fleet can scale horizontally. The engine owns the
 /// placement and coordination logic; the embedder supplies the lease and


### PR DESCRIPTION
## Summary
Adds structured export: instead of dumping raw memories, an LLM reads them and populates a caller-defined JSON schema, so an app gets a typed object (a `UserProfile`, a summary record) rather than a list of sentences.

- `mentedb::export::ExportModel` trait: the model call the embedder plugs in (AWS Bedrock in the hosted platform), mirroring the consolidation `LlmJudge` pattern so the engine core takes on no LLM dependency.
- `export_structured(memories, schema, instructions, model)`: builds the prompt (schema + optional instructions + memories), calls the model, strips code fences, and returns the parsed `serde_json::Value`.

## Verification
- `cargo test -p mentedb export`: 3 passed (fills schema + memories reach the prompt; tolerates code-fenced JSON; invalid JSON errors).
- `cargo clippy --workspace -- -D warnings`: clean.

## Notes
This is the engine-native core. The hosted platform wiring (a Bedrock `ExportModel`, gathering a user's memories, an export endpoint/dashboard) is a thin follow-up in the gateway, matching how consolidation's `BedrockJudge` sits on top of the engine `LlmJudge`.