### PR TITLE
feat(server): browse & manage memories from the bundled console

### DIFF
--- a/crates/mentedb-server/src/auth.rs
+++ b/crates/mentedb-server/src/auth.rs
@@ -92,6 +92,32 @@ fn extract_admin_key(request: &Request<Body>) -> Option<String> {
         .map(String::from)
 }
 
+/// Authorize an admin request from request headers against the configured admin
+/// key. Errors if no admin key is configured (admin endpoints are disabled) or the
+/// provided `x-api-key` / bearer does not match. Used by the /v1/admin endpoints.
+pub fn admin_authorized(
+    headers: &axum::http::HeaderMap,
+    admin_key: &Option<String>,
+) -> Result<(), ApiError> {
+    let expected = admin_key
+        .as_deref()
+        .ok_or_else(|| ApiError::Unauthorized("admin endpoints disabled: no admin key".into()))?;
+    let provided = headers
+        .get("x-api-key")
+        .and_then(|v| v.to_str().ok())
+        .or_else(|| {
+            headers
+                .get("authorization")
+                .and_then(|v| v.to_str().ok())
+                .and_then(|v| v.strip_prefix("Bearer "))
+        })
+        .ok_or_else(|| ApiError::Unauthorized("admin key required".into()))?;
+    if provided != expected {
+        return Err(ApiError::Forbidden("invalid admin key".into()));
+    }
+    Ok(())
+}
+
 pub async fn generate_token(
     State(state): State<Arc<AppState>>,
     request: Request<Body>,
@@ -139,10 +165,13 @@ pub async fn auth_middleware(
 
     // Allow health, token, metrics, and peer-to-peer gossip endpoints without auth.
     let path = request.uri().path();
+    // Admin endpoints are gated by the admin key inside the handler, not the JWT,
+    // so the bundled console (which sends x-api-key) can reach them.
     if path == "/v1/health"
         || path == "/v1/auth/token"
         || path == "/metrics"
         || path == "/console"
+        || path.starts_with("/v1/admin")
         || path == crate::cluster::GOSSIP_PATH
     {
         return next.run(request).await;

--- a/crates/mentedb-server/src/console.rs
+++ b/crates/mentedb-server/src/console.rs
@@ -1,9 +1,8 @@
 //! A tiny, dependency-free management console bundled into the server binary and
-//! served at `GET /console`. It polls the aggregate `/metrics` endpoint and renders
-//! a live health view (up, uptime, memories, cluster nodes, CPU, memory, request
-//! rate and latency), so self-hosters get a management UI with no extra deploy and
-//! no build step. It reads only the already-public `/metrics`, so it needs no auth
-//! of its own.
+//! served at `GET /console`. It has two tabs: Health (polls the public `/metrics`)
+//! and Memories (browses and deletes memories via the admin-key-gated
+//! `/v1/admin/memories` endpoints). Self-hosters get a real DB admin UI with no
+//! extra deploy and no build step.
 
 use axum::response::Html;
 
@@ -17,40 +16,89 @@ const PAGE: &str = r##"<!doctype html>
   :root { color-scheme: dark; }
   * { box-sizing: border-box; }
   body { margin: 0; background: #0a0a0b; color: #e4e4e7; font: 14px/1.5 ui-sans-serif, system-ui, -apple-system, sans-serif; }
-  header { padding: 20px 28px; border-bottom: 1px solid #27272a; display: flex; align-items: center; gap: 12px; }
+  header { padding: 18px 28px; border-bottom: 1px solid #27272a; display: flex; align-items: center; gap: 12px; }
   header h1 { font-size: 16px; font-weight: 600; margin: 0; }
   .dot { width: 10px; height: 10px; border-radius: 50%; background: #52525b; }
   .dot.up { background: #34d399; box-shadow: 0 0 10px rgba(52,211,153,.6); }
   .dot.down { background: #f87171; }
-  main { padding: 24px 28px; max-width: 1100px; margin: 0 auto; }
+  nav { display: flex; gap: 4px; padding: 0 22px; border-bottom: 1px solid #27272a; }
+  nav button { background: none; border: none; color: #a1a1aa; padding: 12px 14px; font: inherit; cursor: pointer; border-bottom: 2px solid transparent; }
+  nav button.active { color: #e4e4e7; border-bottom-color: #34d399; }
+  main { padding: 24px 28px; max-width: 1200px; margin: 0 auto; }
   .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 14px; }
   .card { border: 1px solid #27272a; background: #131316; border-radius: 12px; padding: 16px 18px; }
   .card .label { color: #a1a1aa; font-size: 12px; text-transform: uppercase; letter-spacing: .04em; }
   .card .value { font-size: 26px; font-weight: 600; margin-top: 6px; font-variant-numeric: tabular-nums; }
   .card .value.ok { color: #34d399; }
-  .card .sub { color: #71717a; font-size: 12px; margin-top: 2px; }
   .muted { color: #71717a; font-size: 12px; margin-top: 20px; }
   a { color: #34d399; text-decoration: none; }
+  .sub { color: #71717a; font-size: 12px; }
+  .row { display: flex; gap: 8px; flex-wrap: wrap; align-items: center; margin-bottom: 14px; }
+  input, select, button.act { background: #131316; border: 1px solid #27272a; color: #e4e4e7; border-radius: 8px; padding: 8px 10px; font: inherit; }
+  button.act { cursor: pointer; }
+  button.act:hover { border-color: #3f3f46; }
+  table { width: 100%; border-collapse: collapse; font-size: 13px; }
+  th, td { text-align: left; padding: 8px 10px; border-bottom: 1px solid #1f1f23; vertical-align: top; }
+  th { color: #a1a1aa; font-weight: 500; font-size: 12px; text-transform: uppercase; letter-spacing: .03em; }
+  td.content { max-width: 520px; }
+  .pill { font-size: 11px; padding: 1px 7px; border-radius: 999px; background: #1f1f23; color: #a1a1aa; }
+  .mono { font-family: ui-monospace, SFMono-Regular, monospace; color: #71717a; font-size: 12px; }
+  .del { color: #f87171; cursor: pointer; background: none; border: none; font: inherit; }
+  .hidden { display: none; }
 </style>
 </head>
 <body>
 <header>
   <span id="dot" class="dot"></span>
   <h1>MenteDB console</h1>
-  <span id="uptime" class="sub" style="color:#71717a"></span>
+  <span id="uptime" class="sub"></span>
 </header>
+<nav>
+  <button id="tab-health" class="active" onclick="showTab('health')">Health</button>
+  <button id="tab-memories" onclick="showTab('memories')">Memories</button>
+</nav>
 <main>
-  <div class="grid" id="grid"></div>
-  <p class="muted">Live from <a href="/metrics">/metrics</a>, refreshed every 2s. Aggregate only, no per-account data. For full time-series history, scrape with Prometheus and import the Grafana dashboard.</p>
+  <section id="health">
+    <div class="grid" id="grid"></div>
+    <p class="muted">Live from <a href="/metrics">/metrics</a>, refreshed every 2s. Aggregate only, no per-account data. For history, scrape with Prometheus and import the Grafana dashboard.</p>
+  </section>
+  <section id="memories" class="hidden">
+    <div class="row">
+      <input id="key" type="password" placeholder="admin key (x-api-key)" style="width:220px" />
+      <input id="q" placeholder="search content" style="width:200px" />
+      <select id="type">
+        <option value="">any type</option>
+        <option>episodic</option><option>semantic</option><option>procedural</option>
+        <option>antipattern</option><option>reasoning</option><option>correction</option>
+      </select>
+      <input id="agent" placeholder="agent uuid (optional)" style="width:200px" />
+      <button class="act" onclick="loadMem(0)">Load</button>
+      <span id="memmsg" class="sub"></span>
+    </div>
+    <table><thead><tr><th>Content</th><th>Type</th><th>Agent</th><th>Created</th><th></th></tr></thead>
+    <tbody id="rows"></tbody></table>
+    <div class="row" style="margin-top:14px">
+      <button class="act" id="prev" onclick="pageBy(-1)">Prev</button>
+      <button class="act" id="next" onclick="pageBy(1)">Next</button>
+      <span id="pager" class="sub"></span>
+    </div>
+  </section>
 </main>
 <script>
+function showTab(t) {
+  for (const n of ["health","memories"]) {
+    document.getElementById(n).classList.toggle("hidden", n !== t);
+    document.getElementById("tab-"+n).classList.toggle("active", n === t);
+  }
+}
+// ---- Health ----
 function parse(text) {
-  const m = {}; // name (no labels) -> summed value
+  const m = {};
   for (const line of text.split("\n")) {
     if (!line || line[0] === "#") continue;
     const sp = line.lastIndexOf(" ");
     if (sp < 0) continue;
-    let key = line.slice(0, sp).trim();
+    const key = line.slice(0, sp).trim();
     const val = parseFloat(line.slice(sp + 1));
     if (!isFinite(val)) continue;
     const name = key.indexOf("{") >= 0 ? key.slice(0, key.indexOf("{")) : key;
@@ -58,53 +106,69 @@ function parse(text) {
   }
   return m;
 }
-function fmtDur(s) {
-  s = Math.floor(s);
-  const d = Math.floor(s/86400); s%=86400;
-  const h = Math.floor(s/3600); s%=3600;
-  const mi = Math.floor(s/60);
-  return (d?d+"d ":"") + (h?h+"h ":"") + mi + "m";
-}
-function fmtBytes(b) {
-  if (!b) return "-";
-  const u = ["B","KB","MB","GB","TB"]; let i = 0;
-  while (b >= 1024 && i < u.length-1) { b/=1024; i++; }
-  return b.toFixed(1) + " " + u[i];
-}
-let prev = null, prevT = 0;
-function card(label, value, cls, sub) {
-  return `<div class="card"><div class="label">${label}</div><div class="value ${cls||""}">${value}</div>${sub?`<div class="sub">${sub}</div>`:""}</div>`;
-}
+function fmtDur(s){s=Math.floor(s);const d=Math.floor(s/86400);s%=86400;const h=Math.floor(s/3600);s%=3600;const mi=Math.floor(s/60);return (d?d+"d ":"")+(h?h+"h ":"")+mi+"m";}
+function fmtBytes(b){if(!b)return "-";const u=["B","KB","MB","GB","TB"];let i=0;while(b>=1024&&i<u.length-1){b/=1024;i++;}return b.toFixed(1)+" "+u[i];}
+let prev=null, prevT=0;
+function card(l,v,c){return `<div class="card"><div class="label">${l}</div><div class="value ${c||""}">${v}</div></div>`;}
 async function tick() {
   let m, ok = true;
-  try { m = parse(await (await fetch("/metrics", {cache:"no-store"})).text()); }
-  catch { ok = false; m = {}; }
+  try { m = parse(await (await fetch("/metrics",{cache:"no-store"})).text()); } catch { ok=false; m={}; }
   const up = ok && m["mentedb_up"] === 1;
-  document.getElementById("dot").className = "dot " + (up ? "up" : "down");
-  document.getElementById("uptime").textContent = up ? "up " + fmtDur(m["mentedb_uptime_seconds"]||0) : "unreachable";
-
-  const now = Date.now()/1000;
-  let reqRate = null, cpu = null;
-  if (prev && now > prevT) {
-    const dt = now - prevT;
-    if (m["mentedb_http_requests_total"] != null && prev["mentedb_http_requests_total"] != null)
-      reqRate = Math.max(0, (m["mentedb_http_requests_total"] - prev["mentedb_http_requests_total"]) / dt);
-    if (m["process_cpu_seconds_total"] != null && prev["process_cpu_seconds_total"] != null)
-      cpu = Math.max(0, (m["process_cpu_seconds_total"] - prev["process_cpu_seconds_total"]) / dt);
+  document.getElementById("dot").className = "dot " + (up?"up":"down");
+  document.getElementById("uptime").textContent = up ? "up "+fmtDur(m["mentedb_uptime_seconds"]||0) : "unreachable";
+  const now = Date.now()/1000; let reqRate=null, cpu=null;
+  if (prev && now>prevT){const dt=now-prevT;
+    if(m["mentedb_http_requests_total"]!=null&&prev["mentedb_http_requests_total"]!=null) reqRate=Math.max(0,(m["mentedb_http_requests_total"]-prev["mentedb_http_requests_total"])/dt);
+    if(m["process_cpu_seconds_total"]!=null&&prev["process_cpu_seconds_total"]!=null) cpu=Math.max(0,(m["process_cpu_seconds_total"]-prev["process_cpu_seconds_total"])/dt);
   }
-  prev = m; prevT = now;
-
-  const cards = [
-    card("Status", up ? "Up" : "Down", up ? "ok" : ""),
-    card("Memories stored", (m["mentedb_memory_count"]||0).toLocaleString()),
-    card("Live cluster nodes", m["mentedb_cluster_live_nodes"] != null ? m["mentedb_cluster_live_nodes"] : "-"),
-    card("Requests / sec", reqRate == null ? "…" : reqRate.toFixed(1)),
-    card("CPU (cores)", cpu == null ? (isFinite(m["process_cpu_seconds_total"]) ? "…" : "n/a") : cpu.toFixed(2)),
-    card("Resident memory", isFinite(m["process_resident_memory_bytes"]) ? fmtBytes(m["process_resident_memory_bytes"]) : "n/a"),
-  ];
-  document.getElementById("grid").innerHTML = cards.join("");
+  prev=m; prevT=now;
+  document.getElementById("grid").innerHTML = [
+    card("Status", up?"Up":"Down", up?"ok":""),
+    card("Memories stored",(m["mentedb_memory_count"]||0).toLocaleString()),
+    card("Live cluster nodes", m["mentedb_cluster_live_nodes"]!=null?m["mentedb_cluster_live_nodes"]:"-"),
+    card("Requests / sec", reqRate==null?"…":reqRate.toFixed(1)),
+    card("CPU (cores)", cpu==null?(isFinite(m["process_cpu_seconds_total"])?"…":"n/a"):cpu.toFixed(2)),
+    card("Resident memory", isFinite(m["process_resident_memory_bytes"])?fmtBytes(m["process_resident_memory_bytes"]):"n/a"),
+  ].join("");
 }
 tick(); setInterval(tick, 2000);
+// ---- Memories ----
+let offset = 0, limit = 50, total = 0;
+function esc(s){return (s||"").replace(/[&<>]/g,c=>({"&":"&amp;","<":"&lt;",">":"&gt;"}[c]));}
+function key(){ return document.getElementById("key").value.trim(); }
+async function loadMem(off) {
+  const k = key();
+  if (!k) { document.getElementById("memmsg").textContent = "enter the admin key"; return; }
+  sessionStorage.setItem("mdb_key", k);
+  offset = off;
+  const p = new URLSearchParams({ limit, offset });
+  const q = document.getElementById("q").value.trim(); if (q) p.set("q", q);
+  const t = document.getElementById("type").value; if (t) p.set("type", t);
+  const a = document.getElementById("agent").value.trim(); if (a) p.set("agent", a);
+  document.getElementById("memmsg").textContent = "loading…";
+  let r;
+  try { r = await fetch("/v1/admin/memories?"+p, { headers: { "x-api-key": k } }); }
+  catch { document.getElementById("memmsg").textContent = "request failed"; return; }
+  if (!r.ok) { document.getElementById("memmsg").textContent = "error "+r.status+" (check the admin key)"; return; }
+  const d = await r.json();
+  total = d.total;
+  document.getElementById("rows").innerHTML = (d.memories||[]).map(mem => {
+    const dt = mem.created_at ? new Date(mem.created_at/1000).toISOString().slice(0,16).replace("T"," ") : "";
+    const ag = (mem.agent_id||"").slice(0,8);
+    return `<tr><td class="content">${esc(mem.content)}</td><td><span class="pill">${esc(mem.memory_type)}</span></td><td class="mono">${ag}</td><td class="mono">${dt}</td><td><button class="del" onclick="del('${mem.id}')">delete</button></td></tr>`;
+  }).join("");
+  document.getElementById("memmsg").textContent = "";
+  document.getElementById("pager").textContent = `${offset+1}–${Math.min(offset+limit,total)} of ${total.toLocaleString()}`;
+  document.getElementById("prev").disabled = offset <= 0;
+  document.getElementById("next").disabled = offset+limit >= total;
+}
+function pageBy(dir){ const n = offset + dir*limit; if (n>=0 && n<total) loadMem(n); }
+async function del(id) {
+  if (!confirm("Delete this memory?")) return;
+  const r = await fetch("/v1/admin/memories/"+id, { method:"DELETE", headers: { "x-api-key": key() } });
+  if (r.ok) loadMem(offset); else alert("delete failed: "+r.status);
+}
+window.addEventListener("load", () => { const s = sessionStorage.getItem("mdb_key"); if (s) document.getElementById("key").value = s; });
 </script>
 </body>
 </html>

--- a/crates/mentedb-server/src/handlers.rs
+++ b/crates/mentedb-server/src/handlers.rs
@@ -6,8 +6,8 @@ use std::sync::Arc;
 use crate::auth::AuthenticatedAgent;
 use axum::Extension;
 use axum::Json;
-use axum::extract::{Path, State};
-use axum::http::StatusCode;
+use axum::extract::{Path, Query, State};
+use axum::http::{HeaderMap, StatusCode};
 use axum::response::IntoResponse;
 use mentedb_core::edge::EdgeType;
 use mentedb_core::memory::{AttributeValue, MemoryType};
@@ -695,4 +695,89 @@ pub async fn grant_space_access(
     }
     spaces.grant_access(space_id, target_agent, perm);
     Ok(Json(json!({"status": "granted"})))
+}
+
+// ---------------------------------------------------------------------------
+// Admin endpoints (gated by the admin key, for the bundled /console).
+// ---------------------------------------------------------------------------
+
+/// Query params for GET /v1/admin/memories.
+#[derive(serde::Deserialize)]
+pub struct AdminListParams {
+    pub limit: Option<usize>,
+    pub offset: Option<usize>,
+    /// Filter by owning agent UUID.
+    pub agent: Option<String>,
+    /// Filter by memory type name.
+    #[serde(rename = "type")]
+    pub memory_type: Option<String>,
+    /// Case-insensitive content substring.
+    pub q: Option<String>,
+}
+
+fn memory_type_from_str(s: &str) -> Result<MemoryType, ApiError> {
+    match s.to_lowercase().as_str() {
+        "episodic" => Ok(MemoryType::Episodic),
+        "semantic" => Ok(MemoryType::Semantic),
+        "procedural" => Ok(MemoryType::Procedural),
+        "antipattern" | "anti_pattern" => Ok(MemoryType::AntiPattern),
+        "reasoning" => Ok(MemoryType::Reasoning),
+        "correction" => Ok(MemoryType::Correction),
+        other => Err(ApiError::BadRequest(format!(
+            "unknown memory type: {other}"
+        ))),
+    }
+}
+
+/// GET /v1/admin/memories: a bounded, paginated page of memories for the console.
+pub async fn admin_list_memories(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Query(p): Query<AdminListParams>,
+) -> Result<impl IntoResponse, ApiError> {
+    crate::auth::admin_authorized(&headers, &state.admin_key)?;
+    let limit = p.limit.unwrap_or(50).clamp(1, 200);
+    let offset = p.offset.unwrap_or(0);
+    let agent = match p.agent.as_deref().filter(|s| !s.is_empty()) {
+        Some(s) => {
+            Some(AgentId(s.parse().map_err(|_| {
+                ApiError::BadRequest("invalid agent UUID".into())
+            })?))
+        }
+        None => None,
+    };
+    let mtype = match p.memory_type.as_deref().filter(|s| !s.is_empty()) {
+        Some(s) => Some(memory_type_from_str(s)?),
+        None => None,
+    };
+    let q = p.q.as_deref().filter(|s| !s.is_empty());
+
+    let (total, nodes) = state
+        .db
+        .list_memories(limit, offset, agent, mtype, q)
+        .map_err(|e| ApiError::Internal(e.to_string()))?;
+    let memories: Vec<_> = nodes.iter().map(memory_node_to_json).collect();
+    Ok(Json(json!({
+        "total": total,
+        "limit": limit,
+        "offset": offset,
+        "memories": memories,
+    })))
+}
+
+/// DELETE /v1/admin/memories/{id}: forget a memory from the console.
+pub async fn admin_delete_memory(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Path(id_str): Path<String>,
+) -> Result<impl IntoResponse, ApiError> {
+    crate::auth::admin_authorized(&headers, &state.admin_key)?;
+    let id: MemoryId = id_str
+        .parse()
+        .map_err(|_| ApiError::BadRequest("invalid memory ID".into()))?;
+    state
+        .db
+        .forget(id)
+        .map_err(|e| ApiError::Internal(e.to_string()))?;
+    Ok(Json(json!({ "status": "deleted", "id": id.to_string() })))
 }

--- a/crates/mentedb-server/src/routes.rs
+++ b/crates/mentedb-server/src/routes.rs
@@ -36,5 +36,10 @@ pub fn build_router(state: Arc<AppState>) -> Router {
         )
         .route("/metrics", get(crate::metrics::handler))
         .route("/console", get(crate::console::handler))
+        .route("/v1/admin/memories", get(handlers::admin_list_memories))
+        .route(
+            "/v1/admin/memories/{id}",
+            axum::routing::delete(handlers::admin_delete_memory),
+        )
         .with_state(state)
 }

--- a/crates/mentedb/src/lib.rs
+++ b/crates/mentedb/src/lib.rs
@@ -983,6 +983,47 @@ impl MenteDb {
         self.page_map.read().len()
     }
 
+    /// A bounded, paginated page of stored memories for admin browsing, ordered by
+    /// id so pagination is stable. Only `limit` nodes are loaded from storage per
+    /// call (paginate over the id set first, then load), so it stays cheap even on
+    /// a large store. Optional filters narrow the loaded page by owning agent,
+    /// memory type, and a case-insensitive content substring. Returns the total
+    /// memory count (for the pager) alongside the page.
+    pub fn list_memories(
+        &self,
+        limit: usize,
+        offset: usize,
+        agent: Option<AgentId>,
+        memory_type: Option<MemoryType>,
+        content_query: Option<&str>,
+    ) -> MenteResult<(usize, Vec<MemoryNode>)> {
+        let pm = self.page_map.read();
+        let total = pm.len();
+        let mut ids: Vec<MemoryId> = pm.keys().copied().collect();
+        ids.sort();
+        let needle = content_query.map(|q| q.to_lowercase());
+        let mut out = Vec::new();
+        for id in ids.into_iter().skip(offset).take(limit) {
+            if let Some(&page_id) = pm.get(&id)
+                && let Ok(node) = self.storage.load_memory(page_id)
+            {
+                if agent.is_some_and(|a| node.agent_id != a) {
+                    continue;
+                }
+                if memory_type.is_some_and(|t| node.memory_type != t) {
+                    continue;
+                }
+                if let Some(n) = &needle
+                    && !node.content.to_lowercase().contains(n)
+                {
+                    continue;
+                }
+                out.push(node);
+            }
+        }
+        Ok((total, out))
+    }
+
     /// Removes a memory from storage, indexes, and the graph.
     pub fn forget(&self, id: MemoryId) -> MenteResult<()> {
         debug!("Forgetting memory {}", id);


### PR DESCRIPTION
## Summary
Extends the bundled `/console` from a health page into a real self-host DB admin UI.
- `MenteDb::list_memories(limit, offset, agent, type, content)`: bounded, paginated. Paginates over the sorted id set and loads only that page from storage, so it stays cheap on a large store; optional filters by owning agent, memory type, and content substring. Returns the total for the pager.
- Admin-key-gated endpoints: `GET /v1/admin/memories` (list/search/filter) and `DELETE /v1/admin/memories/{id}` (forget). Gated by the existing `--admin-key` (disabled when unset), JWT-exempt since the admin key is the gate.
- `/console` gains a **Memories** tab: enter the admin key, search content, filter by type/agent, page through, and delete.

## Verification
- Live end-to-end: without the key `GET /v1/admin/memories` returns 401; with it, lists all memories; `q=` filters correctly; `DELETE` removes a memory and the total drops. 
- `cargo clippy --workspace -- -D warnings`: clean.

## Notes
Bounded by design (loads only one page). A query box (full MQL) and per-account/decay/sweep views are natural follow-ups.