### PR TITLE
feat(query): MQL boolean WHERE (OR, NOT, grouping)

### DIFF
--- a/crates/mentedb-query/src/ast.rs
+++ b/crates/mentedb-query/src/ast.rs
@@ -18,10 +18,31 @@ pub enum Statement {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RecallStatement {
+    /// The top-level ANDed leaf filters. For a pure `a AND b AND c` WHERE clause
+    /// this holds every filter and `condition` is `None`, so the planner keeps all
+    /// its index optimizations. When the WHERE uses OR, NOT, or parentheses,
+    /// `condition` carries the full boolean tree and this is empty.
     pub filters: Vec<Filter>,
+    /// The full boolean WHERE expression, set only when it is not a pure AND of
+    /// leaves (i.e. it contains OR, NOT, or grouping). When present, the executor
+    /// evaluates this tree; the planner falls back to a full scan and lets the
+    /// post-filter decide, so results are always correct even if less optimized.
+    pub condition: Option<Condition>,
     pub near: Option<Vec<f32>>,
     pub limit: Option<usize>,
     pub order_by: Option<OrderBy>,
+}
+
+/// A boolean combination of filters. `Leaf` is a single comparison; `And`/`Or`
+/// combine sub-conditions; `Not` negates one. This is the general form of a WHERE
+/// clause; a pure AND of leaves is represented directly as `RecallStatement.filters`
+/// instead, so the common case needs no tree walk.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum Condition {
+    And(Vec<Condition>),
+    Or(Vec<Condition>),
+    Not(Box<Condition>),
+    Leaf(Filter),
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/crates/mentedb-query/src/parser.rs
+++ b/crates/mentedb-query/src/parser.rs
@@ -9,6 +9,29 @@ use crate::ast::*;
 use crate::lexer::{Token, TokenKind};
 use mentedb_core::types::MemoryId;
 
+/// If `cond` is a pure AND of leaf filters (a single leaf, or ANDs nesting only
+/// leaves and further ANDs), return those leaves flattened. Otherwise return
+/// `None`: the tree has an OR or NOT and must be evaluated as a tree. This keeps
+/// the common `a AND b AND c` clause on the flat-filter fast path.
+fn flatten_pure_and(cond: &Condition) -> Option<Vec<Filter>> {
+    fn collect(c: &Condition, out: &mut Vec<Filter>) -> bool {
+        match c {
+            Condition::Leaf(f) => {
+                out.push(f.clone());
+                true
+            }
+            Condition::And(children) => children.iter().all(|ch| collect(ch, out)),
+            _ => false,
+        }
+    }
+    let mut out = Vec::new();
+    if collect(cond, &mut out) {
+        Some(out)
+    } else {
+        None
+    }
+}
+
 pub struct Parser<'a> {
     tokens: &'a [Token],
     pos: usize,
@@ -76,6 +99,7 @@ impl<'a> Parser<'a> {
 
         let mut near = None;
         let mut filters = Vec::new();
+        let mut condition: Option<Condition> = None;
         let mut limit = None;
         let mut order_by = None;
 
@@ -85,10 +109,16 @@ impl<'a> Parser<'a> {
             near = Some(self.parse_vector()?);
         }
 
-        // WHERE clause
+        // WHERE clause. Parse the full boolean expression, then keep the common
+        // pure-AND case as a flat filter list (so the planner's index selection is
+        // unchanged); only fall back to the tree when OR, NOT, or grouping appears.
         if self.at(TokenKind::Where) {
             self.advance();
-            filters = self.parse_filters()?;
+            let cond = self.parse_condition()?;
+            match flatten_pure_and(&cond) {
+                Some(leaves) => filters = leaves,
+                None => condition = Some(cond),
+            }
         }
 
         // ORDER BY field
@@ -123,15 +153,24 @@ impl<'a> Parser<'a> {
             let t: i64 = tok.lexeme.parse().map_err(|_| {
                 MenteError::Query(format!("invalid AS OF timestamp: {}", tok.lexeme))
             })?;
-            filters.push(Filter {
+            let valid_at = Filter {
                 field: Field::ValidAt,
                 op: Operator::Eq,
                 value: Value::Integer(t),
-            });
+            };
+            // AS OF must AND with whatever WHERE produced. In the tree case, wrap
+            // it in; otherwise it is just another top-level AND leaf.
+            match condition.take() {
+                Some(c) => {
+                    condition = Some(Condition::And(vec![c, Condition::Leaf(valid_at)]));
+                }
+                None => filters.push(valid_at),
+            }
         }
 
         Ok(Statement::Recall(RecallStatement {
             filters,
+            condition,
             near,
             limit,
             order_by,
@@ -220,6 +259,60 @@ impl<'a> Parser<'a> {
             filters.push(self.parse_filter()?);
         }
         Ok(filters)
+    }
+
+    /// Parse a boolean WHERE expression with standard precedence:
+    /// OR binds loosest, then AND, then NOT, then a parenthesized group or a leaf
+    /// comparison. `a AND b OR c` parses as `(a AND b) OR c`.
+    fn parse_condition(&mut self) -> MenteResult<Condition> {
+        let mut node = self.parse_and_condition()?;
+        while self.at(TokenKind::Or) {
+            self.advance();
+            let rhs = self.parse_and_condition()?;
+            node = match node {
+                Condition::Or(mut v) => {
+                    v.push(rhs);
+                    Condition::Or(v)
+                }
+                other => Condition::Or(vec![other, rhs]),
+            };
+        }
+        Ok(node)
+    }
+
+    fn parse_and_condition(&mut self) -> MenteResult<Condition> {
+        let mut node = self.parse_not_condition()?;
+        while self.at(TokenKind::And) {
+            self.advance();
+            let rhs = self.parse_not_condition()?;
+            node = match node {
+                Condition::And(mut v) => {
+                    v.push(rhs);
+                    Condition::And(v)
+                }
+                other => Condition::And(vec![other, rhs]),
+            };
+        }
+        Ok(node)
+    }
+
+    fn parse_not_condition(&mut self) -> MenteResult<Condition> {
+        if self.at(TokenKind::Not) {
+            self.advance();
+            let inner = self.parse_not_condition()?;
+            return Ok(Condition::Not(Box::new(inner)));
+        }
+        self.parse_primary_condition()
+    }
+
+    fn parse_primary_condition(&mut self) -> MenteResult<Condition> {
+        if self.at(TokenKind::LParen) {
+            self.advance();
+            let inner = self.parse_condition()?;
+            self.expect(TokenKind::RParen)?;
+            return Ok(inner);
+        }
+        Ok(Condition::Leaf(self.parse_filter()?))
     }
 
     fn parse_filter(&mut self) -> MenteResult<Filter> {
@@ -472,6 +565,55 @@ mod tests {
                 assert_eq!(r.filters[0].value, Value::MemoryType(MemoryType::Episodic));
                 assert_eq!(r.limit, Some(5));
             }
+            _ => panic!("expected Recall"),
+        }
+    }
+
+    #[test]
+    fn test_pure_and_stays_on_flat_fast_path() {
+        // A pure AND clause must flatten to `filters` with `condition == None`, so
+        // the planner keeps its leaf-based index optimizations.
+        let tokens = tokenize("RECALL WHERE type = semantic AND tag = \"x\" LIMIT 5").unwrap();
+        match Parser::parse(&tokens).unwrap() {
+            Statement::Recall(r) => {
+                assert_eq!(r.filters.len(), 2, "both leaves flattened");
+                assert!(r.condition.is_none(), "pure AND must not build a tree");
+            }
+            _ => panic!("expected Recall"),
+        }
+    }
+
+    #[test]
+    fn test_or_builds_condition_tree() {
+        let tokens = tokenize("RECALL WHERE type = semantic OR type = procedural LIMIT 5").unwrap();
+        match Parser::parse(&tokens).unwrap() {
+            Statement::Recall(r) => {
+                assert!(r.filters.is_empty(), "OR clause is carried by the tree");
+                match r.condition {
+                    Some(Condition::Or(branches)) => assert_eq!(branches.len(), 2),
+                    other => panic!("expected Or condition, got {other:?}"),
+                }
+            }
+            _ => panic!("expected Recall"),
+        }
+    }
+
+    #[test]
+    fn test_grouping_and_not_precedence() {
+        // (a OR b) AND NOT c  =>  And[ Or[a, b], Not(c) ]
+        let tokens = tokenize(
+            "RECALL WHERE (type = semantic OR type = procedural) AND NOT tag = \"x\" LIMIT 5",
+        )
+        .unwrap();
+        match Parser::parse(&tokens).unwrap() {
+            Statement::Recall(r) => match r.condition {
+                Some(Condition::And(parts)) => {
+                    assert_eq!(parts.len(), 2);
+                    assert!(matches!(parts[0], Condition::Or(_)), "left is the OR group");
+                    assert!(matches!(parts[1], Condition::Not(_)), "right is the NOT");
+                }
+                other => panic!("expected And condition, got {other:?}"),
+            },
             _ => panic!("expected Recall"),
         }
     }

--- a/crates/mentedb-query/src/planner.rs
+++ b/crates/mentedb-query/src/planner.rs
@@ -13,11 +13,19 @@ pub enum QueryPlan {
         query: Vec<f32>,
         k: usize,
         filters: Vec<Filter>,
+        /// Full boolean WHERE tree, when the clause used OR/NOT/grouping. When set,
+        /// the executor post-filters candidates by this instead of `filters`.
+        #[serde(default)]
+        condition: Option<Condition>,
     },
     TagScan {
         tags: Vec<String>,
         filters: Vec<Filter>,
         limit: Option<usize>,
+        /// Full boolean WHERE tree, when the clause used OR/NOT/grouping. When set,
+        /// the executor post-filters candidates by this instead of `filters`.
+        #[serde(default)]
+        condition: Option<Condition>,
     },
     TemporalScan {
         start: Timestamp,
@@ -70,6 +78,19 @@ fn plan_recall(recall: &RecallStatement) -> MenteResult<QueryPlan> {
             query: vec.clone(),
             k: limit,
             filters: recall.filters.clone(),
+            condition: recall.condition.clone(),
+        });
+    }
+
+    // OR/NOT/grouped WHERE: none of the leaf-based index optimizations below are
+    // safe (they assume every filter must hold), so full-scan and let the executor
+    // evaluate the boolean tree. Correct, if less selective, for these rarer queries.
+    if recall.condition.is_some() {
+        return Ok(QueryPlan::TagScan {
+            tags: Vec::new(),
+            filters: Vec::new(),
+            limit: Some(limit),
+            condition: recall.condition.clone(),
         });
     }
 
@@ -83,6 +104,7 @@ fn plan_recall(recall: &RecallStatement) -> MenteResult<QueryPlan> {
                 query: Vec::new(), // placeholder — executor embeds the SimilarTo text
                 k: limit,
                 filters: recall.filters.clone(),
+                condition: None,
             });
         }
         // SimilarTo with non-text value doesn't make sense
