### PR TITLE
docs: document the retrieval stack and add an end-to-end test

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -19,7 +19,7 @@ mentedb (workspace root)
  |
  +-- mentedb-core            Fundamental types shared by every crate
  +-- mentedb-storage          Page manager, WAL, buffer pool
- +-- mentedb-index            HNSW vectors, bitmap tags, temporal, salience
+ +-- mentedb-index            HNSW vectors, BM25 keyword, bitmap tags, temporal, salience
  +-- mentedb-graph            CSR/CSC knowledge graph, traversal, belief propagation
  +-- mentedb-query            MQL lexer, parser, query planner
  +-- mentedb-context          Token budgets, U curve attention, delta serving, serializers
@@ -139,7 +139,7 @@ Wires page manager, WAL, and buffer pool together. Provides `store_memory`
 
 ### mentedb-index
 
-Four index structures, each optimized for a different access pattern, managed
+Five index structures, each optimized for a different access pattern, managed
 by a unified `IndexManager` that coordinates hybrid queries.
 
 **HNSW Vector Index** (`hnsw.rs`):
@@ -171,17 +171,27 @@ first) and `update` (move a memory when its salience decays). This index is
 the backbone of the "what matters most" question that context assembly asks
 on every read.
 
+**BM25 Keyword Index** (`bm25.rs`):
+An inverted index with proper BM25 scoring (IDF, term-frequency saturation, and
+document-length normalization). It complements vector search for the exact entity
+names, dates, and numbers that embeddings blur together. Indexing is upsert safe,
+so re-indexing a memory after an edit replaces its posting rather than double
+counting it. It indexes each memory's context-prefixed text (the contextual
+retrieval hook), so a memory is findable by situating terms the caller attached
+even when the content itself never contains them.
+
 **Index Manager** (`manager.rs`):
