### PR TITLE
feat(recall): optional MMR diversity pass on hybrid recall

### DIFF
--- a/crates/mentedb/src/lib.rs
+++ b/crates/mentedb/src/lib.rs
@@ -112,6 +112,10 @@ pub mod enrichment;
 /// Optional second-pass reranking of recall results (off by default).
 pub mod reranker;
 
+/// Maximal Marginal Relevance: an optional diversity pass over recall results
+/// (off by default; enabled by `CognitiveConfig::mmr_lambda` below 1.0).
+pub(crate) mod mmr;
+
 /// Structured export: fill a JSON schema from memories via an embedder-supplied LLM.
 pub mod export;
 
@@ -337,6 +341,13 @@ pub struct CognitiveConfig {
     /// relevant hit that the first pass ranked outside the top k. Ignored when no
     /// reranker is installed. Minimum effective value is 1.
     pub rerank_pool_factor: usize,
+    /// Diversity weight for the optional MMR pass on hybrid recall, in `[0, 1]`.
+    /// `1.0` (the default) disables it, ranking on relevance alone. Below 1.0,
+    /// recall greedily balances relevance against novelty so near-duplicate
+    /// memories do not all fill the context budget: `0.7` trims obvious
+    /// duplicates, `0.5` diversifies harder. Runs after any reranker, over the
+    /// same over-fetched pool, so it can pull a distinct memory into the top k.
+    pub mmr_lambda: f32,
     /// Maximum pain signals to retain.
     pub pain_max_warnings: usize,
     /// Configuration for injection attention selection.
@@ -392,6 +403,7 @@ impl Default for CognitiveConfig {
             speculative_keyword_threshold: 0.4,
             project_scope_penalty: 0.5,
             rerank_pool_factor: 4,
+            mmr_lambda: 1.0,
             pain_max_warnings: 5,
             injection_config: injection::InjectionConfig::default(),
             flush_snapshot_interval: 8,
@@ -1051,12 +1063,14 @@ impl MenteDb {
             .filter(|p| !p.is_empty())
             .map(|p| format!("scope:project:{p}"));
         let cross_project_keep = 1.0 - self.cognitive_config.project_scope_penalty;
-        // When a reranker is installed, over-fetch a larger candidate pool so it
-        // can promote a relevant hit the first pass ranked outside the top k;
-        // otherwise the usual 3x over-fetch covers results filtered out below.
+        // When a reranker or the MMR diversity pass is active, over-fetch a larger
+        // candidate pool so it can promote (or diversify in) a relevant hit the
+        // first pass ranked outside the top k; otherwise the usual 3x over-fetch
+        // covers results filtered out below.
         let want_rerank =
             self.reranker.is_some() && query_text.map(|q| !q.is_empty()).unwrap_or(false);
-        let fetch_k = if want_rerank {
+        let want_mmr = self.cognitive_config.mmr_lambda < 1.0;
+        let fetch_k = if want_rerank || want_mmr {
             k.saturating_mul(self.cognitive_config.rerank_pool_factor.max(1))
         } else {
             k * 3
@@ -1066,7 +1080,10 @@ impl MenteDb {
         );
         let graph = self.graph.graph();
         let pm = self.page_map.read();
-        let mut scored: Vec<(MemoryId, f32, Option<String>)> = results
+        // (id, score, content for a reranker, embedding for the MMR pass); the
+        // last two are captured only when their stage is active.
+        type ScoredCandidate = (MemoryId, f32, Option<String>, Option<Vec<f32>>);
+        let mut scored: Vec<ScoredCandidate> = results
             .into_iter()
             .filter_map(|(id, raw_score)| {
                 // Exclude memories that an active Supersedes/Contradicts edge
@@ -1082,10 +1099,10 @@ impl MenteDb {
                 // Without a page entry we cannot check validity or decay; keep
                 // the raw score rather than silently dropping the hit.
                 let Some(&page_id) = pm.get(&id) else {
-                    return Some((id, raw_score, None));
+                    return Some((id, raw_score, None, None));
                 };
                 let Ok(node) = self.storage.load_memory(page_id) else {
-                    return Some((id, raw_score, None));
+                    return Some((id, raw_score, None, None));
                 };
                 // Drop memories outside their validity window or not visible to
                 // this (user, agent) scope. Both owner axes must pass.
@@ -1127,14 +1144,20 @@ impl MenteDb {
                     }
                     _ => score,
                 };
-                // Keep the content only when a reranker will consume it, so the
-                // default path pays no extra allocation.
+                // Capture the content only when a reranker will consume it, and
+                // the embedding only when the MMR pass will, so the default path
+                // pays no extra allocation.
                 let content = if want_rerank {
                     Some(node.content.clone())
                 } else {
                     None
                 };
-                Some((id, score, content))
+                let embedding = if want_mmr && !node.embedding.is_empty() {
+                    Some(node.embedding.clone())
+                } else {
+                    None
+                };
+                Some((id, score, content, embedding))
             })
             .collect();
         // Optional second pass: reorder the whole fetched pool by the installed
@@ -1148,7 +1171,7 @@ impl MenteDb {
             let new_scores: std::collections::HashMap<MemoryId, f32> = {
                 let cands: Vec<RerankCandidate<'_>> = scored
                     .iter()
-                    .map(|(id, sc, content)| RerankCandidate {
+                    .map(|(id, sc, content, _)| RerankCandidate {
                         id: *id,
                         content: content.as_deref().unwrap_or(""),
                         score: *sc,
@@ -1156,7 +1179,7 @@ impl MenteDb {
                     .collect();
                 reranker.rerank(qt, &cands).into_iter().collect()
             };
-            for (id, sc, _) in scored.iter_mut() {
+            for (id, sc, _, _) in scored.iter_mut() {
                 if let Some(&ns) = new_scores.get(id) {
                     *sc = ns;
                 }
@@ -1165,8 +1188,19 @@ impl MenteDb {
         // Re-rank by the (decay-adjusted, then optionally reranked) score before
         // cutting to k, so the ranking reorders results rather than relabeling them.
         scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
-        scored.truncate(k);
-        let scored: Vec<(MemoryId, f32)> = scored.into_iter().map(|(id, sc, _)| (id, sc)).collect();
+        let scored: Vec<(MemoryId, f32)> = if want_mmr && scored.len() > 1 {
+            // Diversity pass: greedily pick k relevant-yet-distinct memories from
+            // the sorted pool, so near-duplicates do not all fill the budget.
+            let rel: Vec<f32> = scored.iter().map(|(_, sc, _, _)| *sc).collect();
+            let emb: Vec<Option<&[f32]>> = scored.iter().map(|(_, _, _, e)| e.as_deref()).collect();
+            mmr::mmr_select(&rel, &emb, self.cognitive_config.mmr_lambda, k)
+                .into_iter()
+                .map(|i| (scored[i].0, scored[i].1))
+                .collect()
+        } else {
+            scored.truncate(k);
+            scored.into_iter().map(|(id, sc, _, _)| (id, sc)).collect()
+        };
         // Time only (do not increment recalls here): recall()/query() already
         // count the read, and they reach this hybrid core via execute_plan, so
         // counting here too would double-count them.
@@ -4537,5 +4571,79 @@ mod reranker_integration_tests {
             )
             .unwrap();
         assert_eq!(out[0].0, b_id, "no query text means no rerank");
+    }
+
+    /// With MMR enabled, recall should pull a distinct memory into the top-k
+    /// ahead of a near-duplicate of the top hit; with MMR off (default), the
+    /// near-duplicate keeps its by-relevance slot.
+    #[test]
+    fn mmr_diversifies_top_k() {
+        // a: closest to the query. b: a near-duplicate of a (same direction),
+        // slightly less relevant. c: a distinct direction, less relevant still.
+        let a_emb = vec![1.0, 0.1, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0];
+        let b_emb = vec![0.98, 0.16, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0];
+        let c_emb = vec![0.1, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0];
+        let query = vec![1.0, 0.1, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0];
+
+        let fill = |db: &MenteDb| -> (MemoryId, MemoryId, MemoryId) {
+            let a = MemoryNode::new(
+                AgentId::nil(),
+                MemoryType::Semantic,
+                "alpha".into(),
+                a_emb.clone(),
+            );
+            let b = MemoryNode::new(
+                AgentId::nil(),
+                MemoryType::Semantic,
+                "alpha prime".into(),
+                b_emb.clone(),
+            );
+            let c = MemoryNode::new(
+                AgentId::nil(),
+                MemoryType::Semantic,
+                "distinct".into(),
+                c_emb.clone(),
+            );
+            let (ai, bi, ci) = (a.id, b.id, c.id);
+            db.store(a).unwrap();
+            db.store(b).unwrap();
+            db.store(c).unwrap();
+            (ai, bi, ci)
+        };
+
+        // Default (mmr_lambda = 1.0): the two nearest fill the top 2, diverse c is out.
+        let dir1 = tempfile::tempdir().unwrap();
+        let db1 = MenteDb::open(dir1.path()).unwrap();
+        let (_a1, _b1, c1) = fill(&db1);
+        let base = db1
+            .recall_hybrid_at(&query, None, 2, now_us(), None, None, None)
+            .unwrap();
+        let base_ids: Vec<MemoryId> = base.iter().map(|(id, _)| *id).collect();
+        assert!(
+            !base_ids.contains(&c1),
+            "without MMR the diverse memory is out of the top 2"
+        );
+
+        // MMR on (lambda = 0.5): the diverse memory is pulled into the top 2.
+        let dir2 = tempfile::tempdir().unwrap();
+        let cfg = CognitiveConfig {
+            mmr_lambda: 0.5,
+            ..CognitiveConfig::default()
+        };
+        let db2 = MenteDb::open_with_config(dir2.path(), cfg).unwrap();
+        let (a2, _b2, c2) = fill(&db2);
+        let mmr = db2
+            .recall_hybrid_at(&query, None, 2, now_us(), None, None, None)
+            .unwrap();
+        let mmr_ids: Vec<MemoryId> = mmr.iter().map(|(id, _)| *id).collect();
+        assert_eq!(
+            mmr_ids.first().copied(),
+            Some(a2),
+            "most relevant is still first"
+        );
+        assert!(
+            mmr_ids.contains(&c2),
+            "MMR pulls the diverse memory into the top 2"
+        );
     }
 }

--- a/crates/mentedb/src/mmr.rs
+++ b/crates/mentedb/src/mmr.rs
@@ -1,0 +1,144 @@
+//! Maximal Marginal Relevance (MMR): a diversity-aware selection over recall
+//! candidates.
+//!
+//! Greedily picks items that are relevant yet dissimilar to what is already
+//! chosen, so near-duplicate memories do not all consume the fixed, U-curve
+//! context budget. Applied as an optional built-in stage after the first pass
+//! and any reranker; disabled by default (`mmr_lambda = 1.0`, pure relevance).
+
+/// Cosine similarity, guarding against zero-norm vectors and length mismatch.
+pub(crate) fn cosine(a: &[f32], b: &[f32]) -> f32 {
+    if a.len() != b.len() || a.is_empty() {
+        return 0.0;
+    }
+    let mut dot = 0.0f32;
+    let mut na = 0.0f32;
+    let mut nb = 0.0f32;
+    for i in 0..a.len() {
+        dot += a[i] * b[i];
+        na += a[i] * a[i];
+        nb += b[i] * b[i];
+    }
+    if na == 0.0 || nb == 0.0 {
+        return 0.0;
+    }
+    dot / (na.sqrt() * nb.sqrt())
+}
+
+/// Greedy MMR ordering. `rel[i]` is candidate `i`'s relevance; `emb[i]` its
+/// embedding (`None` means no diversity penalty can be computed for it, so it is
+/// ranked on relevance alone). `lambda` in `[0, 1]`: `1.0` is pure relevance
+/// (order by `rel`), `0.0` is pure diversity. Returns candidate indices in
+/// selection order, at most `k` of them.
+///
+/// Relevance is min-max normalized to `[0, 1]` so it trades off against cosine
+/// (also `[0, 1]` for the non-negative embeddings recall produces) on a common
+/// scale, which keeps `lambda` meaningful regardless of the score magnitudes the
+/// first pass emits.
+pub(crate) fn mmr_select(rel: &[f32], emb: &[Option<&[f32]>], lambda: f32, k: usize) -> Vec<usize> {
+    let n = rel.len();
+    debug_assert_eq!(n, emb.len());
+    let k = k.min(n);
+    if k == 0 {
+        return Vec::new();
+    }
+    let lambda = lambda.clamp(0.0, 1.0);
+
+    let mut lo = f32::INFINITY;
+    let mut hi = f32::NEG_INFINITY;
+    for &r in rel {
+        lo = lo.min(r);
+        hi = hi.max(r);
+    }
+    let span = hi - lo;
+    let reln = |i: usize| {
+        if span > 0.0 {
+            (rel[i] - lo) / span
+        } else {
+            1.0
+        }
+    };
+
+    let mut selected: Vec<usize> = Vec::with_capacity(k);
+    let mut chosen = vec![false; n];
+    while selected.len() < k {
+        let mut best: Option<usize> = None;
+        let mut best_score = f32::NEG_INFINITY;
+        for i in 0..n {
+            if chosen[i] {
+                continue;
+            }
+            // Diversity penalty: the largest cosine to anything already picked.
+            let max_sim = match emb[i] {
+                Some(ei) => selected
+                    .iter()
+                    .filter_map(|&s| emb[s].map(|es| cosine(ei, es)))
+                    .fold(0.0f32, f32::max),
+                None => 0.0,
+            };
+            let mmr = lambda * reln(i) - (1.0 - lambda) * max_sim;
+            if mmr > best_score {
+                best_score = mmr;
+                best = Some(i);
+            }
+        }
+        match best {
+            Some(i) => {
+                chosen[i] = true;
+                selected.push(i);
+            }
+            None => break,
+        }
+    }
+    selected
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lambda_one_is_pure_relevance_order() {
+        // With lambda=1 the diversity term vanishes, so the order is exactly by
+        // descending relevance regardless of embeddings.
+        let rel = [0.2, 0.9, 0.5];
+        let a = [1.0f32, 0.0];
+        let emb = [Some(&a[..]), Some(&a[..]), Some(&a[..])];
+        let order = mmr_select(&rel, &emb, 1.0, 3);
+        assert_eq!(order, vec![1, 2, 0]);
+    }
+
+    #[test]
+    fn diversity_demotes_a_near_duplicate() {
+        // Candidate 0 is the most relevant. Candidate 1 is a near-duplicate of 0
+        // (identical vector) but slightly less relevant; candidate 2 is a bit
+        // less relevant still but points a different direction. With diversity
+        // weighted in, the second pick should be the diverse 2, not the
+        // duplicate 1.
+        let rel = [1.0, 0.9, 0.8];
+        let v0 = [1.0f32, 0.0, 0.0];
+        let v1 = [1.0f32, 0.0, 0.0]; // duplicate of v0
+        let v2 = [0.0f32, 1.0, 0.0]; // orthogonal
+        let emb = [Some(&v0[..]), Some(&v1[..]), Some(&v2[..])];
+        let order = mmr_select(&rel, &emb, 0.5, 3);
+        assert_eq!(order[0], 0, "most relevant is picked first");
+        assert_eq!(order[1], 2, "diverse candidate beats the near-duplicate");
+        assert_eq!(order[2], 1);
+    }
+
+    #[test]
+    fn missing_embeddings_fall_back_to_relevance() {
+        let rel = [0.3, 0.7];
+        let emb: [Option<&[f32]>; 2] = [None, None];
+        let order = mmr_select(&rel, &emb, 0.5, 2);
+        assert_eq!(order, vec![1, 0]);
+    }
+
+    #[test]
+    fn k_is_clamped_and_zero_is_empty() {
+        let rel = [0.5, 0.4];
+        let emb: [Option<&[f32]>; 2] = [None, None];
+        assert_eq!(mmr_select(&rel, &emb, 0.5, 0), Vec::<usize>::new());
+        assert_eq!(mmr_select(&rel, &emb, 0.5, 9).len(), 2);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds Maximal Marginal Relevance (MMR) as a built-in, config-gated diversity pass on hybrid recall, so near-duplicate memories do not all consume the fixed U-curve context budget.

## How it works
- New `CognitiveConfig::mmr_lambda` in `[0, 1]`. `1.0` (default) disables MMR and ranks on relevance alone, so existing behavior is byte-identical; below 1.0 diversifies (`0.7` trims obvious duplicates, `0.5` harder).
- Runs after the first pass and any reranker, over the same over-fetched pool, greedily maximizing `lambda * relevance - (1 - lambda) * max_cosine_to_selected`. Relevance is min-max normalized so `lambda` is meaningful regardless of first-pass score magnitude.
- Candidate embeddings are captured for the pool only when MMR is active, so the default path pays no extra allocation. Pure-Rust, zero new dependencies.

## Why
From the Pinecone/RAG gap analysis: MMR is the best effort-to-payoff remaining retrieval win and compounds specifically with MenteDB's token-budgeted U-curve context assembly.

## Verification
- New `mmr` unit tests (pure-relevance order, near-duplicate demotion, missing-embedding fallback, k clamping) and a Db-level test that MMR pulls a diverse memory into the top-k while default recall keeps the near-duplicate.
- `cargo clippy -p mentedb --features enrichment` clean; `cargo test -p mentedb` green (166 tests).