### PR TITLE
fix(docker): serve on the default 6677 port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,8 @@ COPY --from=builder /build/target/release/mentedb-server /usr/local/bin/mentedb-
 
 RUN mkdir -p /var/mentedb/data
 
-EXPOSE 8080
+# 6677 = REST API, /metrics, and /console; 6678 = gRPC (both start by default).
+# This is the default port the CLI, docs, and the observability compose all assume.
+EXPOSE 6677 6678
 
-CMD ["mentedb-server", "--port", "8080", "--data-dir", "/var/mentedb/data"]
+CMD ["mentedb-server", "--port", "6677", "--data-dir", "/var/mentedb/data"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,9 +2,12 @@ services:
   mentedb:
     build: .
     ports:
-      - "8080:8080"
+      - "6677:6677" # REST API, /metrics, /console
+      - "6678:6678" # gRPC
     volumes:
       - mentedb-data:/var/mentedb/data
+    # Uncomment to enable the console's admin browse/query tabs:
+    # command: ["mentedb-server", "--port", "6677", "--data-dir", "/var/mentedb/data", "--admin-key", "change-me"]
 
 volumes:
   mentedb-data:


### PR DESCRIPTION
## Problem
The Dockerfile and `docker-compose.yml` ran `mentedb-server` on 8080 and only mapped that port, but the server default, the `mentedb` CLI, the docs, and the observability compose all use **6677**. So `curl localhost:6677` from the docs failed against the container.

## Fix
- Serve on 6677 and `EXPOSE 6677 6678` (REST/metrics/console + gRPC, both start by default).
- Map both ports in compose; add a commented `--admin-key` command for the console's browse/query tabs.

The image already builds `mentedb-server` with `local-embeddings` (bundled all-MiniLM-L6-v2) for zero-config semantic search; only the port was wrong. A full image build is running to confirm.