### PR TITLE
perf(recall): fetch scope:always via the tag index, not a full page scan

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2242,7 +2242,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb"
-version = "0.24.4"
+version = "0.24.5"
 dependencies = [
  "criterion",
  "mentedb-cognitive",
@@ -2267,7 +2267,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-cli"
-version = "0.24.4"
+version = "0.24.5"
 dependencies = [
  "mentedb",
  "reqwest",
@@ -2276,7 +2276,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-cognitive"
-version = "0.24.4"
+version = "0.24.5"
 dependencies = [
  "ahash 0.8.12",
  "criterion",
@@ -2294,7 +2294,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-consolidation"
-version = "0.24.4"
+version = "0.24.5"
 dependencies = [
  "ahash 0.8.12",
  "mentedb-core",
@@ -2306,7 +2306,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-context"
-version = "0.24.4"
+version = "0.24.5"
 dependencies = [
  "ahash 0.8.12",
  "mentedb-core",
@@ -2318,7 +2318,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-core"
-version = "0.24.4"
+version = "0.24.5"
 dependencies = [
  "ahash 0.8.12",
  "bytemuck",
@@ -2333,7 +2333,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-embedding"
-version = "0.24.4"
+version = "0.24.5"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -2356,7 +2356,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-extraction"
-version = "0.24.4"
+version = "0.24.5"
 dependencies = [
  "chrono",
  "hmac",
@@ -2375,7 +2375,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-graph"
-version = "0.24.4"
+version = "0.24.5"
 dependencies = [
  "ahash 0.8.12",
  "bincode",
@@ -2392,7 +2392,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-index"
-version = "0.24.4"
+version = "0.24.5"
 dependencies = [
  "ahash 0.8.12",
  "bincode",
@@ -2410,7 +2410,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-query"
-version = "0.24.4"
+version = "0.24.5"
 dependencies = [
  "mentedb-core",
  "serde",
@@ -2422,7 +2422,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-replication"
-version = "0.24.4"
+version = "0.24.5"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -2443,7 +2443,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-server"
-version = "0.24.4"
+version = "0.24.5"
 dependencies = [
  "anyhow",
  "axum",
@@ -2475,7 +2475,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-storage"
-version = "0.24.4"
+version = "0.24.5"
 dependencies = [
  "ahash 0.8.12",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.24.4"
+version = "0.24.5"
 edition = "2024"
 authors = ["Nam Rodriguez <nambok@gmail.com>"]
 license = "Apache-2.0"

--- a/crates/mentedb/src/process_turn.rs
+++ b/crates/mentedb/src/process_turn.rs
@@ -398,15 +398,18 @@ impl MenteDb {
             })
             .collect();
 
-        // Append always-scoped memories (not already in results)
+        // Append always-scoped memories not already recalled. Fetch them from the
+        // tag index (scope:always is capped near-zero), loading only the handful
+        // of matches. The old path scanned every page and called load_memory for
+        // every memory on each turn, which thrashed the buffer pool against disk
+        // on large accounts and dominated turn latency.
         let hybrid_ids: std::collections::HashSet<MemoryId> =
             scored.iter().map(|sm| sm.memory.id).collect();
-        let always_scope_tag = "scope:always";
-        let pm = self.page_map.read();
-        for pid in pm.values() {
-            if let Ok(mem) = self.storage.load_memory(*pid)
-                && mem.tags.iter().any(|t| t == always_scope_tag)
-                && !hybrid_ids.contains(&mem.id)
+        for mid in self.index.bitmap.query_tag("scope:always") {
+            if hybrid_ids.contains(&mid) {
+                continue;
+            }
+            if let Ok(mem) = self.get_memory(mid)
                 && crate::agent_visible(mem.agent_id, agent)
                 && crate::user_visible(mem.user_id, user)
             {
@@ -416,7 +419,6 @@ impl MenteDb {
                 });
             }
         }
-        drop(pm);
 
         let ids: Vec<MemoryId> = scored.iter().map(|sm| sm.memory.id).collect();
         Ok((scored, ids, false))


### PR DESCRIPTION
## Summary
`retrieve_context` appended standing rules by scanning every page and calling `load_memory` for each memory on every turn. On large accounts this thrashed the buffer pool against disk and dominated turn latency: a 13k-memory account spent ~1.6s of a 2.3s turn in this single loop, while a 400-memory account (fits in the pool) did not.

## Changes
- Replace the full page scan in `retrieve_context` with `self.index.bitmap.query_tag("scope:always")`, loading only the matches. This is the same authoritative tag-index path the engine already uses in `is_duplicate_standing_rule`. `scope:always` is capped near-zero, so this is effectively O(1).
- Bump workspace version to 0.24.5.

Behavior is unchanged: the same standing rules are returned, still owner-scoped and deduped against the hybrid results.

## Verification
- `cargo fmt --all`, `cargo clippy --workspace -- -D warnings`: clean.
- `cargo test -p mentedb`: 179 passed (15 suites).