### PR TITLE
feat(recall): contextual-retrieval hook via an optional context field

### DIFF
--- a/crates/mentedb-consolidation/src/lib.rs
+++ b/crates/mentedb-consolidation/src/lib.rs
@@ -58,6 +58,7 @@ pub(crate) mod test_helpers {
             tags: Vec::new(),
             valid_from: None,
             valid_until: None,
+            context: None,
         }
     }
 }

--- a/crates/mentedb-consolidation/tests/integration.rs
+++ b/crates/mentedb-consolidation/tests/integration.rs
@@ -15,6 +15,7 @@ fn make_memory(content: &str, embedding: Vec<f32>) -> MemoryNode {
         agent_id: AgentId::new(),
         user_id: UserId::nil(),
         memory_type: MemoryType::Episodic,
+        context: None,
         embedding,
         content: content.to_string(),
         created_at: 0,

--- a/crates/mentedb-core/src/memory.rs
+++ b/crates/mentedb-core/src/memory.rs
@@ -78,6 +78,14 @@ pub struct MemoryNode {
     /// None means still valid.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub valid_until: Option<Timestamp>,
+    /// Optional retrieval context, prepended to the content when the memory is
+    /// indexed (BM25) and embedded, but NOT stored as part of the content the
+    /// caller reads back. This is the contextual-retrieval hook: a short
+    /// situating blurb the caller generates (for example "From a thread about the
+    /// billing migration") that makes an otherwise-ambiguous memory findable by
+    /// terms it never literally contains. None indexes the content as-is.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context: Option<String>,
 }
 
 impl MemoryNode {
@@ -110,6 +118,7 @@ impl MemoryNode {
             tags: Vec::new(),
             valid_from: None,
             valid_until: None,
+            context: None,
         }
     }
 
@@ -120,6 +129,25 @@ impl MemoryNode {
     pub fn with_user_id(mut self, user_id: UserId) -> Self {
         self.user_id = user_id;
         self
+    }
+
+    /// Attach retrieval context (builder style). See [`MemoryNode::context`].
+    pub fn with_context(mut self, context: impl Into<String>) -> Self {
+        let ctx = context.into();
+        self.context = if ctx.is_empty() { None } else { Some(ctx) };
+        self
+    }
+
+    /// The text to index and embed: the context (when present) prefixed to the
+    /// content, so retrieval matches on both while the stored `content` stays
+    /// exactly what the caller wrote.
+    pub fn indexed_text(&self) -> std::borrow::Cow<'_, str> {
+        match &self.context {
+            Some(ctx) if !ctx.is_empty() => {
+                std::borrow::Cow::Owned(format!("{ctx}\n{}", self.content))
+            }
+            _ => std::borrow::Cow::Borrowed(&self.content),
+        }
     }
 }
 
