### PR TITLE
feat: mentedb CLI + MQL query endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2266,6 +2266,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mentedb-cli"
+version = "0.17.9"
+dependencies = [
+ "mentedb",
+ "reqwest",
+ "serde_json",
+]
+
+[[package]]
 name = "mentedb-cognitive"
 version = "0.17.9"
 dependencies = [
@@ -3525,6 +3534,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "crates/mentedb-query",
     "crates/mentedb-context",
     "crates/mentedb-server",
+    "crates/mentedb-cli",
     "crates/mentedb-cognitive",
     "crates/mentedb-consolidation",
     "crates/mentedb-embedding",

--- a/README.md
+++ b/README.md
@@ -80,6 +80,23 @@ pip install mentedb-langchain  # LangChain memory provider
 pip install mentedb-crewai     # CrewAI memory provider
 ```
 
+### Command-line client
+
+`mentedb` runs MQL from the shell, against a local data directory (opened
+in-process, like `sqlite3`) or a running server (over HTTP). `cargo install
+mentedb-cli` installs the `mentedb` binary.
+
+```bash
+# local: query a data directory directly (must not be open by a server)
+mentedb query --data-dir ./data 'RECALL memories WHERE type = semantic LIMIT 10'
+
+# remote: query a running server
+mentedb query --url http://localhost:6677 --admin-key "$KEY" 'RECALL memories LIMIT 5'
+
+# interactive REPL, or --format json | csv
+mentedb repl --data-dir ./data
+```
+
 ## Quick start: an agent that remembers
 
 Memory is one call. `process_turn` embeds the user message, recalls what is

--- a/README.md
+++ b/README.md
@@ -86,15 +86,20 @@ pip install mentedb-crewai     # CrewAI memory provider
 in-process, like `sqlite3`) or a running server (over HTTP). `cargo install
 mentedb-cli` installs the `mentedb` binary.
 
+With no flags it just works: it defaults to a local `./mentedb-data` (the server's
+default directory), so run it where you ran the server. Set `MENTEDB_URL` (and
+`MENTEDB_ADMIN_KEY`) or `MENTEDB_DATA_DIR` to point it elsewhere without repeating
+flags; explicit flags always win.
+
 ```bash
-# local: query a data directory directly (must not be open by a server)
-mentedb query --data-dir ./data 'RECALL memories WHERE type = semantic LIMIT 10'
+mentedb query 'RECALL memories WHERE type = semantic LIMIT 10'   # local ./mentedb-data
+mentedb query --data-dir ./data 'RECALL memories LIMIT 5'        # a specific directory
 
-# remote: query a running server
-mentedb query --url http://localhost:6677 --admin-key "$KEY" 'RECALL memories LIMIT 5'
+# a running server (or export the vars once)
+export MENTEDB_URL=http://localhost:6677 MENTEDB_ADMIN_KEY="$KEY"
+mentedb query 'RECALL memories LIMIT 5'
 
-# interactive REPL, or --format json | csv
-mentedb repl --data-dir ./data
+mentedb repl                                                     # interactive; --format json | csv
 ```
 
 ## Quick start: an agent that remembers

--- a/crates/mentedb-cli/Cargo.toml
+++ b/crates/mentedb-cli/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "mentedb-cli"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Command-line client for MenteDB: run MQL against a local data dir or a remote server."
+
+[[bin]]
+name = "mentedb"
+path = "src/main.rs"
+
+[dependencies]
+mentedb = { workspace = true }
+serde_json = { workspace = true }
+reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "rustls-tls"] }

--- a/crates/mentedb-cli/src/main.rs
+++ b/crates/mentedb-cli/src/main.rs
@@ -1,0 +1,242 @@
+//! `mentedb`: a command-line client for running MQL against MenteDB, either a
+//! local data directory (opened in-process) or a running server (over HTTP).
+
+use std::io::{self, BufRead, Write};
+
+use mentedb::MenteDb;
+use serde_json::{Value, json};
+
+const USAGE: &str = "\
+mentedb - MenteDB command-line client
+
+USAGE:
+    mentedb query [connection] [--format table|json|csv] <MQL>
+    mentedb repl  [connection] [--format table|json|csv]
+
+CONNECTION (pick one):
+    --data-dir <DIR>                 open a local data directory (no server; the
+                                     directory must not be open by a server)
+    --url <URL> --admin-key <KEY>    connect to a running server
+
+EXAMPLES:
+    mentedb query --data-dir ./data 'RECALL memories WHERE type = semantic LIMIT 10'
+    mentedb query --url http://localhost:6677 --admin-key \"$KEY\" 'RECALL memories LIMIT 5'
+    mentedb repl --data-dir ./data
+";
+
+enum Conn {
+    Local(String),
+    Remote { url: String, key: String },
+}
+
+struct Opts {
+    conn: Conn,
+    format: String,
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() < 2 || args[1] == "--help" || args[1] == "-h" {
+        print!("{USAGE}");
+        return;
+    }
+    let cmd = args[1].clone();
+
+    let (mut data_dir, mut url, mut key) = (None, None, None);
+    let mut format = "table".to_string();
+    let mut mql_parts: Vec<String> = Vec::new();
+    let mut i = 2;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--data-dir" => {
+                data_dir = args.get(i + 1).cloned();
+                i += 2;
+            }
+            "--url" => {
+                url = args.get(i + 1).cloned();
+                i += 2;
+            }
+            "--admin-key" => {
+                key = args.get(i + 1).cloned();
+                i += 2;
+            }
+            "--format" => {
+                format = args.get(i + 1).cloned().unwrap_or(format);
+                i += 2;
+            }
+            other => {
+                mql_parts.push(other.to_string());
+                i += 1;
+            }
+        }
+    }
+
+    let conn = match (data_dir, url, key) {
+        (Some(d), _, _) => Conn::Local(d),
+        (None, Some(u), Some(k)) => Conn::Remote { url: u, key: k },
+        _ => {
+            eprintln!("error: specify either --data-dir, or --url with --admin-key\n\n{USAGE}");
+            std::process::exit(2);
+        }
+    };
+    let opts = Opts { conn, format };
+
+    match cmd.as_str() {
+        "query" => {
+            let mql = mql_parts.join(" ");
+            if mql.trim().is_empty() {
+                eprintln!("error: no MQL query given");
+                std::process::exit(2);
+            }
+            match run_query(&opts.conn, &mql) {
+                Ok(rows) => print_results(&rows, &opts.format),
+                Err(e) => {
+                    eprintln!("error: {e}");
+                    std::process::exit(1);
+                }
+            }
+        }
+        "repl" => repl(&opts),
+        other => {
+            eprintln!("error: unknown command '{other}'\n\n{USAGE}");
+            std::process::exit(2);
+        }
+    }
+}
+
+fn repl(opts: &Opts) {
+    println!("MenteDB CLI. Enter an MQL query, or \\q to quit.");
+    let stdin = io::stdin();
+    loop {
+        print!("mentedb> ");
+        io::stdout().flush().ok();
+        let mut line = String::new();
+        if stdin.lock().read_line(&mut line).unwrap_or(0) == 0 {
+            println!();
+            break;
+        }
+        let q = line.trim();
+        if q.is_empty() {
+            continue;
+        }
+        if q == "\\q" || q == "\\quit" || q == "exit" {
+            break;
+        }
+        match run_query(&opts.conn, q) {
+            Ok(rows) => print_results(&rows, &opts.format),
+            Err(e) => eprintln!("error: {e}"),
+        }
+    }
+}
+
+/// Run the query and return the matches as JSON memory objects
+/// (content, memory_type, agent_id, created_at, score).
+fn run_query(conn: &Conn, mql: &str) -> Result<Vec<Value>, String> {
+    match conn {
+        Conn::Local(dir) => {
+            let db = MenteDb::open(std::path::Path::new(dir)).map_err(|e| e.to_string())?;
+            let results = db.query(mql).map_err(|e| e.to_string())?;
+            Ok(results
+                .iter()
+                .map(|s| {
+                    json!({
+                        "id": s.memory.id.to_string(),
+                        "memory_type": format!("{:?}", s.memory.memory_type).to_lowercase(),
+                        "agent_id": s.memory.agent_id.to_string(),
+                        "content": s.memory.content,
+                        "created_at": s.memory.created_at,
+                        "score": s.score,
+                    })
+                })
+                .collect())
+        }
+        Conn::Remote { url, key } => {
+            let endpoint = format!("{}/v1/admin/mql", url.trim_end_matches('/'));
+            let resp = reqwest::blocking::Client::new()
+                .post(&endpoint)
+                .header("x-api-key", key)
+                .json(&json!({ "mql": mql }))
+                .send()
+                .map_err(|e| e.to_string())?;
+            if !resp.status().is_success() {
+                return Err(format!("server returned {}", resp.status()));
+            }
+            let body: Value = resp.json().map_err(|e| e.to_string())?;
+            Ok(body
+                .get("memories")
+                .and_then(|m| m.as_array())
+                .cloned()
+                .unwrap_or_default())
+        }
+    }
+}
+
+fn field(v: &Value, k: &str) -> String {
+    match v.get(k) {
+        Some(Value::String(s)) => s.clone(),
+        Some(Value::Number(n)) => n.to_string(),
+        Some(other) => other.to_string(),
+        None => String::new(),
+    }
+}
+
+fn print_results(rows: &[Value], format: &str) {
+    match format {
+        "json" => println!(
+            "{}",
+            serde_json::to_string_pretty(&rows).unwrap_or_else(|_| "[]".into())
+        ),
+        "csv" => {
+            println!("score,type,agent,content");
+            for r in rows {
+                println!(
+                    "{},{},{},{}",
+                    field(r, "score"),
+                    field(r, "memory_type"),
+                    field(r, "agent_id"),
+                    csv_escape(&field(r, "content")),
+                );
+            }
+        }
+        _ => print_table(rows),
+    }
+}
+
+fn print_table(rows: &[Value]) {
+    if rows.is_empty() {
+        println!("(0 rows)");
+        return;
+    }
+    println!("{:>7}  {:<11}  {:<8}  CONTENT", "SCORE", "TYPE", "AGENT");
+    for r in rows {
+        let score = field(r, "score");
+        let score = score
+            .parse::<f64>()
+            .map(|f| format!("{f:.3}"))
+            .unwrap_or(score);
+        let mtype = field(r, "memory_type");
+        let agent: String = field(r, "agent_id").chars().take(8).collect();
+        let content = {
+            let c = field(r, "content").replace('\n', " ");
+            if c.chars().count() > 70 {
+                format!("{}…", c.chars().take(69).collect::<String>())
+            } else {
+                c
+            }
+        };
+        println!("{score:>7}  {mtype:<11}  {agent:<8}  {content}");
+    }
+    println!(
+        "({} row{})",
+        rows.len(),
+        if rows.len() == 1 { "" } else { "s" }
+    );
+}
+
+fn csv_escape(s: &str) -> String {
+    if s.contains([',', '"', '\n']) {
+        format!("\"{}\"", s.replace('"', "\"\""))
+    } else {
+        s.to_string()
+    }
+}

--- a/crates/mentedb-cli/src/main.rs
+++ b/crates/mentedb-cli/src/main.rs
@@ -13,15 +13,17 @@ USAGE:
     mentedb query [connection] [--format table|json|csv] <MQL>
     mentedb repl  [connection] [--format table|json|csv]
 
-CONNECTION (pick one):
-    --data-dir <DIR>                 open a local data directory (no server; the
-                                     directory must not be open by a server)
-    --url <URL> --admin-key <KEY>    connect to a running server
+CONNECTION (flags override env; defaults to a local ./mentedb-data):
+    --data-dir <DIR>    or  MENTEDB_DATA_DIR    local directory (default ./mentedb-data)
+    --url <URL>         or  MENTEDB_URL         a running server (over HTTP)
+    --admin-key <KEY>   or  MENTEDB_ADMIN_KEY   admin key, required for a server
 
 EXAMPLES:
-    mentedb query --data-dir ./data 'RECALL memories WHERE type = semantic LIMIT 10'
-    mentedb query --url http://localhost:6677 --admin-key \"$KEY\" 'RECALL memories LIMIT 5'
-    mentedb repl --data-dir ./data
+    mentedb query 'RECALL memories LIMIT 10'                       # local ./mentedb-data
+    mentedb query --data-dir ./data 'RECALL memories LIMIT 5'
+    MENTEDB_URL=http://localhost:6677 MENTEDB_ADMIN_KEY=\"$KEY\" \\
+        mentedb query 'RECALL memories WHERE type = semantic LIMIT 5'
+    mentedb repl
 ";
 
 enum Conn {
@@ -71,12 +73,33 @@ fn main() {
         }
     }
 
-    let conn = match (data_dir, url, key) {
-        (Some(d), _, _) => Conn::Local(d),
-        (None, Some(u), Some(k)) => Conn::Remote { url: u, key: k },
-        _ => {
-            eprintln!("error: specify either --data-dir, or --url with --admin-key\n\n{USAGE}");
-            std::process::exit(2);
+    // Resolve the target with no flags required: flags win, then env vars, then a
+    // local ./mentedb-data (the server's default), so `mentedb query '...'` in the
+    // directory you ran the server from just works.
+    let data_dir = data_dir.or_else(|| std::env::var("MENTEDB_DATA_DIR").ok());
+    let url = url.or_else(|| std::env::var("MENTEDB_URL").ok());
+    let key = key.or_else(|| std::env::var("MENTEDB_ADMIN_KEY").ok());
+
+    let conn = match url {
+        Some(u) => match key {
+            Some(k) => Conn::Remote { url: u, key: k },
+            None => {
+                eprintln!(
+                    "error: a server URL needs an admin key (--admin-key or MENTEDB_ADMIN_KEY)"
+                );
+                std::process::exit(2);
+            }
+        },
+        None => {
+            let dir = data_dir.unwrap_or_else(|| "./mentedb-data".to_string());
+            if !std::path::Path::new(&dir).exists() {
+                eprintln!(
+                    "error: no data directory at '{dir}'. Pass --data-dir <DIR>, or set \
+                     MENTEDB_URL (+ MENTEDB_ADMIN_KEY) to query a running server.\n\n{USAGE}"
+                );
+                std::process::exit(2);
+            }
+            Conn::Local(dir)
         }
     };
     let opts = Opts { conn, format };

--- a/crates/mentedb-server/src/handlers.rs
+++ b/crates/mentedb-server/src/handlers.rs
@@ -781,3 +781,34 @@ pub async fn admin_delete_memory(
         .map_err(|e| ApiError::Internal(e.to_string()))?;
     Ok(Json(json!({ "status": "deleted", "id": id.to_string() })))
 }
+
+/// POST /v1/admin/mql: run an MQL query, return the scored matches. Powers the
+/// console query box and the `mentedb` CLI's remote mode.
+pub async fn admin_run_mql(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Json(body): Json<Value>,
+) -> Result<impl IntoResponse, ApiError> {
+    crate::auth::admin_authorized(&headers, &state.admin_key)?;
+    let mql = body
+        .get("mql")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| ApiError::BadRequest("missing 'mql'".into()))?;
+    let scored = state
+        .db
+        .query(mql)
+        .map_err(|e| ApiError::BadRequest(format!("query error: {e}")))?;
+    let memories: Vec<Value> = scored
+        .iter()
+        .map(|s| {
+            let mut j = memory_node_to_json(&s.memory);
+            if let Value::Object(ref mut m) = j {
+                m.insert("score".into(), json!(s.score));
+            }
+            j
+        })
+        .collect();
+    Ok(Json(
+        json!({ "count": memories.len(), "memories": memories }),
+    ))
+}

--- a/crates/mentedb-server/src/routes.rs
+++ b/crates/mentedb-server/src/routes.rs
@@ -41,5 +41,6 @@ pub fn build_router(state: Arc<AppState>) -> Router {
             "/v1/admin/memories/{id}",
             axum::routing::delete(handlers::admin_delete_memory),
         )
+        .route("/v1/admin/mql", post(handlers::admin_run_mql))
         .with_state(state)
 }

--- a/crates/mentedb/src/lib.rs
+++ b/crates/mentedb/src/lib.rs
@@ -653,6 +653,15 @@ impl MenteDb {
         Ok(window)
     }
 
+    /// Run an MQL query and return the scored matches directly, without assembling
+    /// a context window. This is the raw query primitive behind `recall` (which
+    /// additionally packs the results into a token-budgeted context), and it powers
+    /// the `mentedb` CLI and the admin query endpoint.
+    pub fn query(&self, mql: &str) -> MenteResult<Vec<ScoredMemory>> {
+        let plan = Mql::parse(mql)?;
+        self.execute_plan(&plan)
+    }
+
     /// Like [`recall`](Self::recall), but runs an optional second pass through a
     /// [`Reranker`](crate::reranker::Reranker) before assembling the context
     /// window. The reranker reorders the first-pass candidates by `query_text`


### PR DESCRIPTION
## Summary
A `mentedb` command-line client for running MQL, the way `psql`/`redis-cli` work for their DBs.

- **New `mentedb-cli` crate** (binary `mentedb`): runs MQL against a **local data directory** (opened in-process, like `sqlite3`) or a **running server** (over HTTP). One-shot (`mentedb query …`) or interactive (`mentedb repl`), with `table` / `json` / `csv` output.
- **`MenteDb::query(mql)`**: the raw MQL primitive behind `recall` (returns the scored matches without context assembly). Powers the CLI's local mode and the endpoint.
- **`POST /v1/admin/mql`** (admin-key gated): runs MQL, returns scored matches. Backs the CLI's remote mode and the console query box.

## Verification (live)
- **Remote:** `mentedb query --url … 'RECALL memories LIMIT 5'` prints the table; `--format json` with `CONTAINS "espresso"` returns the filtered JSON.
- **Local:** after stopping the server, `mentedb query --data-dir … 'RECALL memories WHERE type = semantic LIMIT 5'` queries the directory in-process.
- `cargo clippy --workspace -- -D warnings`: clean.