### PR TITLE
feat(metrics): write/read/cache/storage/index/graph metrics

### DIFF
--- a/crates/mentedb-server/src/metrics.rs
+++ b/crates/mentedb-server/src/metrics.rs
@@ -31,6 +31,19 @@ pub struct Metrics {
     live_nodes: IntGauge,
     http_requests: IntCounterVec,
     http_duration: HistogramVec,
+    // Engine metrics, refreshed from `db.metrics()` on each scrape. Cumulative
+    // totals are exposed as gauges set to the running total (rate() still works).
+    stores: IntGauge,
+    recalls: IntGauge,
+    bp_hits: IntGauge,
+    bp_misses: IntGauge,
+    bp_evictions: IntGauge,
+    bp_pages: IntGauge,
+    storage_bytes: IntGauge,
+    pages: IntGauge,
+    vector_index_size: IntGauge,
+    graph_nodes: IntGauge,
+    standing_rules: IntGauge,
 }
 
 static METRICS: OnceLock<Metrics> = OnceLock::new();
@@ -81,6 +94,30 @@ impl Metrics {
         )
         .unwrap();
 
+        // Engine gauges: create, register, and return in one step.
+        let gauge = |name: &str, help: &str| {
+            let g = IntGauge::new(name, help).unwrap();
+            registry.register(Box::new(g.clone())).ok();
+            g
+        };
+        let stores = gauge("mentedb_stores_total", "Memories written (writes)");
+        let recalls = gauge("mentedb_recalls_total", "Recall/query operations (reads)");
+        let bp_hits = gauge("mentedb_buffer_pool_hits_total", "Page cache hits");
+        let bp_misses = gauge("mentedb_buffer_pool_misses_total", "Page cache misses");
+        let bp_evictions = gauge(
+            "mentedb_buffer_pool_evictions_total",
+            "Page cache evictions",
+        );
+        let bp_pages = gauge("mentedb_buffer_pool_pages", "Frames holding a page");
+        let storage_bytes = gauge("mentedb_storage_bytes", "On-disk data size in bytes");
+        let pages = gauge("mentedb_pages_total", "Pages in the store");
+        let vector_index_size = gauge("mentedb_vector_index_size", "Vectors in the HNSW index");
+        let graph_nodes = gauge("mentedb_graph_nodes", "Nodes in the memory graph");
+        let standing_rules = gauge(
+            "mentedb_standing_rules",
+            "Pinned standing rules (scope:always)",
+        );
+
         for g in [&uptime, &memory_count, &live_nodes] {
             registry.register(Box::new(g.clone())).ok();
         }
@@ -94,6 +131,17 @@ impl Metrics {
             live_nodes,
             http_requests,
             http_duration,
+            stores,
+            recalls,
+            bp_hits,
+            bp_misses,
+            bp_evictions,
+            bp_pages,
+            storage_bytes,
+            pages,
+            vector_index_size,
+            graph_nodes,
+            standing_rules,
         }
     }
 }