@@ -148,6 +176,35 @@ impl MemoryNode {
 mod tests {
     use super::*;
     use crate::types::{AgentId, UserId};
+
+    #[test]
+    fn context_prefixes_indexed_text_but_not_content() {
+        let n = MemoryNode::new(
+            AgentId::new(),
+            MemoryType::Semantic,
+            "the migration plan".to_string(),
+            vec![1.0],
+        )
+        .with_context("From a thread about billing");
+        // The stored content the caller reads back is untouched.
+        assert_eq!(n.content, "the migration plan");
+        // What gets indexed/embedded carries the context prefix.
+        assert_eq!(
+            n.indexed_text(),
+            "From a thread about billing\nthe migration plan"
+        );
+
+        // No context (and empty context) indexes the content as-is.
+        let plain = MemoryNode::new(
+            AgentId::new(),
+            MemoryType::Semantic,
+            "x".to_string(),
+            vec![1.0],
+        );
+        assert_eq!(plain.indexed_text(), "x");
+        assert_eq!(plain.context, None);
+        assert_eq!(plain.with_context("").context, None);
+    }
 
     #[test]
     fn new_memory_has_no_temporal_bounds() {

--- a/crates/mentedb-index/src/manager.rs
+++ b/crates/mentedb-index/src/manager.rs
@@ -101,9 +101,11 @@ impl IndexManager {
             let _ = self.hnsw.insert(node.id, &node.embedding);
         }
 
-        // BM25 full-text index
-        if !node.content.is_empty() {
-            self.bm25.insert(node.id, &node.content);
+        // BM25 full-text index, over the context-prefixed text so contextual
+        // retrieval also matches the caller's situating blurb.
+        let indexed = node.indexed_text();
+        if !indexed.is_empty() {
+            self.bm25.insert(node.id, &indexed);
         }
 
         // Tag bitmap index. Clear this id's existing tags first, so a re-index

--- a/crates/mentedb-server/src/extraction_queue.rs
+++ b/crates/mentedb-server/src/extraction_queue.rs
@@ -101,6 +101,7 @@ async fn process_extraction(req: ExtractionRequest) -> Result<(), String> {
             tags: memory.tags.clone(),
             valid_from: None,
             valid_until: None,
+            context: None,
         };
         match req.db.store(node) {
             Ok(()) => stored += 1,

--- a/crates/mentedb-server/src/grpc.rs
+++ b/crates/mentedb-server/src/grpc.rs
@@ -241,6 +241,7 @@ impl MemoryService for MemoryServiceImpl {
             tags: req.tags,
             valid_from: req.valid_from,
             valid_until: req.valid_until,
+            context: None,
         };
 
         let db = &*self.state.db;

--- a/crates/mentedb-server/src/handlers.rs
+++ b/crates/mentedb-server/src/handlers.rs
@@ -135,6 +135,7 @@ pub async fn store_memory(
         tags,
         valid_from: req.get("valid_from").and_then(|v| v.as_u64()),
         valid_until: req.get("valid_until").and_then(|v| v.as_u64()),
+        context: None,
     };
 
     let db = &*state.db;
@@ -468,6 +469,7 @@ async fn run_extraction(
             tags: memory.tags.clone(),
             valid_from: None,
             valid_until: None,
+            context: None,
         };
         match db.store(node) {
             Ok(()) => stored_ids.push(id.to_string()),

--- a/crates/mentedb/src/lib.rs
+++ b/crates/mentedb/src/lib.rs
@@ -1916,10 +1916,11 @@ impl MenteDb {
                 continue;
             };
             // Already at the target dimension: nothing to do.
-            if node.embedding.len() == target || node.content.is_empty() {
+            let text = node.indexed_text();
+            if node.embedding.len() == target || text.is_empty() {
                 continue;
             }
-            let Some(embedding) = self.embed_text(&node.content)? else {
+            let Some(embedding) = self.embed_text(&text)? else {
                 continue;
             };
             // The embedder is not yet producing the target dimension; leave the
@@ -4644,6 +4645,56 @@ mod reranker_integration_tests {
         assert!(
             mmr_ids.contains(&c2),
             "MMR pulls the diverse memory into the top 2"
+        );
+    }
+
+    /// The contextual-retrieval hook: a term that appears only in a memory's
+    /// context (not its content) still finds it via BM25, and the stored content
+    /// is unchanged.
+    #[test]
+    fn contextual_hook_makes_context_terms_findable() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = MenteDb::open(dir.path()).unwrap();
+
+        // "kubernetes" is in the context, never in the content.
+        let node = MemoryNode::new(
+            AgentId::nil(),
+            MemoryType::Semantic,
+            "rolled the pods back to the previous tag".into(),
+            vec![0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8],
+        )
+        .with_context("incident in the kubernetes cluster");
+        let id = node.id;
+        db.store(node).unwrap();
+        // A decoy sharing neither the content nor the context terms.
+        db.store(MemoryNode::new(
+            AgentId::nil(),
+            MemoryType::Semantic,
+            "lunch plans for friday".into(),
+            vec![0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1],
+        ))
+        .unwrap();
+
+        let hits = db
+            .recall_hybrid_at(
+                &[0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8],
+                Some("kubernetes"),
+                5,
+                now_us(),
+                None,
+                None,
+                None,
+            )
+            .unwrap();
+        let ids: Vec<MemoryId> = hits.iter().map(|(id, _)| *id).collect();
+        assert!(
+            ids.contains(&id),
+            "a term only in the context must find the memory via BM25"
+        );
+        // The stored content is exactly what was written, no context leaked in.
+        assert_eq!(
+            db.get_memory(id).unwrap().content,
+            "rolled the pods back to the previous tag"
         );
     }
 }


### PR DESCRIPTION
## Summary
- Adds the contextual-retrieval primitive: an optional per-memory `context` that is indexed and embedded alongside the content but is not part of the stored content.

## How it works
- `MemoryNode::context: Option<String>` (serde-default, so existing data and struct users are unaffected), a `with_context()` builder, and `indexed_text()` which prefixes the context to the content.
- The BM25 index and the engine's re-embed path use `indexed_text()`, so a memory becomes findable by terms that appear only in its context. The `content` the caller reads back is untouched.
- Generation of the context stays with the caller (it needs their LLM); the engine just exposes the enabling mechanism. Zero new dependencies.

## Why
From the Pinecone/RAG gap analysis, this is the highest-ceiling ingestion-side retrieval win. Anthropic's contextual retrieval reports up to 49% fewer retrieval failures (67% with reranking).

## Verification
- New tests: `context` prefixes `indexed_text()` but not `content`; empty context stays `None`; a term only in the context finds the memory via BM25 while the stored content is verified unchanged.
- `cargo test --workspace` green (681 tests), `cargo clippy --workspace --features enrichment` clean, `cargo fmt --all` applied. All MemoryNode struct-literal sites (server, consolidation) updated for the new field.