@@ -109,6 +131,7 @@ fn plan_recall(recall: &RecallStatement) -> MenteResult<QueryPlan> {
             tags,
             filters: Vec::new(),
             limit: Some(limit),
+            condition: None,
         });
     }
 
@@ -169,6 +192,7 @@ fn plan_recall(recall: &RecallStatement) -> MenteResult<QueryPlan> {
         tags: Vec::new(),
         filters: recall.filters.clone(),
         limit: Some(limit),
+        condition: None,
     })
 }
 

--- a/crates/mentedb-query/tests/integration.rs
+++ b/crates/mentedb-query/tests/integration.rs
@@ -49,7 +49,9 @@ fn test_recall_near_vector() {
     )
     .unwrap();
     match plan {
-        QueryPlan::VectorSearch { query, k, filters } => {
+        QueryPlan::VectorSearch {
+            query, k, filters, ..
+        } => {
             assert_eq!(query, vec![0.1, 0.2, 0.3]);
             assert_eq!(k, 10);
             assert_eq!(filters.len(), 1);

--- a/crates/mentedb/src/lib.rs
+++ b/crates/mentedb/src/lib.rs
@@ -68,7 +68,7 @@ use mentedb_core::{MemoryEdge, MemoryNode, MenteError};
 use mentedb_embedding::provider::EmbeddingProvider;
 use mentedb_graph::GraphManager;
 use mentedb_index::IndexManager;
-use mentedb_query::{Field, Filter, Mql, Operator, QueryPlan, Value};
+use mentedb_query::{Condition, Field, Filter, Mql, Operator, QueryPlan, Value};
 use mentedb_storage::StorageEngine;
 use parking_lot::RwLock;
 use tracing::{debug, info, warn};
@@ -1753,7 +1753,12 @@ impl MenteDb {
     /// Executes a query plan against the indexes and graph, returning scored memories.
     fn execute_plan(&self, plan: &QueryPlan) -> MenteResult<Vec<ScoredMemory>> {
         match plan {
-            QueryPlan::VectorSearch { query, k, filters } => {
+            QueryPlan::VectorSearch {
+                query,
+                k,
+                filters,
+                condition,
+            } => {
                 // `content ~> "text"` arrives with an empty vector and the
                 // SimilarTo filter left in place for us to embed now (no embedder
                 // at plan time). NEAR arrives with the vector already filled in.
@@ -1781,19 +1786,29 @@ impl MenteDb {
                 };
                 let hits = self.index.hybrid_search(qvec, None, None, *k);
                 let mut scored = self.load_scored_memories(&hits)?;
-                // The SimilarTo filter is the query itself; apply any others.
-                scored.retain(|sm| {
-                    filters
-                        .iter()
-                        .filter(|f| f.op != Operator::SimilarTo)
-                        .all(|f| Self::filter_matches(f, &sm.memory))
-                });
+                // The SimilarTo filter is the query itself; apply any others. A
+                // boolean tree (NEAR combined with OR/NOT) takes over the whole
+                // post-filter when present.
+                match condition {
+                    Some(cond) => {
+                        scored.retain(|sm| Self::condition_matches(cond, &sm.memory));
+                    }
+                    None => {
+                        scored.retain(|sm| {
+                            filters
+                                .iter()
+                                .filter(|f| f.op != Operator::SimilarTo)
+                                .all(|f| Self::filter_matches(f, &sm.memory))
+                        });
+                    }
+                }
                 Ok(scored)
             }
             QueryPlan::TagScan {
                 tags,
                 filters,
                 limit,
+                condition,
             } => {
                 let k = limit.unwrap_or(20);
                 let mut scored = if tags.is_empty() {
@@ -1811,8 +1826,18 @@ impl MenteDb {
                     let hits = self.index.hybrid_search(&[], Some(&tag_refs), None, k);
                     self.load_scored_memories(&hits)?
                 };
-                // Apply the metadata filters the planner attached (type, etc.).
-                scored.retain(|sm| filters.iter().all(|f| Self::filter_matches(f, &sm.memory)));
+                // Apply the WHERE clause: a boolean tree when present (OR/NOT/
+                // grouping), otherwise the flat AND of metadata filters.
+                match condition {
+                    Some(cond) => {
+                        scored.retain(|sm| Self::condition_matches(cond, &sm.memory));
+                    }
+                    None => {
+                        scored.retain(|sm| {
+                            filters.iter().all(|f| Self::filter_matches(f, &sm.memory))
+                        });
+                    }
+                }
                 scored.truncate(k);
                 Ok(scored)
             }
@@ -1852,6 +1877,18 @@ impl MenteDb {
                 }])
             }
             _ => Ok(vec![]),
+        }
+    }
+
+    /// Whether a memory satisfies a boolean WHERE tree (OR/NOT/grouping). Leaves
+    /// defer to `filter_matches`, so a leaf that `filter_matches` treats as
+    /// permissive stays permissive; `And`/`Or`/`Not` compose those results.
+    fn condition_matches(c: &Condition, node: &MemoryNode) -> bool {
+        match c {
+            Condition::Leaf(f) => Self::filter_matches(f, node),
+            Condition::And(children) => children.iter().all(|ch| Self::condition_matches(ch, node)),
+            Condition::Or(children) => children.iter().any(|ch| Self::condition_matches(ch, node)),
+            Condition::Not(inner) => !Self::condition_matches(inner, node),
         }
     }
 
@@ -3292,6 +3329,135 @@ mod mql_execution_tests {
                 .all(|sm| sm.memory.memory_type == MemoryType::Semantic),
             "only semantic memories should come back"
         );
+    }
+
+    /// Build a small fixture: three types, two of them tagged "keep", so boolean
+    /// WHERE clauses have something to include and exclude.
+    fn boolean_fixture() -> (tempfile::TempDir, MenteDb) {
+        let dir = tempfile::tempdir().unwrap();
+        let db = MenteDb::open(dir.path()).unwrap();
+        let mut sem_keep = MemoryNode::new(
+            AgentId::nil(),
+            MemoryType::Semantic,
+            "semantic kept".into(),
+            vec![0.1_f32; 8],
+        );
+        sem_keep.tags = vec!["keep".into()];
+        let sem_plain = MemoryNode::new(
+            AgentId::nil(),
+            MemoryType::Semantic,
+            "semantic plain".into(),
+            vec![0.2_f32; 8],
+        );
+        let mut proc_keep = MemoryNode::new(
+            AgentId::nil(),
+            MemoryType::Procedural,
+            "procedural kept".into(),
+            vec![0.3_f32; 8],
+        );
+        proc_keep.tags = vec!["keep".into()];
+        let anti = MemoryNode::new(
+            AgentId::nil(),
+            MemoryType::AntiPattern,
+            "antipattern plain".into(),
+            vec![0.4_f32; 8],
+        );
+        for n in [sem_keep, sem_plain, proc_keep, anti] {
+            db.store(n).unwrap();
+        }
+        (dir, db)
+    }
+
+    fn contents(db: &MenteDb, mql: &str) -> Vec<String> {
+        let mut v: Vec<String> = db
+            .query(mql)
+            .unwrap()
+            .into_iter()
+            .map(|s| s.memory.content)
+            .collect();
+        v.sort();
+        v
+    }
+
+    /// OR must union the branches: `type = semantic OR type = procedural` returns
+    /// exactly the semantic and procedural rows, never the antipattern.
+    #[test]
+    fn or_unions_branches() {
+        let (_d, db) = boolean_fixture();
+        let got = contents(
+            &db,
+            "RECALL WHERE type = semantic OR type = procedural LIMIT 50",
+        );
+        assert_eq!(
+            got,
+            vec![
+                "procedural kept".to_string(),
+                "semantic kept".to_string(),
+                "semantic plain".to_string()
+            ],
+            "OR should return semantic and procedural, excluding antipattern"
+        );
+    }
+
+    /// NOT must exclude: `NOT type = semantic` returns everything that is not
+    /// semantic.
+    #[test]
+    fn not_excludes() {
+        let (_d, db) = boolean_fixture();
+        let got = contents(&db, "RECALL WHERE NOT type = semantic LIMIT 50");
+        assert_eq!(
+            got,
+            vec![
+                "antipattern plain".to_string(),
+                "procedural kept".to_string()
+            ],
+            "NOT type = semantic should drop both semantic rows"
+        );
+    }
+
+    /// AND with NOT: `type = semantic AND NOT tag = keep` isolates the untagged
+    /// semantic row, proving NOT composes under AND.
+    #[test]
+    fn and_not_composes() {
+        let (_d, db) = boolean_fixture();
+        let got = contents(
+            &db,
+            r#"RECALL WHERE type = semantic AND NOT tag = "keep" LIMIT 50"#,
+        );
+        assert_eq!(
+            got,
+            vec!["semantic plain".to_string()],
+            "only the untagged semantic row should remain"
+        );
+    }
+
+    /// Grouping changes meaning: `(type = semantic OR type = procedural) AND tag =
+    /// keep` must return only the kept rows of those two types, not the plain
+    /// semantic one. This is the precedence case a flat AND list cannot express.
+    #[test]
+    fn grouping_binds_before_and() {
+        let (_d, db) = boolean_fixture();
+        let got = contents(
+            &db,
+            r#"RECALL WHERE (type = semantic OR type = procedural) AND tag = "keep" LIMIT 50"#,
+        );
+        assert_eq!(
+            got,
+            vec!["procedural kept".to_string(), "semantic kept".to_string()],
+            "grouping must apply the tag filter to both OR branches"
+        );
+    }
+
+    /// Regression: a pure AND clause still returns the intersection (and stays on
+    /// the flat-filter fast path, which this exercises end to end).
+    #[test]
+    fn pure_and_still_intersects() {
+        let (_d, db) = boolean_fixture();
+        let got = contents(
+            &db,
+            r#"RECALL WHERE type = semantic AND tag = "keep" LIMIT 50"#,
+        );
+        assert_eq!(got, vec!["semantic kept".to_string()]);
     }
 }
 


### PR DESCRIPTION
## Summary
- MQL WHERE clauses now support `OR`, `NOT`, and parenthesized grouping, e.g. `(type = semantic OR type = procedural) AND NOT tag = "x"`.
- A pure AND of leaves stays on the flat-filter fast path (`condition == None`), so the planner keeps all its index optimizations. OR/NOT/grouping build a boolean tree that the planner full-scans and the executor evaluates in `condition_matches`, guaranteeing correct results.

## Changes
- `ast`: `Condition` tree (And/Or/Not/Leaf) + `RecallStatement.condition`.
- `parser`: precedence parsing (OR < AND < NOT < primary/grouping); pure-AND flattens to `filters`.
- `planner`: `condition` threaded onto TagScan/VectorSearch; OR/NOT routes to a full scan.
- `executor`: `condition_matches` recursion; both post-filter arms honor the tree.

## Verification
- New parser tests (tree shape, precedence, fast-path preservation) and executor tests (union, exclusion, AND+NOT, grouping precedence, pure-AND regression).
- `cargo test --workspace`, `cargo clippy --workspace -- -D warnings`, `cargo fmt --check` all clean.