### PR TITLE
feat(recall): project scope weighting and configurable speculative cache

### DIFF
--- a/crates/mentedb/src/enrichment.rs
+++ b/crates/mentedb/src/enrichment.rs
@@ -134,6 +134,7 @@ pub async fn run_enrichment<J: LlmJudge>(
                             None,
                             Some(agent),
                             Some(user),
+                            None,
                         )
                         .unwrap_or_default()
                         .into_iter()

--- a/crates/mentedb/src/injection.rs
+++ b/crates/mentedb/src/injection.rs
@@ -103,6 +103,11 @@ pub struct InjectionQuery<'a> {
     /// knowledge, orthogonal to `agent_id`. None recalls globally on the user
     /// axis. A memory is injectable only when visible on BOTH axes.
     pub user_id: Option<UserId>,
+    /// Current project (a `scope:project:<name>` value without the prefix). When
+    /// set, memories from other projects are weighted down in recall so injection
+    /// favors the active project instead of dumping cross-project noise. None
+    /// recalls across all projects.
+    pub current_project: Option<&'a str>,
 }
 
 /// Why an item was selected, for introspection and client display.
@@ -207,6 +212,7 @@ impl MenteDb {
                 None,
                 query.agent_id,
                 query.user_id,
+                query.current_project,
             )
             .unwrap_or_default();
 

