### PR TITLE
feat(server): Prometheus /metrics endpoint + Grafana dashboard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1676,6 +1676,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "hf-hub"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2129,6 +2135,12 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
@@ -2435,6 +2447,7 @@ dependencies = [
  "mentedb-core",
  "mentedb-embedding",
  "mentedb-extraction",
+ "prometheus",
  "prost",
  "reqwest",
  "serde",
@@ -3061,6 +3074,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "procfs"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "731e0d9356b0c25f16f33b5be79b1c57b562f141ebfcdb0ad8ac2c13a24293b4"
+dependencies = [
+ "bitflags",
+ "hex",
+ "lazy_static",
+ "procfs-core",
+ "rustix 0.38.44",
+]
+
+[[package]]
+name = "procfs-core"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d3554923a69f4ce04c4a754260c338f505ce22642d3830e049a399fc2059a29"
+dependencies = [
+ "bitflags",
+ "hex",
+]
+
+[[package]]
+name = "prometheus"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "libc",
+ "memchr",
+ "parking_lot",
+ "procfs",
+ "protobuf",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "prost"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3111,6 +3164,12 @@ checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
 dependencies = [
  "prost",
 ]
+
+[[package]]
+name = "protobuf"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "ptr_meta"
@@ -3621,6 +3680,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -3628,7 +3700,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -4127,7 +4199,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 

--- a/README.md
+++ b/README.md
@@ -610,6 +610,22 @@ automatically yet. A single well-provisioned node already serves hundreds of use
 (raise `MENTEDB_MAX_OPEN_DBS` to hold more open at once); the fleet is for when one
 node's write throughput becomes the ceiling.
 
+## Observability
+
+`mentedb-server` exposes Prometheus metrics at `GET /metrics` (no auth, aggregate
+only, no per-account labels). It reports process CPU and memory, uptime, memories
+stored, live cluster nodes, and HTTP request rate and latency. Point Prometheus at
+it and import [`crates/mentedb-server/grafana-dashboard.json`](crates/mentedb-server/grafana-dashboard.json)
+for an overview dashboard.
+
+```yaml
+# prometheus.yml
+scrape_configs:
+  - job_name: mentedb
+    static_configs:
+      - targets: ["mentedb-0:6677", "mentedb-1:6677"]
+```
+
 ## Crates
 
 MenteDB is organized as a Cargo workspace with 13 crates:

--- a/crates/mentedb-server/Cargo.toml
+++ b/crates/mentedb-server/Cargo.toml
@@ -33,6 +33,7 @@ jsonwebtoken = { version = "10", features = ["rust_crypto"] }
 tonic = "0.13"
 prost = "0.13"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+prometheus = { version = "0.13", features = ["process"] }
 
 [features]
 default = []

--- a/crates/mentedb-server/grafana-dashboard.json
+++ b/crates/mentedb-server/grafana-dashboard.json
@@ -1,0 +1,135 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "Prometheus data source scraping the MenteDB /metrics endpoint",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "title": "MenteDB",
+  "uid": "mentedb-overview",
+  "tags": ["mentedb"],
+  "schemaVersion": 39,
+  "version": 1,
+  "editable": true,
+  "time": { "from": "now-6h", "to": "now" },
+  "refresh": "30s",
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "type": "datasource",
+        "query": "prometheus",
+        "current": {},
+        "hide": 0
+      }
+    ]
+  },
+  "panels": [
+    {
+      "type": "stat",
+      "title": "Up",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 0 },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            { "type": "value", "options": { "0": { "text": "Down", "color": "red" }, "1": { "text": "Up", "color": "green" } } }
+          ],
+          "color": { "mode": "thresholds" }
+        }
+      },
+      "targets": [{ "expr": "max(mentedb_up)", "refId": "A" }]
+    },
+    {
+      "type": "stat",
+      "title": "Memories stored",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 0 },
+      "targets": [{ "expr": "sum(mentedb_memory_count)", "refId": "A" }]
+    },
+    {
+      "type": "stat",
+      "title": "Live cluster nodes",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 0 },
+      "targets": [{ "expr": "max(mentedb_cluster_live_nodes)", "refId": "A" }]
+    },
+    {
+      "type": "stat",
+      "title": "Uptime",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 0 },
+      "fieldConfig": { "defaults": { "unit": "s" } },
+      "targets": [{ "expr": "max(mentedb_uptime_seconds)", "refId": "A" }]
+    },
+    {
+      "type": "timeseries",
+      "title": "Request rate (per second, by status)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 4 },
+      "fieldConfig": { "defaults": { "unit": "reqps" } },
+      "targets": [
+        {
+          "expr": "sum by (status) (rate(mentedb_http_requests_total[5m]))",
+          "legendFormat": "{{status}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Request latency (seconds)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 4 },
+      "fieldConfig": { "defaults": { "unit": "s" } },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(mentedb_http_request_duration_seconds_bucket[5m])))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(mentedb_http_request_duration_seconds_bucket[5m])))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(mentedb_http_request_duration_seconds_bucket[5m])))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "CPU (cores)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 12 },
+      "targets": [
+        {
+          "expr": "rate(process_cpu_seconds_total[5m])",
+          "legendFormat": "cpu cores",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Resident memory",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 12 },
+      "fieldConfig": { "defaults": { "unit": "bytes" } },
+      "targets": [
+        {
+          "expr": "process_resident_memory_bytes",
+          "legendFormat": "rss",
+          "refId": "A"
+        }
+      ]
+    }
+  ]
+}

