### PR TITLE
feat: one-command Prometheus + Grafana observability stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -613,18 +613,21 @@ node's write throughput becomes the ceiling.
 ## Observability
 
 `mentedb-server` exposes Prometheus metrics at `GET /metrics` (no auth, aggregate
-only, no per-account labels). It reports process CPU and memory, uptime, memories
-stored, live cluster nodes, and HTTP request rate and latency. Point Prometheus at
-it and import [`crates/mentedb-server/grafana-dashboard.json`](crates/mentedb-server/grafana-dashboard.json)
-for an overview dashboard.
+only, no per-account labels): process CPU and memory, uptime, memories stored, live
+cluster nodes, and HTTP request rate and latency. It also serves a bundled console
+at `GET /console` (live health, plus a memory browser gated by `--admin-key`).
 
-```yaml
-# prometheus.yml
-scrape_configs:
-  - job_name: mentedb
-    static_configs:
-      - targets: ["mentedb-0:6677", "mentedb-1:6677"]
+For a full stack, [`observability/`](observability/) has a one-command Prometheus +
+Grafana setup with the dashboard already provisioned:
+
+```bash
+docker compose -f observability/docker-compose.yml up -d
+open http://localhost:3000   # Grafana, "MenteDB" dashboard, live
 ```
+
+Point [`observability/prometheus.yml`](observability/prometheus.yml) at your nodes,
+or import [`crates/mentedb-server/grafana-dashboard.json`](crates/mentedb-server/grafana-dashboard.json)
+into an existing Grafana.
 
 ## Crates
 

--- a/observability/README.md
+++ b/observability/README.md
@@ -1,0 +1,34 @@
+# Observability
+
+A one-command Prometheus + Grafana stack for MenteDB. Prometheus scrapes a
+server's aggregate `/metrics` endpoint; Grafana starts with the MenteDB dashboard
+already provisioned.
+
+## Run it
+
+```bash
+# start a server first (metrics are on the same port as the API)
+mentedb-server --data-dir ./data
+
+# then bring up the stack
+docker compose -f observability/docker-compose.yml up -d
+open http://localhost:3000        # Grafana (anonymous admin), "MenteDB" dashboard
+```
+
+Grafana comes up at `:3000` (no login), Prometheus at `:9090`. The dashboard shows
+up/uptime/memories/live nodes, request rate, latency percentiles, CPU, and resident
+memory.
+
+## Point it at your nodes
+
+Edit [`prometheus.yml`](prometheus.yml) and list your targets. The default scrapes
+a `mentedb-server` on the host at `:6677`; add more nodes or the platform gateway
+(`:8080`) as extra targets. `/metrics` is aggregate only (no per-account labels),
+so it is safe to scrape without auth.
+
+## Files
+
+- `prometheus.yml` — scrape config.
+- `grafana/provisioning/` — datasource + dashboard providers (auto-loaded).
+- `grafana/dashboards/mentedb.json` — the dashboard.
+- `docker-compose.yml` — the two services.

--- a/observability/docker-compose.yml
+++ b/observability/docker-compose.yml
@@ -1,0 +1,32 @@
+# One-command observability for MenteDB: Prometheus scrapes the server's /metrics
+# and Grafana comes up with the MenteDB dashboard already loaded.
+#
+#   docker compose -f observability/docker-compose.yml up -d
+#   open http://localhost:3000   # Grafana, anonymous admin, "MenteDB" dashboard
+#
+# Point prometheus.yml at your node(s). The default scrapes a mentedb-server on the
+# host at :6677 (host.docker.internal works on Docker Desktop and, via the
+# host-gateway mapping below, on Linux too).
+services:
+  prometheus:
+    image: prom/prometheus:latest
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    ports:
+      - "9090:9090"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+  grafana:
+    image: grafana/grafana:latest
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_AUTH_DISABLE_LOGIN_FORM=true
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
+    depends_on:
+      - prometheus

--- a/observability/grafana/dashboards/mentedb.json
+++ b/observability/grafana/dashboards/mentedb.json
@@ -1,0 +1,86 @@
+{
+  "title": "MenteDB",
+  "uid": "mentedb-overview",
+  "tags": ["mentedb"],
+  "schemaVersion": 39,
+  "version": 1,
+  "editable": true,
+  "time": { "from": "now-6h", "to": "now" },
+  "refresh": "30s",
+  "panels": [
+    {
+      "type": "stat",
+      "title": "Up",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 0 },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            { "type": "value", "options": { "0": { "text": "Down", "color": "red" }, "1": { "text": "Up", "color": "green" } } }
+          ],
+          "color": { "mode": "thresholds" }
+        }
+      },
+      "targets": [{ "expr": "max(mentedb_up)", "refId": "A" }]
+    },
+    {
+      "type": "stat",
+      "title": "Memories stored",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 0 },
+      "targets": [{ "expr": "sum(mentedb_memory_count)", "refId": "A" }]
+    },
+    {
+      "type": "stat",
+      "title": "Live cluster nodes",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 0 },
+      "targets": [{ "expr": "max(mentedb_cluster_live_nodes)", "refId": "A" }]
+    },
+    {
+      "type": "stat",
+      "title": "Uptime",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 0 },
+      "fieldConfig": { "defaults": { "unit": "s" } },
+      "targets": [{ "expr": "max(mentedb_uptime_seconds)", "refId": "A" }]
+    },
+    {
+      "type": "timeseries",
+      "title": "Request rate (per second, by status)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 4 },
+      "fieldConfig": { "defaults": { "unit": "reqps" } },
+      "targets": [
+        { "expr": "sum by (status) (rate(mentedb_http_requests_total[5m]))", "legendFormat": "{{status}}", "refId": "A" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Request latency (seconds)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 4 },
+      "fieldConfig": { "defaults": { "unit": "s" } },
+      "targets": [
+        { "expr": "histogram_quantile(0.50, sum by (le) (rate(mentedb_http_request_duration_seconds_bucket[5m])))", "legendFormat": "p50", "refId": "A" },
+        { "expr": "histogram_quantile(0.95, sum by (le) (rate(mentedb_http_request_duration_seconds_bucket[5m])))", "legendFormat": "p95", "refId": "B" },
+        { "expr": "histogram_quantile(0.99, sum by (le) (rate(mentedb_http_request_duration_seconds_bucket[5m])))", "legendFormat": "p99", "refId": "C" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "CPU (cores)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 12 },
+      "targets": [{ "expr": "rate(process_cpu_seconds_total[5m])", "legendFormat": "cpu cores", "refId": "A" }]
+    },
+    {
+      "type": "timeseries",
+      "title": "Resident memory",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 12 },
+      "fieldConfig": { "defaults": { "unit": "bytes" } },
+      "targets": [{ "expr": "process_resident_memory_bytes", "legendFormat": "rss", "refId": "A" }]
+    }
+  ]
+}

--- a/observability/grafana/provisioning/dashboards/provider.yml
+++ b/observability/grafana/provisioning/dashboards/provider.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+providers:
+  - name: mentedb
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    allowUiUpdates: true
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/observability/grafana/provisioning/datasources/datasource.yml
+++ b/observability/grafana/provisioning/datasources/datasource.yml
@@ -1,0 +1,8 @@
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    type: prometheus
+    uid: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true

--- a/observability/prometheus.yml
+++ b/observability/prometheus.yml
@@ -1,0 +1,17 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  # A self-hosted mentedb-server running on the host at :6677.
+  - job_name: mentedb-server
+    static_configs:
+      - targets: ["host.docker.internal:6677"]
+        labels:
+          instance: mentedb-server
+
+  # Add more nodes or the platform gateway here, for example:
+  # - job_name: mentedb-gateway
+  #   static_configs:
+  #     - targets: ["host.docker.internal:8080"]
+  #       labels:
+  #         instance: gateway


### PR DESCRIPTION
## Summary
Makes the metrics we ship actually consumable end to end. `observability/` is a `docker compose up` that stands up Prometheus (scraping the server's `/metrics`) and Grafana with the MenteDB dashboard already provisioned, no manual setup, no paid managed service.

- `prometheus.yml` scrape config (defaults to a server on the host at :6677; add nodes / the gateway).
- Grafana provisioning: the Prometheus datasource + the dashboard, auto-loaded.
- `docker-compose.yml` + a README.

## Verification (live, not hand-waved)
Started a server, ran the stack, and confirmed: Prometheus target `up` with `mentedb_up=1`; Grafana provisioned the `Prometheus` datasource and the `MenteDB` dashboard; Grafana queried Prometheus and got `mentedb_up=1`.

## Notes
For the hosted platform, pointing its existing AWS observability at the gateway `/metrics` is a separate (cost/infra) step, deliberately not provisioned here.