--- a/crates/mentedb/src/lib.rs
+++ b/crates/mentedb/src/lib.rs
@@ -320,6 +320,17 @@ pub struct CognitiveConfig {
     pub trajectory_max_turns: usize,
     /// Maximum speculative cache entries.
     pub speculative_cache_size: usize,
+    /// Cosine similarity threshold for a query to hit a speculative cache entry.
+    pub speculative_embedding_threshold: f32,
+    /// Keyword-overlap threshold for a query to hit a speculative cache entry.
+    pub speculative_keyword_threshold: f32,
+    /// Recall relevance penalty for a memory from a DIFFERENT project than the
+    /// query's current project (0.0 = off, 1.0 = hard isolation). A weighted
+    /// signal, not a filter: a strongly-relevant cross-project memory still
+    /// surfaces, ranked below the current project's; global (un-projected) and
+    /// same-project memories are never penalized. Applied only when the caller
+    /// passes a current project (None = search across all projects).
+    pub project_scope_penalty: f32,
     /// Maximum pain signals to retain.
     pub pain_max_warnings: usize,
     /// Configuration for injection attention selection.
@@ -370,7 +381,10 @@ impl Default for CognitiveConfig {
             enrichment_config: EnrichmentConfig::default(),
             interference_threshold: 0.8,
             trajectory_max_turns: 100,
-            speculative_cache_size: 10,
+            speculative_cache_size: 32,
+            speculative_embedding_threshold: 0.5,
+            speculative_keyword_threshold: 0.4,
+            project_scope_penalty: 0.5,
             pain_max_warnings: 5,
             injection_config: injection::InjectionConfig::default(),
             flush_snapshot_interval: 8,
@@ -549,8 +563,8 @@ impl MenteDb {
         let phantom = RwLock::new(PhantomTracker::new(cognitive_config.phantom_config.clone()));
         let speculative = RwLock::new(SpeculativeCache::new(
             cognitive_config.speculative_cache_size,
-            0.5,
-            0.4,
+            cognitive_config.speculative_embedding_threshold,
+            cognitive_config.speculative_keyword_threshold,
         ));
         let interference = InterferenceDetector::new(cognitive_config.interference_threshold);
         let entity_resolver = RwLock::new(EntityResolver::new());
@@ -908,7 +922,7 @@ impl MenteDb {
         tags: Option<&[&str]>,
         time_range: Option<(Timestamp, Timestamp)>,
     ) -> MenteResult<Vec<(MemoryId, f32)>> {
-        self.recall_hybrid_at(embedding, None, k, at, tags, time_range)
+        self.recall_hybrid_at(embedding, None, k, at, tags, time_range, None)
     }
 
     /// Hybrid search combining vector similarity and BM25 keyword matching.
@@ -916,6 +930,7 @@ impl MenteDb {
     /// When `query_text` is provided, BM25 results are fused with vector
     /// results via Reciprocal Rank Fusion (RRF) for better recall on
     /// exact entity names, dates, and specific terms.
+    #[allow(clippy::too_many_arguments)]
     pub fn recall_hybrid_at(
         &self,
         embedding: &[f32],
@@ -924,8 +939,18 @@ impl MenteDb {
         at: Timestamp,
         tags: Option<&[&str]>,
         time_range: Option<(Timestamp, Timestamp)>,
+        current_project: Option<&str>,
     ) -> MenteResult<Vec<(MemoryId, f32)>> {
-        self.recall_hybrid_at_mode(embedding, query_text, k, at, tags, false, time_range)
+        self.recall_hybrid_at_mode(
+            embedding,
+            query_text,
+            k,
+            at,
+            tags,
+            false,
+            time_range,
+            current_project,
+        )
     }
 
     /// Hybrid recall with configurable tag mode (AND vs OR).
@@ -939,9 +964,19 @@ impl MenteDb {
         tags: Option<&[&str]>,
         tags_or: bool,
         time_range: Option<(Timestamp, Timestamp)>,
+        current_project: Option<&str>,
     ) -> MenteResult<Vec<(MemoryId, f32)>> {
         self.recall_hybrid_scoped_at_mode(
-            embedding, query_text, k, at, tags, tags_or, time_range, None, None,
+            embedding,
+            query_text,
+            k,
+            at,
+            tags,
+            tags_or,
+            time_range,
+            None,
+            None,
+            current_project,
         )
     }
 
@@ -963,6 +998,7 @@ impl MenteDb {
         time_range: Option<(Timestamp, Timestamp)>,
         agent: Option<AgentId>,
         user: Option<UserId>,
+        current_project: Option<&str>,
     ) -> MenteResult<Vec<(MemoryId, f32)>> {
         let started = std::time::Instant::now();
         debug!(
@@ -972,6 +1008,14 @@ impl MenteDb {
             query_text.is_some(),
             tags_or
         );
+        // Project scope weight: precompute the current project's scope tag and the
+        // retained fraction for cross-project memories. None (or empty) disables
+        // the weighting entirely, which is the "search across all projects"
+        // override.
+        let current_project_tag = current_project
+            .filter(|p| !p.is_empty())
+            .map(|p| format!("scope:project:{p}"));
+        let cross_project_keep = 1.0 - self.cognitive_config.project_scope_penalty;
         // Over-fetch to account for filtered-out results
         let results = self.index.hybrid_search_with_query_mode(
             embedding,
@@ -1027,6 +1071,22 @@ impl MenteDb {
                     raw_score * 0.7 + decayed * 0.3
                 } else {
                     raw_score
+                };
+                // Weight down a memory that belongs to a DIFFERENT project than
+                // the query's current project. Same-project and global (no
+                // scope:project tag) memories are unaffected, so cross-project
+                // recall still works when a memory is strongly relevant, it is
+                // just ranked below the current project's.
+                let score = match &current_project_tag {
+                    Some(cpt)
+                        if node
+                            .tags
+                            .iter()
+                            .any(|t| t.starts_with("scope:project:") && t != cpt) =>
+                    {
+                        score * cross_project_keep
+                    }
+                    _ => score,
                 };
                 Some((id, score))
             })
@@ -1095,7 +1155,8 @@ impl MenteDb {
 
         for (i, emb) in embeddings.iter().enumerate() {
             let qt = query_texts.and_then(|texts| texts.get(i).map(|s| s.as_str()));
-            let results = self.recall_hybrid_at_mode(emb, qt, k, now, tags, tags_or, time_range)?;
+            let results =
+                self.recall_hybrid_at_mode(emb, qt, k, now, tags, tags_or, time_range, None)?;
             for (rank, (id, _score)) in results.iter().enumerate() {
                 *rrf_scores.entry(*id).or_insert(0.0) += 1.0 / (rrf_k + rank as f32);
             }
@@ -1420,6 +1481,7 @@ impl MenteDb {
                 None,
                 Some(new_memory.agent_id),
                 Some(new_memory.user_id),
+                None,
             )
             .unwrap_or_default()
         } else {

--- a/crates/mentedb/src/process_turn.rs
+++ b/crates/mentedb/src/process_turn.rs
@@ -386,6 +386,7 @@ impl MenteDb {
             None,
             agent,
             user,
+            None,
         )?;
         let mut scored: Vec<ScoredMemory> = results
             .iter()
@@ -531,6 +532,7 @@ impl MenteDb {
                 None,
                 agent,
                 user,
+                None,
             )
             .unwrap_or_default();
         let existing: Vec<MemoryNode> = similar_ids
@@ -699,6 +701,7 @@ impl MenteDb {
                 None,
                 agent,
                 user,
+                None,
             )
             .unwrap_or_default();
         let nearby: Vec<MemoryNode> = similar_ids
@@ -763,6 +766,7 @@ impl MenteDb {
                     None,
                     agent,
                     user,
+                    None,
                 )
                 .unwrap_or_default();
             for (mid, score) in &results {

--- a/crates/mentedb/tests/agent_isolation.rs
+++ b/crates/mentedb/tests/agent_isolation.rs
@@ -79,6 +79,7 @@ fn scoped_recall_isolates_agents() {
             None,
             Some(coder),
             None,
+            None,
         )
         .unwrap();
     let ids: Vec<MemoryId> = hits.iter().map(|(id, _)| *id).collect();
@@ -101,6 +102,7 @@ fn scoped_recall_isolates_agents() {
             now_us(),
             None,
             false,
+            None,
             None,
             None,
             None,
@@ -207,6 +209,7 @@ fn injection_respects_agent_scope() {
             max_episodic: 2,
             agent_id: Some(coder),
             user_id: None,
+            current_project: None,
         })
         .unwrap();
 
@@ -245,6 +248,7 @@ fn ghost_memories_never_inject() {
             max_episodic: 2,
             agent_id: None,
             user_id: None,
+            current_project: None,
         })
         .unwrap();
     let contents: Vec<&str> = selected.iter().map(|c| c.node.content.as_str()).collect();

--- a/crates/mentedb/tests/integration.rs
+++ b/crates/mentedb/tests/integration.rs
@@ -1644,6 +1644,7 @@ mod injection_attention {
                 max_episodic: 0,
                 agent_id: None,
                 user_id: None,
+                current_project: None,
             };
             let ids: Vec<_> = db
                 .recall_for_injection(&query)
@@ -1702,6 +1703,7 @@ mod injection_attention {
             max_episodic: 2,
             agent_id: None,
             user_id: None,
+            current_project: None,
         };
         let out = db.recall_for_injection(&query).unwrap();
 
@@ -1820,6 +1822,7 @@ mod injection_attention {
             max_episodic: 0,
             agent_id: None,
             user_id: None,
+            current_project: None,
         };
         let out = db.recall_for_injection(&query).unwrap();
         let relevant: Vec<_> = out

--- a/crates/mentedb/tests/snapshot_amortization.rs
+++ b/crates/mentedb/tests/snapshot_amortization.rs
@@ -34,7 +34,7 @@ fn now_us() -> u64 {
 }
 
 fn recall_ids(db: &MenteDb, axis: usize) -> Vec<MemoryId> {
-    db.recall_hybrid_at(&vec_for(axis), None, 10, now_us(), None, None)
+    db.recall_hybrid_at(&vec_for(axis), None, 10, now_us(), None, None, None)
         .unwrap()
         .into_iter()
         .map(|(id, _)| id)

--- a/crates/mentedb/tests/user_isolation.rs
+++ b/crates/mentedb/tests/user_isolation.rs
@@ -141,6 +141,7 @@ fn scoped_user_still_sees_own_and_global() {
             None,
             Some(bob),
             None,
+            None,
         )
         .unwrap();
     let ids: Vec<MemoryId> = hits.iter().map(|(id, _)| *id).collect();
@@ -175,6 +176,7 @@ fn scoped_recall_excludes_other_users_even_as_top_match() {
             false,
             None,
             Some(bob),
+            None,
             None,
         )
         .unwrap();
@@ -269,6 +271,7 @@ fn user_scoping_is_orthogonal_to_agent() {
             None,
             Some(agent),
             Some(ua),
+            None,
         )
         .unwrap();
     let ids: Vec<MemoryId> = hits.iter().map(|(id, _)| *id).collect();


### PR DESCRIPTION
## Summary
- Recall now folds project scope distance into ranking, so cross-project memories are down-weighted rather than either ignored or allowed to crowd out the current project's.
- Makes the speculative cache size and hit thresholds configurable and lifts the default cap from 10 to 32.

## Project scope weighting
- A memory tagged for a DIFFERENT project than the query's current project keeps only `(1 - project_scope_penalty)` of its score (default penalty 0.5). Same-project and global (un-projected) memories are never penalized.
- It is a weighted signal, not a filter: a strongly relevant cross-project memory still surfaces, just ranked below the current project's. Passing no current project searches across all projects (the override).
- `current_project` is threaded through the hybrid recall path and `InjectionQuery`; all internal callers default to `None` (unchanged behavior).

## Speculative cache config
- `speculative_cache_size` default raised 10 to 32.
- The previously hardcoded embedding and keyword hit thresholds are now `CognitiveConfig` fields, per the no-magic-numbers convention.

## Verification
- `cargo clippy -p mentedb --features enrichment` clean; `cargo test -p mentedb` green (159 tests), including the agent and user isolation suites updated for the new parameter.