--- a/crates/mentedb-server/src/auth.rs
+++ b/crates/mentedb-server/src/auth.rs
@@ -137,9 +137,13 @@ pub async fn auth_middleware(
         None => return next.run(request).await,
     };
 
-    // Allow health, token, and peer-to-peer gossip endpoints without auth.
+    // Allow health, token, metrics, and peer-to-peer gossip endpoints without auth.
     let path = request.uri().path();
-    if path == "/v1/health" || path == "/v1/auth/token" || path == crate::cluster::GOSSIP_PATH {
+    if path == "/v1/health"
+        || path == "/v1/auth/token"
+        || path == "/metrics"
+        || path == crate::cluster::GOSSIP_PATH
+    {
         return next.run(request).await;
     }
 

--- a/crates/mentedb-server/src/cluster.rs
+++ b/crates/mentedb-server/src/cluster.rs
@@ -109,6 +109,15 @@ impl Cluster {
         })
     }
 
+    /// How many nodes the gossip layer currently considers live.
+    pub async fn live_node_count(&self) -> usize {
+        self.membership
+            .live_nodes()
+            .await
+            .map(|n| n.len())
+            .unwrap_or(0)
+    }
+
     /// Run the gossip loop in the background: one anti-entropy round per interval.
     pub fn spawn_gossip(&self) {
         let membership = self.membership.clone();

--- a/crates/mentedb-server/src/lib.rs
+++ b/crates/mentedb-server/src/lib.rs
@@ -23,6 +23,7 @@ pub mod extraction_queue;
 pub mod grpc;
 /// HTTP request handlers for the REST API.
 pub mod handlers;
+pub mod metrics;
 /// Token bucket rate limiting middleware.
 pub mod rate_limit;
 /// Axum router construction.

--- a/crates/mentedb-server/src/main.rs
+++ b/crates/mentedb-server/src/main.rs
@@ -7,6 +7,7 @@ mod extraction_queue;
 mod grpc;
 mod handlers;
 mod maintenance;
+mod metrics;
 mod rate_limit;
 mod routes;
 mod state;
@@ -473,6 +474,7 @@ async fn main() -> Result<()> {
             state.clone(),
             cluster::route,
         ))
+        .layer(middleware::from_fn(metrics::track))
         .layer(RateLimiter::default())
         .layer(CompressionLayer::new())
         .layer(TraceLayer::new_for_http())

