### PR TITLE
feat(server): export store + search latency metrics + document

### DIFF
--- a/README.md
+++ b/README.md
@@ -654,9 +654,11 @@ the fleet is for when one node's write throughput becomes the ceiling.
 ## Observability
 
 `mentedb-server` exposes Prometheus metrics at `GET /metrics` (no auth, aggregate
-only, no per-account labels): process CPU and memory, uptime, memories stored, live
-cluster nodes, and HTTP request rate and latency. It also serves a bundled console
-at `GET /console` (live health, plus a memory browser gated by `--admin-key`).
+only, no per-account labels): process CPU and memory, uptime, memories stored,
+engine store and search op latency (`mentedb_store_latency_microseconds`,
+`mentedb_search_latency_microseconds`), live cluster nodes, and HTTP request rate
+and latency. It also serves a bundled console at `GET /console` (live health, plus
+a memory browser gated by `--admin-key`).
 
 For a full stack, [`observability/`](observability/) has a one-command Prometheus +
 Grafana setup with the dashboard already provisioned:

--- a/crates/mentedb-server/src/metrics.rs
+++ b/crates/mentedb-server/src/metrics.rs
@@ -44,6 +44,8 @@ pub struct Metrics {
     vector_index_size: IntGauge,
     graph_nodes: IntGauge,
     standing_rules: IntGauge,
+    store_latency_us: IntGauge,
+    search_latency_us: IntGauge,
 }
 
 static METRICS: OnceLock<Metrics> = OnceLock::new();
@@ -117,6 +119,14 @@ impl Metrics {
             "mentedb_standing_rules",
             "Pinned standing rules (scope:always)",
         );
+        let store_latency_us = gauge(
+            "mentedb_store_latency_microseconds",
+            "EMA of store op latency in microseconds",
+        );
+        let search_latency_us = gauge(
+            "mentedb_search_latency_microseconds",
+            "EMA of hybrid-search op latency in microseconds",
+        );
 
         for g in [&uptime, &memory_count, &live_nodes] {
             registry.register(Box::new(g.clone())).ok();
@@ -142,6 +152,8 @@ impl Metrics {
             vector_index_size,
             graph_nodes,
             standing_rules,
+            store_latency_us,
+            search_latency_us,
         }
     }
 }
@@ -177,6 +189,8 @@ pub async fn handler(State(state): State<Arc<AppState>>) -> impl IntoResponse {
     m.vector_index_size.set(dm.vector_index_size as i64);
     m.graph_nodes.set(dm.graph_nodes as i64);
     m.standing_rules.set(dm.standing_rules as i64);
+    m.store_latency_us.set(dm.avg_store_latency_us as i64);
+    m.search_latency_us.set(dm.avg_search_latency_us as i64);
     let live = match &state.cluster {
         Some(c) => c.live_node_count().await as i64,
         None => 1,


### PR DESCRIPTION
Wires the 0.21.0 DbMetrics latency fields (avg_store/search_latency_us) into the Prometheus exporter as `mentedb_store_latency_microseconds` / `mentedb_search_latency_microseconds`, and documents them in the README Observability section. Follow-up to #323 so the metric is scrapable at `GET /metrics`.

Verification: `cargo clippy -p mentedb-server -- -D warnings` clean.