### PR TITLE
fix(index): stop over-counting standing rules after un-pin

### DIFF
--- a/crates/mentedb-index/src/manager.rs
+++ b/crates/mentedb-index/src/manager.rs
@@ -106,7 +106,12 @@ impl IndexManager {
             self.bm25.insert(node.id, &node.content);
         }
 
-        // Tag bitmap index
+        // Tag bitmap index. Clear this id's existing tags first, so a re-index
+        // after an edit (e.g. un-pinning, which removes scope:always and re-stores
+        // the node) reflects the node's CURRENT tags exactly, not the union across
+        // every stored version. Without this, a removed tag lingers in the index
+        // and over-counts on query_tag. Harmless no-op on a first insert.
+        self.bitmap.remove_all(node.id);
         for tag in &node.tags {
             self.bitmap.add_tag(node.id, tag);
         }

--- a/crates/mentedb/src/lib.rs
+++ b/crates/mentedb/src/lib.rs
@@ -1146,8 +1146,25 @@ impl MenteDb {
             page_count,
             vector_index_size: self.index.hnsw.len() as u64,
             graph_nodes: self.graph.graph().node_count() as u64,
-            standing_rules: self.index.bitmap.query_tag("scope:always").len() as u64,
+            standing_rules: self.count_standing_rules() as u64,
         }
+    }
+
+    /// Accurate count of pinned standing rules. The tag index can over-count after
+    /// an un-pin re-indexed on an older engine (the tag was removed from the node
+    /// but lingered in the bitmap), so verify each candidate still carries the tag.
+    /// Cheap: it loads only the (few, capped) candidates, not the whole corpus.
+    fn count_standing_rules(&self) -> usize {
+        self.index
+            .bitmap
+            .query_tag("scope:always")
+            .into_iter()
+            .filter(|id| {
+                self.get_memory(*id)
+                    .map(|n| n.tags.iter().any(|t| t == "scope:always"))
+                    .unwrap_or(false)
+            })
+            .count()
     }
 
     /// A bounded, paginated page of stored memories for admin browsing, ordered by
@@ -3972,6 +3989,35 @@ mod standing_rule_policy_tests {
             .filter_map(|id| db.get_memory(*id).ok())
             .filter(|n| n.tags.iter().any(|t| t == "scope:always"))
             .count()
+    }
+
+    /// Regression: un-pinning a rule (removing scope:always and re-storing) must
+    /// drop the standing-rule count. The tag index used to only add tags, so the
+    /// count stayed stale (the admin dashboard showed 261 when the account had 0).
+    #[test]
+    fn standing_rule_count_drops_after_unpin() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = MenteDb::open(dir.path()).unwrap();
+        let rule = always_rule("always use tabs", vec![0.2_f32; 8], false);
+        let id = rule.id;
+        db.store(rule).unwrap();
+        assert_eq!(db.metrics().standing_rules, 1);
+
+        // Un-pin exactly as the prune does: strip the tag, re-store the same id.
+        let mut m = db.get_memory(id).unwrap();
+        m.tags.retain(|t| t != "scope:always");
+        db.store(m).unwrap();
+
+        assert_eq!(
+            db.metrics().standing_rules,
+            0,
+            "un-pinned rule must not be counted"
+        );
+        assert_eq!(
+            always_count(&db),
+            0,
+            "the node itself no longer carries the tag"
+        );
     }
 
     /// Re-pinning a rule that already exists (same embedding, reworded) does not


### PR DESCRIPTION
## The bug you saw
Admin showed nambok@gmail.com with **261 standing rules** when the account actually has **0 injected**.

## Root cause
`index_memory` only ever *added* a node's tags to the bitmap, never removed them, and `open` loads a snapshot rather than rebuilding. So when the prune un-pins a rule (removes `scope:always` from the node and re-stores it), the node stops being injected (correct) but the tag lingers in the bitmap — `query_tag("scope:always")` keeps counting it. `forget` cleans the bitmap; un-pin didn't.

## Fix
- `index_memory` clears the node's existing tags before re-adding, so a re-index reflects the node's current tags exactly (no-op on first insert). Fixes it going forward and for anything using the tag index (dedup, entity-boost).
- `metrics().standing_rules` verifies each bitmap candidate still carries the tag, so accounts whose stale entries predate this fix (like nambok) read correctly immediately. Cheap — loads only the few candidates, not the whole corpus.

## Verification
- Regression test: un-pinning drops the count to 0. `cargo test --workspace`, `clippy -D warnings`, `fmt` clean.