--- a/crates/mentedb-server/src/metrics.rs
+++ b/crates/mentedb-server/src/metrics.rs
@@ -1,0 +1,138 @@
+//! Prometheus metrics exposed at `GET /metrics` in the standard text format.
+//!
+//! Aggregate only, with no per-account or per-agent labels, so it is safe to
+//! scrape without auth. It covers process health (CPU and memory on Linux) plus
+//! MenteDB gauges (memories stored, uptime, live cluster nodes) and HTTP request
+//! rate and latency, which together answer the "is it healthy and how hard is it
+//! working" question a dashboard needs.
+
+use std::sync::Arc;
+use std::sync::OnceLock;
+use std::time::Instant;
+
+use axum::{
+    body::Body,
+    extract::{Request, State},
+    http::{StatusCode, header},
+    middleware::Next,
+    response::{IntoResponse, Response},
+};
+use prometheus::{
+    Encoder, HistogramVec, IntCounterVec, IntGauge, Registry, TextEncoder, histogram_opts, opts,
+};
+
+use crate::state::AppState;
+
+/// The metric set, held in a process-global registry.
+pub struct Metrics {
+    registry: Registry,
+    uptime: IntGauge,
+    memory_count: IntGauge,
+    live_nodes: IntGauge,
+    http_requests: IntCounterVec,
+    http_duration: HistogramVec,
+}
+
+static METRICS: OnceLock<Metrics> = OnceLock::new();
+
+/// The process-global metric set, initialized on first use.
+pub fn metrics() -> &'static Metrics {
+    METRICS.get_or_init(Metrics::new)
+}
+
+impl Metrics {
+    fn new() -> Self {
+        let registry = Registry::new();
+
+        // Process CPU and memory, populated on Linux via /proc.
+        #[cfg(target_os = "linux")]
+        {
+            let collector = prometheus::process_collector::ProcessCollector::for_self();
+            let _ = registry.register(Box::new(collector));
+        }
+
+        // `mentedb_up` is a constant 1; register it and let the registry own it.
+        let up = IntGauge::new("mentedb_up", "1 if the server is serving").unwrap();
+        up.set(1);
+        registry.register(Box::new(up)).ok();
+
+        let uptime = IntGauge::new("mentedb_uptime_seconds", "Seconds since start").unwrap();
+        let memory_count =
+            IntGauge::new("mentedb_memory_count", "Memories stored on this node").unwrap();
+        let live_nodes = IntGauge::new(
+            "mentedb_cluster_live_nodes",
+            "Live nodes in the gossip cluster (1 when sharding is off)",
+        )
+        .unwrap();
+        let http_requests = IntCounterVec::new(
+            opts!(
+                "mentedb_http_requests_total",
+                "HTTP requests by method and status"
+            ),
+            &["method", "status"],
+        )
+        .unwrap();
+        let http_duration = HistogramVec::new(
+            histogram_opts!(
+                "mentedb_http_request_duration_seconds",
+                "HTTP request latency in seconds"
+            ),
+            &["method"],
+        )
+        .unwrap();
+
+        for g in [&uptime, &memory_count, &live_nodes] {
+            registry.register(Box::new(g.clone())).ok();
+        }
+        registry.register(Box::new(http_requests.clone())).ok();
+        registry.register(Box::new(http_duration.clone())).ok();
+
+        Self {
+            registry,
+            uptime,
+            memory_count,
+            live_nodes,
+            http_requests,
+            http_duration,
+        }
+    }
+}
+
+/// Middleware: time every request and count it by method and response status.
+pub async fn track(req: Request, next: Next) -> Response {
+    let method = req.method().as_str().to_string();
+    let start = Instant::now();
+    let resp = next.run(req).await;
+    let m = metrics();
+    let status = resp.status().as_u16().to_string();
+    m.http_requests.with_label_values(&[&method, &status]).inc();
+    m.http_duration
+        .with_label_values(&[&method])
+        .observe(start.elapsed().as_secs_f64());
+    resp
+}
+
+/// `GET /metrics`: refresh the point-in-time gauges, then encode the registry.
+pub async fn handler(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    let m = metrics();
+    m.uptime.set(state.start_time.elapsed().as_secs() as i64);
+    m.memory_count.set(state.db.memory_count() as i64);
+    let live = match &state.cluster {
+        Some(c) => c.live_node_count().await as i64,
+        None => 1,
+    };
+    m.live_nodes.set(live);
+
+    let mut buf = Vec::new();
+    if TextEncoder::new()
+        .encode(&m.registry.gather(), &mut buf)
+        .is_err()
+    {
+        return (StatusCode::INTERNAL_SERVER_ERROR, "metric encode error").into_response();
+    }
+    (
+        [(header::CONTENT_TYPE, "text/plain; version=0.0.4")],
+        Body::from(buf),
+    )
+        .into_response()
+}

--- a/crates/mentedb-server/src/routes.rs
+++ b/crates/mentedb-server/src/routes.rs
@@ -34,5 +34,6 @@ pub fn build_router(state: Arc<AppState>) -> Router {
             crate::cluster::GOSSIP_PATH,
             post(crate::cluster::gossip_handler),
         )
+        .route("/metrics", get(crate::metrics::handler))
         .with_state(state)
 }


### PR DESCRIPTION
## Summary
Step 1 of the management-UI plan: the health/CPU layer. `mentedb-server` now exposes aggregate Prometheus metrics so any Prometheus + Grafana stack can chart health, CPU, memory, and throughput.

- `GET /metrics` (auth-exempt, aggregate only, no per-account/per-agent labels, so it is safe to scrape): process CPU and resident memory (Linux via /proc), `mentedb_up`, `mentedb_uptime_seconds`, `mentedb_memory_count`, `mentedb_cluster_live_nodes`, `mentedb_http_requests_total{method,status}`, and `mentedb_http_request_duration_seconds` (histogram).
- A tracking middleware times and counts every request; a `/metrics` handler refreshes the point-in-time gauges from the engine and cluster on each scrape.
- Ships `crates/mentedb-server/grafana-dashboard.json` (importable overview: up/memories/nodes/uptime stats + request rate, latency p50/p95/p99, CPU, RSS) and a README Observability section with a scrape-config example.

## Changes
- `prometheus` dep (process feature); `metrics` module; `/metrics` route; auth + gossip-routing exemptions; `Cluster::live_node_count`.

## Verification
- Ran the server and curled `/metrics`: all `mentedb_*` gauges, the request counter, and the latency histogram emit correctly.
- `cargo clippy --workspace -- -D warnings`: clean.

## Next
Step 2/3: broaden stats into queryable views and bundle a thin domain console (fleet map, per-account/agent memory + decay/sweep state, slow queries) into the binary; extend the cloud dashboard from the same API.