### PR TITLE
feat: supersession_history API for previous-value questions

### DIFF
--- a/crates/mentedb/src/lib.rs
+++ b/crates/mentedb/src/lib.rs
@@ -1431,6 +1431,45 @@ impl MenteDb {
         self.storage.load_memory(page_id)
     }
 
+    /// The supersession history of a memory: the chain of older versions this
+    /// fact replaced, newest predecessor first, walked over `Supersedes` edges
+    /// (source = newer, target = replaced) up to `max_depth` hops.
+    ///
+    /// The engine keeps superseded memories bi-temporally but recall hides
+    /// them, which makes "what was my previous X" unanswerable downstream even
+    /// though the answer is stored. This surfaces it: callers can attach the
+    /// predecessors of a recalled fact ("phone number is 4321, previously
+    /// 1234") without re-deriving graph internals. Cycle-guarded; a memory
+    /// with no history returns an empty vec.
+    pub fn supersession_history(
+        &self,
+        id: MemoryId,
+        max_depth: usize,
+    ) -> MenteResult<Vec<MemoryNode>> {
+        let graph = self.graph.graph();
+        let mut history = Vec::new();
+        let mut seen = std::collections::HashSet::from([id]);
+        let mut current = id;
+        for _ in 0..max_depth {
+            let mut next: Option<MemoryId> = None;
+            for (target, edge) in graph.outgoing(current) {
+                if edge.edge_type == EdgeType::Supersedes && !seen.contains(&target) {
+                    next = Some(target);
+                    break;
+                }
+            }
+            let Some(prev) = next else { break };
+            seen.insert(prev);
+            match self.get_memory(prev) {
+                Ok(node) => history.push(node),
+                // A dangling edge (predecessor forgotten) ends the chain.
+                Err(_) => break,
+            }
+            current = prev;
+        }
+        Ok(history)
+    }
+
     /// Returns all memory IDs currently stored in the database.
     pub fn memory_ids(&self) -> Vec<MemoryId> {
         self.page_map.read().keys().copied().collect()

--- a/crates/mentedb/tests/supersession_history.rs
+++ b/crates/mentedb/tests/supersession_history.rs
@@ -1,0 +1,83 @@
+//! Supersession history: the chain of replaced versions behind a fact is
+//! reachable through a public API, so "what was my previous X" is answerable
+//! downstream (the stored data always had it; recall alone hides it).
+
+use mentedb::MenteDb;
+use mentedb::prelude::*;
+
+fn now_us() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_micros() as u64
+}
+
+fn fact(agent: AgentId, content: &str, at: u64) -> MemoryNode {
+    let mut n = MemoryNode::new(
+        agent,
+        MemoryType::Semantic,
+        content.into(),
+        vec![1.0, 0.05, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+    );
+    n.created_at = at;
+    n
+}
+
+#[test]
+fn history_walks_the_supersession_chain() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = MenteDb::open(dir.path()).unwrap();
+    let agent = AgentId::new();
+    let t = now_us();
+
+    // Three generations of the same fact; the value-update rule chains the
+    // supersessions at store time.
+    let v1 = fact(agent, "My phone number is 1111", t);
+    let v1_id = v1.id;
+    db.store(v1).unwrap();
+    let v2 = fact(agent, "My phone number is 2222", t + 1);
+    let v2_id = v2.id;
+    db.store(v2).unwrap();
+    let v3 = fact(agent, "My phone number is 3333", t + 2);
+    let v3_id = v3.id;
+    db.store(v3).unwrap();
+
+    let history = db.supersession_history(v3_id, 5).unwrap();
+    let ids: Vec<MemoryId> = history.iter().map(|n| n.id).collect();
+    assert!(
+        ids.contains(&v2_id),
+        "history must contain the direct predecessor, got {ids:?}"
+    );
+    // The chain shape depends on which candidate the value-update rule picked
+    // per store, but the oldest version must be reachable through the walk.
+    let full: Vec<String> = history.iter().map(|n| n.content.clone()).collect();
+    assert!(
+        ids.contains(&v1_id) || full.iter().any(|c| c.contains("1111")),
+        "the oldest version should be reachable in the chain, got {full:?}"
+    );
+
+    // A memory with no predecessors has an empty history.
+    let fresh = fact(agent, "The office wifi password rotates monthly", t + 3);
+    let fresh_id = fresh.id;
+    db.store(fresh).unwrap();
+    assert!(db.supersession_history(fresh_id, 5).unwrap().is_empty());
+}
+
+#[test]
+fn history_respects_depth_cap() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = MenteDb::open(dir.path()).unwrap();
+    let agent = AgentId::new();
+    let t = now_us();
+
+    let v1 = fact(agent, "My desk is number 11", t);
+    db.store(v1).unwrap();
+    let v2 = fact(agent, "My desk is number 22", t + 1);
+    db.store(v2).unwrap();
+    let v3 = fact(agent, "My desk is number 33", t + 2);
+    let v3_id = v3.id;
+    db.store(v3).unwrap();
+
+    assert!(db.supersession_history(v3_id, 1).unwrap().len() <= 1);
+    assert!(db.supersession_history(v3_id, 0).unwrap().is_empty());
+}


### PR DESCRIPTION
## Summary
- Fixes #338: the chain of older versions behind a fact is now reachable through a public API, `MenteDb::supersession_history(id, max_depth)`.

## Why
The engine keeps superseded memories bi-temporally and hides them from recall, which is correct for context hygiene but made "what was my previous phone number" unanswerable downstream even though the answer is stored (live-reproduced on the demo). Consumers (the platform's process_turn context assembly, the demo's answer layer) can now attach predecessors to a recalled fact: "number is 4321, previously 1234".

## Design
- Walks outgoing `Supersedes` edges (source = newer, target = replaced), newest predecessor first, depth-capped, cycle-guarded; a dangling edge (forgotten predecessor) ends the chain cleanly.
- Pairs with #341: value-update corrections now create these chains automatically, so the API has real data the moment a correction happens.

## Verification
- New `tests/supersession_history.rs`: a three-generation corrected fact exposes its chain; fresh memories return empty; depth cap respected (including 0).
- `cargo test -p mentedb` green, clippy clean, fmt applied.