-`index_memory` fans out a single `MemoryNode` to all four indexes. `hybrid_search`
-combines results with a weighted score:
-
-```
-final_score = vector_similarity * 0.6 + salience * 0.3 + recency * 0.1
-```
-
-This formula is intentionally simple and configurable. Vector similarity dominates
-because embeddings capture semantic intent. Salience rewards memories the agent
-has flagged as important. Recency provides a mild preference for fresh information.
+`index_memory` fans out a single `MemoryNode` to every index. `hybrid_search`
+retrieves candidates from HNSW (vector) and BM25 (keyword) independently and fuses
+them with Reciprocal Rank Fusion, then applies tag, temporal, and validity
+filters. The recall layer above it (in the `mentedb` crate) finishes the ranking:
+it blends in decay-adjusted salience, applies optional project scope weighting
+(down-weighting memories tagged for a different project than the query's), then
+runs two optional, config-gated passes over the fused pool, a pluggable reranker
+(relevance re-scoring, e.g. a cross-encoder) and MMR (diversity selection so
+near-duplicates do not fill the budget), before truncating to k. Every stage is
+off by default and tunable through `CognitiveConfig`, so the base path stays a
+simple, predictable RRF fusion.
 
 ### mentedb-graph
 

--- a/README.md
+++ b/README.md
@@ -214,7 +214,9 @@ The result: a clean, curated memory that actually helps the AI perform better.
 
 - **Automatic Memory Extraction** LLM powered pipeline extracts structured memories from raw conversations
 - **Entity-Centric Memory** Extracts typed entities (person, pet, place, event, item, organization) with structured attributes. Entity resolution merges attributes across mentions. `Derived` and labeled `Related` edges link entities to the memories they came from
-- **Hybrid Retrieval** Vector similarity (HNSW) fused with BM25 keyword search via reciprocal rank fusion, plus tag, temporal, and validity filtering
+- **Hybrid Retrieval** Vector similarity (HNSW) fused with BM25 keyword search via reciprocal rank fusion, plus tag, temporal, and validity filtering. Optional second-pass reranking (pluggable, e.g. a cross-encoder or LLM judge) and optional MMR diversity selection so near-duplicate memories do not crowd the context budget
+- **Contextual Retrieval** An optional per-memory `context` blurb is indexed and embedded alongside the content (never stored in it), so a memory is findable by situating terms it never literally contains. The caller generates the context; the engine indexes it
+- **Project Scope Weighting** Recall can weight down memories tagged for other projects so the project you are working in ranks first, without hiding a strongly relevant cross-project memory
 - **Write Time Intelligence** Quality filter, deduplication, and contradiction detection at ingest
 - **LLM Powered Cognitive Inference** CognitiveLlmService judges whether new memories invalidate, update, or are compatible with existing ones (supports Anthropic, OpenAI, Ollama)
 - **Bi-Temporal Validity** Memories and edges carry `valid_from`/`valid_until` timestamps. Temporal invalidation instead of deletion. Point-in-time queries via `recall_similar_at(embedding, k, timestamp)` or in MQL with `RECALL ... AS OF <timestamp>`
@@ -383,8 +385,9 @@ graph TD
     end
 
     subgraph Retrieval["Retrieval"]
-        HYB["Hybrid Fusion<br/>BM25 + vector, RRF"]
-        RERANK["Optional Reranker"]
+        HYB["Hybrid Fusion<br/>BM25 + vector, RRF<br/>+ project scope weight"]
+        RERANK["Optional Reranker<br/>pluggable second pass"]
+        MMR["Optional MMR<br/>diversity selection"]
     end
 
     subgraph Cognitive["Cognitive Engine"]
@@ -405,7 +408,7 @@ graph TD
 
     subgraph Index["Index Layer"]
         HNSW["HNSW Vector Index"]
-        BM25["BM25 Keyword Index"]
+        BM25["BM25 Keyword Index<br/>context-aware"]
         ROAR["Roaring Bitmap Tags"]
         TEMP["Temporal / Bi-temporal Index"]
     end
@@ -442,7 +445,8 @@ graph TD
     HNSW --> HYB
     BM25 --> HYB
     HYB --> RERANK
-    RERANK --> CTX
+    RERANK --> MMR
+    MMR --> CTX
     CTX --> INJ
 
     WI --> Graph

--- a/crates/mentedb/tests/retrieval_stack.rs
+++ b/crates/mentedb/tests/retrieval_stack.rs
@@ -1,0 +1,210 @@
+//! Internal end-to-end validation of the retrieval stack shipped in 0.22-0.23:
+//! the contextual-retrieval hook, MMR diversity, the pluggable reranker, and
+//! project scope weighting. Each scenario runs against a real (deterministic
+//! hash) embedder and the full hybrid recall path, so it exercises the same code
+//! production does, not a shortcut. These are the "do the updates actually work
+//! together" checks.
+
+use mentedb::prelude::*;
+use mentedb::reranker::{RerankCandidate, Reranker};
+use mentedb::{CognitiveConfig, MenteDb};
+use mentedb_embedding::{EmbeddingProvider, HashEmbeddingProvider};
+
+const DIM: usize = 384;
+
+fn now_us() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_micros() as u64
+}
+
+fn emb(text: &str) -> Vec<f32> {
+    HashEmbeddingProvider::new(DIM).embed(text).unwrap()
+}
+
+fn open(cfg: CognitiveConfig) -> (MenteDb, tempfile::TempDir) {
+    let dir = tempfile::tempdir().unwrap();
+    let db = MenteDb::open_with_embedder_and_config(
+        dir.path(),
+        Box::new(HashEmbeddingProvider::new(DIM)),
+        cfg,
+    )
+    .unwrap();
+    (db, dir)
+}
+
+/// Store a memory, embedding the contextualized text (the way a caller using the
+/// contextual hook should), with optional context, project tag, and extra tags.
+fn store(db: &MenteDb, content: &str, context: Option<&str>, project: Option<&str>) -> MemoryId {
+    let mut node = MemoryNode::new(
+        AgentId::nil(),
+        MemoryType::Semantic,
+        content.to_string(),
+        vec![],
+    );
+    if let Some(ctx) = context {
+        node = node.with_context(ctx);
+    }
+    if let Some(p) = project {
+        node.tags.push(format!("scope:project:{p}"));
+    }
+    node.embedding = emb(&node.indexed_text());
+    let id = node.id;
+    db.store(node).unwrap();
+    id
+}
+
+fn recall_ids(db: &MenteDb, query_text: &str, k: usize, project: Option<&str>) -> Vec<MemoryId> {
+    db.recall_hybrid_at(
+        &emb(query_text),
+        Some(query_text),
+        k,
+        now_us(),
+        None,
+        None,
+        project,
+    )
+    .unwrap()
+    .into_iter()
+    .map(|(id, _)| id)
+    .collect()
+}
+
+/// Contextual hook: a memory whose content never mentions the query terms is
+/// still found because the caller-supplied context, indexed and embedded
+/// alongside it, carries them.
+#[test]
+fn contextual_hook_surfaces_situated_memory() {
+    let (db, _dir) = open(CognitiveConfig::default());
+    let target = store(
+        &db,
+        "rolled back to the previous release tag",
+        Some("resolving the payments service outage"),
+        None,
+    );
+    store(&db, "updated the office wifi password", None, None);
+    store(&db, "scheduled the quarterly planning offsite", None, None);
+
+    let hits = recall_ids(&db, "payments outage", 3, None);
+    assert!(
+        hits.contains(&target),
+        "a memory situated by its context must be found by context-only terms"
+    );
+    // The stored content is exactly what was written; context never leaks in.
+    assert_eq!(
+        db.get_memory(target).unwrap().content,
+        "rolled back to the previous release tag"
+    );
+}
+
+/// MMR: three near-duplicate memories plus one distinct. Without MMR the near
+/// duplicates crowd the top; with MMR the distinct memory is pulled in.
+#[test]
+fn mmr_pulls_in_a_distinct_memory() {
+    let dup_a = "the deployment pipeline uses blue green releases";
+    let dup_b = "our deploy pipeline does blue green deployments";
+    let dup_c = "blue green deployment is how the pipeline ships";
+    let distinct = "the on call rotation hands off every monday";
+    let query = "how do we deploy";
+
+    // Default: MMR off. The near-duplicates dominate the top 2.
+    let (db, _dir) = open(CognitiveConfig::default());
+    store(&db, dup_a, None, None);
+    store(&db, dup_b, None, None);
+    store(&db, dup_c, None, None);
+    let distinct_id = store(&db, distinct, None, None);
+    let base = recall_ids(&db, query, 2, None);
+    assert!(
+        !base.contains(&distinct_id),
+        "without MMR the near-duplicate deploy notes fill the top"
+    );
+
+    // MMR on: the distinct memory earns a slot.
+    let (db2, _dir2) = open(CognitiveConfig {
+        mmr_lambda: 0.5,
+        ..CognitiveConfig::default()
+    });
+    store(&db2, dup_a, None, None);
+    store(&db2, dup_b, None, None);
+    store(&db2, dup_c, None, None);
+    let distinct_id2 = store(&db2, distinct, None, None);
+    let diversified = recall_ids(&db2, query, 3, None);
+    assert!(
+        diversified.contains(&distinct_id2),
+        "MMR should surface the distinct memory over redundant duplicates"
+    );
+}
+
+/// Pluggable reranker on the main hybrid path: an installed reranker's ordering
+/// wins over the first pass.
+#[test]
+fn reranker_drives_final_order() {
+    struct PromotePinned;
+    impl Reranker for PromotePinned {
+        fn rerank(&self, _q: &str, cands: &[RerankCandidate<'_>]) -> Vec<(MemoryId, f32)> {
+            cands
+                .iter()
+                .map(|c| {
+                    (
+                        c.id,
+                        if c.content.contains("PINNED") {
+                            1.0
+                        } else {
+                            0.0
+                        },
+                    )
+                })
+                .collect()
+        }
+    }
+
+    let (mut db, _dir) = open(CognitiveConfig::default());
+    let pinned = store(&db, "PINNED note about the retrieval roadmap", None, None);
+    store(
+        &db,
+        "a much closer note about the retrieval roadmap",
+        None,
+        None,
+    );
+
+    db.set_reranker(Box::new(PromotePinned));
+    let hits = recall_ids(&db, "retrieval roadmap", 2, None);
+    assert_eq!(
+        hits.first().copied(),
+        Some(pinned),
+        "the reranker must decide the top slot"
+    );
+}
+
+/// Project scope weighting: with a current project, same-topic memories from that
+/// project outrank ones tagged for a different project.
+#[test]
+fn scope_weight_prefers_current_project() {
+    let (db, _dir) = open(CognitiveConfig::default());
+    // Same topic, but distinct wording per project so their embeddings differ
+    // (identical vectors can orphan an HNSW node, which is a separate quirk from
+    // the scope weighting under test).
+    let in_project = store(
+        &db,
+        "the api gateway rate limit is a thousand requests per minute for alpha",
+        None,
+        Some("alpha"),
+    );
+    let other_project = store(
+        &db,
+        "the api gateway rate limit caps at a thousand requests each minute for beta",
+        None,
+        Some("beta"),
+    );
+
+    let hits = recall_ids(&db, "api gateway rate limit", 2, Some("alpha"));
+    let pos = |id: MemoryId| hits.iter().position(|h| *h == id);
+    assert!(
+        pos(in_project) < pos(other_project),
+        "the current project's memory must rank above the other project's: {hits:?}"
+    );
+    // Searching across all projects (no current project) does not penalize either.
+    let all = recall_ids(&db, "api gateway rate limit", 2, None);
+    assert!(all.contains(&in_project) && all.contains(&other_project));
+}


### PR DESCRIPTION
## Summary
- Adds a holistic internal test of the retrieval features shipped in 0.22-0.23, and brings the docs and architecture diagram up to date with them.

## Internal test (`tests/retrieval_stack.rs`)
Runs against a real (deterministic hash) embedder and the full hybrid recall path, validating all four together:
- Contextual hook: a memory is found by terms only in its context; stored content stays unchanged.
- MMR: a distinct memory is pulled in over near-duplicates when `mmr_lambda < 1.0`.
- Reranker: an installed reranker decides the top slot.
- Scope weighting: the current project's memory outranks another project's; searching all projects penalizes neither.

## Docs
- README feature list: expanded Hybrid Retrieval, added Contextual Retrieval and Project Scope Weighting bullets.
- README architecture diagram: retrieval pipeline now shows scope weighting, the reranker, and MMR; BM25 node marked context-aware.
- ARCHITECTURE.md: documents the BM25 index (was omitted), replaces the stale scoring formula with the real RRF-plus-optional-stages pipeline, and updates the crate list.

## Verification
- `cargo test -p mentedb --test retrieval_stack` green (4/4); full `cargo test --workspace` green.