@@ -116,7 +164,19 @@ pub async fn track(req: Request, next: Next) -> Response {
 pub async fn handler(State(state): State<Arc<AppState>>) -> impl IntoResponse {
     let m = metrics();
     m.uptime.set(state.start_time.elapsed().as_secs() as i64);
-    m.memory_count.set(state.db.memory_count() as i64);
+    let dm = state.db.metrics();
+    m.memory_count.set(dm.memory_count as i64);
+    m.stores.set(dm.stores as i64);
+    m.recalls.set(dm.recalls as i64);
+    m.bp_hits.set(dm.buffer_pool_hits as i64);
+    m.bp_misses.set(dm.buffer_pool_misses as i64);
+    m.bp_evictions.set(dm.buffer_pool_evictions as i64);
+    m.bp_pages.set(dm.buffer_pool_pages as i64);
+    m.storage_bytes.set(dm.storage_bytes as i64);
+    m.pages.set(dm.page_count as i64);
+    m.vector_index_size.set(dm.vector_index_size as i64);
+    m.graph_nodes.set(dm.graph_nodes as i64);
+    m.standing_rules.set(dm.standing_rules as i64);
     let live = match &state.cluster {
         Some(c) => c.live_node_count().await as i64,
         None => 1,

--- a/crates/mentedb-storage/src/buffer.rs
+++ b/crates/mentedb-storage/src/buffer.rs
@@ -4,6 +4,8 @@
 //! prevent eviction of pages currently in use. The CLOCK algorithm sweeps
 //! frames looking for an unpinned, unreferenced victim when the pool is full.
 
+use std::sync::atomic::{AtomicU64, Ordering};
+
 use ahash::AHashMap;
 use parking_lot::Mutex;
 
@@ -12,6 +14,17 @@ use mentedb_core::error::{MenteError, MenteResult};
 use tracing::{debug, trace};
 
 type FrameId = usize;
+
+/// A snapshot of buffer-pool cache activity, for metrics. `hits / (hits + misses)`
+/// is the page cache hit ratio, the primary read-performance signal.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct BufferStats {
+    pub hits: u64,
+    pub misses: u64,
+    pub evictions: u64,
+    /// Frames currently holding a page.
+    pub resident_pages: u64,
+}
 
 /// A single frame in the buffer pool.
 struct Frame {
@@ -45,6 +58,9 @@ struct BufferPoolInner {
 /// Thread-safe buffer pool with CLOCK eviction.
 pub struct BufferPool {
     inner: Mutex<BufferPoolInner>,
+    hits: AtomicU64,
+    misses: AtomicU64,
+    evictions: AtomicU64,
 }
 
 impl BufferPool {
@@ -64,6 +80,20 @@ impl BufferPool {
                 clock_hand: 0,
                 capacity,
             }),
+            hits: AtomicU64::new(0),
+            misses: AtomicU64::new(0),
+            evictions: AtomicU64::new(0),
+        }
+    }
+
+    /// Cache-activity counters for metrics. Lock-free reads.
+    pub fn stats(&self) -> BufferStats {
+        let resident_pages = self.inner.lock().page_table.len() as u64;
+        BufferStats {
+            hits: self.hits.load(Ordering::Relaxed),
+            misses: self.misses.load(Ordering::Relaxed),
+            evictions: self.evictions.load(Ordering::Relaxed),
+            resident_pages,
         }
     }
 
@@ -79,11 +109,13 @@ impl BufferPool {
             let frame = &mut inner.frames[frame_id];
             frame.pin_count += 1;
             frame.reference = true;
+            self.hits.fetch_add(1, Ordering::Relaxed);
             trace!(page_id = page_id.0, frame_id, "buffer pool hit");
             return Ok(frame.page.clone());
         }
 
         // Cache miss — find a victim frame.
+        self.misses.fetch_add(1, Ordering::Relaxed);
         let frame_id = Self::find_victim(&mut inner)?;
 
         // Flush dirty victim if needed.
@@ -94,9 +126,11 @@ impl BufferPool {
             debug!(page_id = old_pid.0, frame_id, "flushed dirty victim");
         }
 
-        // Remove old mapping.
+        // Remove old mapping. A displaced page is a real eviction (the reuse and
+        // grow paths in find_victim leave page_id None, so they are not counted).
         if let Some(old_pid) = inner.frames[frame_id].page_id {
             inner.page_table.remove(&old_pid);
+            self.evictions.fetch_add(1, Ordering::Relaxed);
         }
 
         // Load the requested page from disk.

--- a/crates/mentedb-storage/src/engine.rs
+++ b/crates/mentedb-storage/src/engine.rs
@@ -259,6 +259,16 @@ impl StorageEngine {
             .fetch_page(page_id, &mut self.page_manager.lock())
     }
 
+    /// Buffer-pool cache activity, for metrics (hit ratio, evictions, residency).
+    pub fn buffer_stats(&self) -> crate::buffer::BufferStats {
+        self.buffer_pool.stats()
+    }
+
+    /// Total pages in the store; multiply by `PAGE_SIZE` for on-disk bytes.
+    pub fn page_count(&self) -> u64 {
+        self.page_manager.lock().page_count()
+    }
+
     /// Write data into an already-allocated page with WAL protection.
     ///
     /// Acquires the WAL flock for the duration of the write transaction.

--- a/crates/mentedb-storage/src/lib.rs
+++ b/crates/mentedb-storage/src/lib.rs
@@ -51,7 +51,7 @@ pub mod page;
 pub mod wal;
 
 // Re-export key types at crate root for convenience.
-pub use buffer::BufferPool;
+pub use buffer::{BufferPool, BufferStats};
 pub use engine::StorageEngine;
 pub use page::{PAGE_DATA_SIZE, PAGE_SIZE, Page, PageHeader, PageId, PageType};
 pub use wal::{Lsn, Wal, WalEntry, WalEntryType};

--- a/crates/mentedb/src/lib.rs
+++ b/crates/mentedb/src/lib.rs
@@ -222,6 +222,37 @@ pub struct PruneReport {
     pub capped: usize,
 }
 
+/// A point-in-time snapshot of engine metrics for a `/metrics` exporter. Cheap to
+/// take: counters are atomic loads and sizes are O(1) index/graph/page lookups, so
+/// a scrape does not scan the corpus.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct DbMetrics {
+    /// Memories stored on this node.
+    pub memory_count: u64,
+    /// Lifetime store operations (writes).
+    pub stores: u64,
+    /// Lifetime recall/query operations (reads).
+    pub recalls: u64,
+    /// Buffer-pool page cache hits.
+    pub buffer_pool_hits: u64,
+    /// Buffer-pool page cache misses (disk reads).
+    pub buffer_pool_misses: u64,
+    /// Buffer-pool CLOCK evictions.
+    pub buffer_pool_evictions: u64,
+    /// Frames currently holding a page.
+    pub buffer_pool_pages: u64,
+    /// On-disk data size in bytes (page_count * page size).
+    pub storage_bytes: u64,
+    /// Pages in the store.
+    pub page_count: u64,
+    /// Vectors in the HNSW index.
+    pub vector_index_size: u64,
+    /// Nodes in the memory graph.
+    pub graph_nodes: u64,
+    /// Pinned standing rules (scope:always).
+    pub standing_rules: u64,
+}
+
 /// A confirmed entity resolution from an external resolver (LLM).
 ///
 /// Used to feed LLM entity resolution results back into the engine
@@ -357,6 +388,10 @@ pub struct MenteDb {
     page_map: RwLock<HashMap<MemoryId, PageId>>,
     /// Hot flushes since the last snapshot write; see flush_snapshot_interval.
     flushes_since_snapshot: std::sync::atomic::AtomicU32,
+    /// Lifetime count of store operations (metrics).
+    stores: std::sync::atomic::AtomicU64,
+    /// Lifetime count of recall/query operations (metrics).
+    recalls: std::sync::atomic::AtomicU64,
     /// Expected embedding dimension (0 = no validation).
     embedding_dim: usize,
     /// Database directory path for persistence.
@@ -527,6 +562,8 @@ impl MenteDb {
             graph,
             page_map: RwLock::new(page_map),
             flushes_since_snapshot: std::sync::atomic::AtomicU32::new(0),
+            stores: std::sync::atomic::AtomicU64::new(0),
+            recalls: std::sync::atomic::AtomicU64::new(0),
             embedding_dim: 0,
             path: path.to_path_buf(),
             embedder: None,
@@ -627,6 +664,8 @@ impl MenteDb {
         self.page_map.write().insert(id, page_id);
         self.index.index_memory(&node);
         self.graph.add_memory(id);
+        self.stores
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
 
         // Run write inference to auto-create edges and detect contradictions.
         if self.cognitive_config.write_inference {
@@ -717,6 +756,8 @@ impl MenteDb {
             ids.push(node.id);
         }
         drop(page_map);
+        self.stores
+            .fetch_add(ids.len() as u64, std::sync::atomic::Ordering::Relaxed);
 
         // Batch inserts get the same auto-linking, contradiction detection,
         // and invalidation as single stores.
@@ -736,6 +777,8 @@ impl MenteDb {
     /// token-budget-aware context window.
     pub fn recall(&self, query: &str) -> MenteResult<ContextWindow> {
         debug!("Recalling with query: {}", query);
+        self.recalls
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         let plan = Mql::parse(query)?;
 
         let scored = self.execute_plan(&plan)?;
@@ -749,6 +792,8 @@ impl MenteDb {
     /// additionally packs the results into a token-budgeted context), and it powers
     /// the `mentedb` CLI and the admin query endpoint.
     pub fn query(&self, mql: &str) -> MenteResult<Vec<ScoredMemory>> {
+        self.recalls
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         let plan = Mql::parse(mql)?;
         self.execute_plan(&plan)
     }
@@ -1081,6 +1126,28 @@ impl MenteDb {
     /// Returns the number of memories currently stored.
     pub fn memory_count(&self) -> usize {
         self.page_map.read().len()
+    }
+
+    /// Snapshot the engine's operational metrics (writes, reads, cache, storage,
+    /// index, graph, standing rules) for a `/metrics` exporter. O(1), no scan.
+    pub fn metrics(&self) -> DbMetrics {
+        use std::sync::atomic::Ordering::Relaxed;
+        let bp = self.storage.buffer_stats();
+        let page_count = self.storage.page_count();
+        DbMetrics {
+            memory_count: self.memory_count() as u64,
+            stores: self.stores.load(Relaxed),
+            recalls: self.recalls.load(Relaxed),
+            buffer_pool_hits: bp.hits,
+            buffer_pool_misses: bp.misses,
+            buffer_pool_evictions: bp.evictions,
+            buffer_pool_pages: bp.resident_pages,
+            storage_bytes: page_count * mentedb_storage::PAGE_SIZE as u64,
+            page_count,
+            vector_index_size: self.index.hnsw.len() as u64,
+            graph_nodes: self.graph.graph().node_count() as u64,
+            standing_rules: self.index.bitmap.query_tag("scope:always").len() as u64,
+        }
     }
 
     /// A bounded, paginated page of stored memories for admin browsing, ordered by
@@ -3634,6 +3701,44 @@ mod mql_execution_tests {
             r#"RECALL WHERE type = semantic AND tag = "keep" LIMIT 50"#,
         );
         assert_eq!(got, vec!["semantic kept".to_string()]);
+    }
+}
+
+#[cfg(test)]
+mod metrics_snapshot_tests {
+    use super::*;
+
+    /// The metrics snapshot counts writes and reads, sizes the store and index,
+    /// and reflects buffer-pool activity.
+    #[test]
+    fn metrics_track_writes_reads_and_cache() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = MenteDb::open(dir.path()).unwrap();
+        for i in 0..3 {
+            db.store(MemoryNode::new(
+                AgentId::nil(),
+                MemoryType::Semantic,
+                format!("fact {i}"),
+                vec![0.1_f32 + i as f32 * 0.1; 8],
+            ))
+            .unwrap();
+        }
+        // Read paths: recall (assembles a window) and query (raw).
+        let _ = db.recall("RECALL memories LIMIT 10").unwrap();
+        let _ = db.query("RECALL LIMIT 10").unwrap();
+
+        let m = db.metrics();
+        assert_eq!(m.stores, 3, "three writes counted");
+        assert_eq!(m.recalls, 2, "recall + query counted as reads");
+        assert_eq!(m.memory_count, 3);
+        assert_eq!(m.vector_index_size, 3, "three vectors indexed");
+        assert_eq!(m.graph_nodes, 3, "three graph nodes");
+        assert!(m.storage_bytes > 0, "pages written to disk");
+        assert!(
+            m.buffer_pool_hits + m.buffer_pool_misses > 0,
+            "reads exercised the buffer pool"
+        );
+        assert_eq!(m.standing_rules, 0, "no pins yet");
     }
 }
 


### PR DESCRIPTION
## Summary
`/metrics` reported only memory count + HTTP stats. This instruments the engine and exports the signals a memory DB needs.

## New metrics (all on /metrics)
- **Writes/Reads**: `mentedb_stores_total`, `mentedb_recalls_total` (facade store/recall paths).
- **Cache**: `mentedb_buffer_pool_hits_total` / `misses_total` / `evictions_total` / `pages` — the page cache hit ratio.
- **Storage**: `mentedb_storage_bytes`, `mentedb_pages_total`.
- **Index/Graph**: `mentedb_vector_index_size`, `mentedb_graph_nodes`.
- **Cognition**: `mentedb_standing_rules`.

## Design
- `MenteDb::metrics() -> DbMetrics` snapshots everything in O(1) (atomic counters + index/graph/page lookups, no corpus scan).
- Buffer pool gains lock-free hit/miss/eviction counters + a `stats()` accessor.
- `mentedb-server` /metrics refreshes gauges from the snapshot each scrape. Aggregate only, no per-account labels.

## Verification
- Facade test asserts stores/recalls/index/graph/cache counts; live /metrics scrape shows all series; `cargo test --workspace`, `clippy -D warnings`, `fmt` clean.