### PR TITLE
fix(engine): scope standing-rule dedup to the same owner

### DIFF
--- a/crates/mentedb/src/lib.rs
+++ b/crates/mentedb/src/lib.rs
@@ -650,6 +650,12 @@ impl MenteDb {
             let Ok(existing) = self.get_memory(id) else {
                 continue;
             };
+            // Dedup only within the same owner: another user or agent pinning the
+            // same rule is a separate standing rule, and collapsing across owners
+            // would break isolation.
+            if existing.user_id != node.user_id || existing.agent_id != node.agent_id {
+                continue;
+            }
             if existing.content.trim() == node.content.trim() {
                 return true;
             }


### PR DESCRIPTION
## Problem
The standing-rule dedup shipped in #302 compared a new `scope:always` write against **every** standing rule regardless of owner, so two different agents (or users) pinning the same rule collapsed into one — breaking agent/user isolation. This was caught by `injection_respects_agent_scope` after #302 was admin-merged, leaving main's test job red.

## Fix
Dedup only within the same `(user_id, agent_id)`: another owner pinning the same rule is a separate standing rule.

## Verification
- `injection_respects_agent_scope` passes; standing-rule policy tests still pass; full `cargo test --workspace` green locally.