### PR TITLE
feat: embedder calibration, dedup sweep, and recall/ingest turn split

### DIFF
--- a/crates/mentedb/src/calibration.rs
+++ b/crates/mentedb/src/calibration.rs
@@ -1,0 +1,408 @@
+//! Embedder self-calibration for cosine-based cognitive thresholds.
+//!
+//! Absolute cosine thresholds are embedder-coupled: the same paraphrase pair
+//! lands near 0.67 on one embedder and 0.80 on another, so a constant like
+//! 0.97 silently disables deduplication on every real embedder (measured in
+//! production, and the same failure previously disabled value-update
+//! supersession at 0.88). Instead of hand-tuning constants per embedder, this
+//! module embeds a small built-in probe set once per embedder and derives the
+//! operating thresholds from the measured score distributions. Calibration is
+//! persisted next to the database keyed by model and dimension, so it runs
+//! once per embedder and self-heals on any embedder swap.
+//!
+//! Derivation is distribution-relative, never absolute: the dedup cosine sits
+//! just below the paraphrase distribution while staying above measured
+//! unrelated noise, and the topical floor (the loosest gate the value-update
+//! rule uses) is the unrelated noise ceiling itself. When an embedder cannot
+//! separate paraphrase from unrelated (a hash or degenerate provider),
+//! calibration reports failure and callers keep their configured defaults.
+
+use std::path::{Path, PathBuf};
+
+use mentedb_core::error::{MenteError, MenteResult};
+use mentedb_embedding::provider::EmbeddingProvider;
+use serde::{Deserialize, Serialize};
+use tracing::info;
+
+/// Version of the built-in probe set. Bump when the probe sentences change so
+/// stored calibrations recompute instead of describing an older probe set.
+pub const PROBE_VERSION: u32 = 1;
+
+/// Minimum separation between the paraphrase p25 and unrelated p95 for the
+/// embedder to count as calibratable. Below this the distributions overlap and
+/// derived thresholds would be noise.
+const MIN_SEPARATION: f32 = 0.05;
+
+/// How far below the paraphrase p25 the dedup cosine sits, so the bulk of the
+/// paraphrase distribution clears the gate rather than only its upper half.
+const PARAPHRASE_MARGIN: f32 = 0.05;
+
+/// How far above the unrelated p95 the dedup cosine must stay, so measured
+/// noise never counts as a paraphrase even when the margins collide.
+const NOISE_MARGIN: f32 = 0.02;
+
+/// Sentence pairs that state the same fact in different words. Dedup must
+/// catch these.
+pub(crate) const PARAPHRASE_PAIRS: &[(&str, &str)] = &[
+    (
+        "The user prefers dark mode in every editor",
+        "The user likes their editors set to dark mode",
+    ),
+    (
+        "Standup is at 9:30 every weekday morning",
+        "Every weekday the standup happens at 9:30 in the morning",
+    ),
+    (
+        "The production database runs Postgres 16",
+        "Postgres 16 is what the production database runs",
+    ),
+    (
+        "Sarah leads the payments team",
+        "The payments team is led by Sarah",
+    ),
+    (
+        "Deploys go out on Friday afternoons",
+        "The team ships deploys Friday afternoon",
+    ),
+    (
+        "The user is allergic to peanuts",
+        "Peanuts trigger the user's allergy",
+    ),
+    (
+        "The API rate limit is one hundred requests per minute",
+        "Clients may send at most one hundred requests a minute to the API",
+    ),
+    (
+        "The user's favorite coffee is a latte",
+        "A latte is the user's coffee of choice",
+    ),
+    (
+        "Error budgets reset on the first of the month",
+        "On the first of each month the error budget resets",
+    ),
+    (
+        "The mobile app is written in Kotlin",
+        "Kotlin is the language of the mobile app",
+    ),
+    (
+        "Meetings are documented in the shared wiki",
+        "The shared wiki holds the meeting notes",
+    ),
+    (
+        "The user commutes by bicycle on dry days",
+        "On dry days the user bikes to work",
+    ),
+];
+
+/// Sentence pairs with no semantic relationship. Their cosine distribution is
+/// the embedder's noise floor.
+pub(crate) const UNRELATED_PAIRS: &[(&str, &str)] = &[
+    (
+        "The user prefers dark mode in every editor",
+        "The quarterly tax filing is due in April",
+    ),
+    (
+        "Standup is at 9:30 every weekday morning",
+        "The cat needs a rabies booster next year",
+    ),
+    (
+        "Postgres 16 is what the production database runs",
+        "Flights to Lisbon are cheapest in February",
+    ),
+    (
+        "Sarah leads the payments team",
+        "The garage door opener needs new batteries",
+    ),
+    (
+        "Deploys go out on Friday afternoons",
+        "Basil grows best with six hours of sunlight",
+    ),
+    (
+        "The user is allergic to peanuts",
+        "The staging cluster autoscaled to four nodes",
+    ),
+    (
+        "The API rate limit is one hundred requests per minute",
+        "Grandma's birthday dinner is at the Italian place",
+    ),
+    (
+        "The user's favorite coffee is a latte",
+        "The linter forbids unused imports in CI",
+    ),
+    (
+        "Error budgets reset on the first of the month",
+        "The marathon route crosses two bridges",
+    ),
+    (
+        "The mobile app is written in Kotlin",
+        "Rent is due on the third of the month",
+    ),
+    (
+        "Meetings are documented in the shared wiki",
+        "The aquarium filter hums when it needs cleaning",
+    ),
+    (
+        "The user commutes by bicycle on dry days",
+        "Invoices over five thousand need a second approval",
+    ),
+    (
+        "The retro board uses three columns",
+        "The user's daughter plays goalkeeper on Saturdays",
+    ),
+    (
+        "Feature flags live in the settings service",
+        "The soup needs more salt near the end of cooking",
+    ),
+];
+
+/// Thresholds derived from an embedder's measured score distributions.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EmbedderCalibration {
+    /// Embedder model the calibration describes.
+    pub model: String,
+    /// Embedding dimension the calibration describes.
+    pub dimensions: usize,
+    /// Probe set version the calibration was computed against.
+    pub probe_version: u32,
+    /// 25th percentile of paraphrase-pair cosines.
+    pub paraphrase_p25: f32,
+    /// 95th percentile of unrelated-pair cosines (the noise ceiling).
+    pub unrelated_p95: f32,
+    /// Operating cosine gate for paraphrase deduplication.
+    pub dedup_cosine: f32,
+    /// Loosest topical gate: text less similar than this is noise. Used as
+    /// the value-update similarity floor.
+    pub topical_floor: f32,
+}
+
+/// Nearest-rank percentile of an unsorted sample.
+fn percentile(values: &mut [f32], q: f32) -> f32 {
+    if values.is_empty() {
+        return 0.0;
+    }
+    values.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let idx = ((values.len() - 1) as f32 * q).round() as usize;
+    values[idx.min(values.len() - 1)]
+}
+
+fn cosine(a: &[f32], b: &[f32]) -> f32 {
+    if a.len() != b.len() || a.is_empty() {
+        return 0.0;
+    }
+    let dot: f32 = a.iter().zip(b).map(|(x, y)| x * y).sum();
+    let na: f32 = a.iter().map(|x| x * x).sum::<f32>().sqrt();
+    let nb: f32 = b.iter().map(|x| x * x).sum::<f32>().sqrt();
+    if na == 0.0 || nb == 0.0 {
+        return 0.0;
+    }
+    dot / (na * nb)
+}
+
+/// Embed the probe set and derive operating thresholds. Errors when the
+/// embedder fails or cannot separate paraphrase from unrelated noise; callers
+/// keep their configured defaults in that case.
+pub fn calibrate(embedder: &dyn EmbeddingProvider) -> MenteResult<EmbedderCalibration> {
+    let texts: Vec<&str> = PARAPHRASE_PAIRS
+        .iter()
+        .chain(UNRELATED_PAIRS.iter())
+        .flat_map(|(a, b)| [*a, *b])
+        .collect();
+    let vectors = embedder.embed_batch(&texts)?;
+    if vectors.len() != texts.len() {
+        return Err(MenteError::Index(format!(
+            "calibration embed returned {} vectors for {} probes",
+            vectors.len(),
+            texts.len()
+        )));
+    }
+
+    let pair_cosines = |offset: usize, count: usize| -> Vec<f32> {
+        (0..count)
+            .map(|i| cosine(&vectors[offset + 2 * i], &vectors[offset + 2 * i + 1]))
+            .collect()
+    };
+    let mut para = pair_cosines(0, PARAPHRASE_PAIRS.len());
+    let mut unrel = pair_cosines(PARAPHRASE_PAIRS.len() * 2, UNRELATED_PAIRS.len());
+
+    let paraphrase_p25 = percentile(&mut para, 0.25);
+    let unrelated_p95 = percentile(&mut unrel, 0.95);
+
+    if paraphrase_p25 < unrelated_p95 + MIN_SEPARATION {
+        return Err(MenteError::Index(format!(
+            "embedder does not separate paraphrase from noise (paraphrase p25 {paraphrase_p25:.3}, unrelated p95 {unrelated_p95:.3}); keeping configured thresholds"
+        )));
+    }
+
+    let dedup_cosine = (paraphrase_p25 - PARAPHRASE_MARGIN).max(unrelated_p95 + NOISE_MARGIN);
+    Ok(EmbedderCalibration {
+        model: embedder.model_name().to_string(),
+        dimensions: embedder.dimensions(),
+        probe_version: PROBE_VERSION,
+        paraphrase_p25,
+        unrelated_p95,
+        dedup_cosine,
+        topical_floor: unrelated_p95,
+    })
+}
+
+/// File the calibration persists to, keyed by probe version, model, and
+/// dimension so an embedder swap recomputes instead of reusing stale numbers.
+fn calibration_path(dir: &Path, model: &str, dimensions: usize) -> PathBuf {
+    let slug: String = model
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+        .collect();
+    dir.join(format!(
+        ".embedder_calibration_v{PROBE_VERSION}_{slug}_{dimensions}.json"
+    ))
+}
+
+/// Load a stored calibration for this embedder, or compute and persist one.
+/// A failed save still returns the computed calibration; a failed computation
+/// propagates so the caller can fall back to configured defaults.
+pub fn load_or_calibrate(
+    dir: &Path,
+    embedder: &dyn EmbeddingProvider,
+) -> MenteResult<EmbedderCalibration> {
+    let path = calibration_path(dir, embedder.model_name(), embedder.dimensions());
+    if let Ok(raw) = std::fs::read_to_string(&path)
+        && let Ok(cal) = serde_json::from_str::<EmbedderCalibration>(&raw)
+        && cal.probe_version == PROBE_VERSION
+        && cal.dimensions == embedder.dimensions()
+    {
+        return Ok(cal);
+    }
+    let cal = calibrate(embedder)?;
+    match serde_json::to_string_pretty(&cal) {
+        Ok(json) => {
+            if let Err(e) = std::fs::write(&path, json) {
+                tracing::warn!(error = %e, "calibration computed but not persisted");
+            }
+        }
+        Err(e) => tracing::warn!(error = %e, "calibration serialize failed"),
+    }
+    info!(
+        model = %cal.model,
+        dedup_cosine = cal.dedup_cosine,
+        topical_floor = cal.topical_floor,
+        "embedder calibration computed"
+    );
+    Ok(cal)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    /// Deterministic provider mapping each probe text to a designed vector:
+    /// both halves of a paraphrase pair share one basis vector, unrelated
+    /// halves get mutually orthogonal vectors.
+    struct DesignedProvider {
+        vectors: HashMap<String, Vec<f32>>,
+        dims: usize,
+    }
+
+    impl DesignedProvider {
+        fn separable() -> Self {
+            let dims = 2 * (PARAPHRASE_PAIRS.len() + 2 * UNRELATED_PAIRS.len());
+            let mut vectors = HashMap::new();
+            let basis = |i: usize| -> Vec<f32> {
+                let mut v = vec![0.0; dims];
+                v[i] = 1.0;
+                v
+            };
+            for (i, (a, b)) in PARAPHRASE_PAIRS.iter().enumerate() {
+                // Same direction with a slight tilt: cosine near but below 1.
+                let va = basis(i);
+                let mut vb = basis(i);
+                vb[dims - 1] = 0.3;
+                vectors.insert((*a).to_string(), va);
+                vectors.entry((*b).to_string()).or_insert(vb);
+            }
+            let base = PARAPHRASE_PAIRS.len();
+            for (j, (a, b)) in UNRELATED_PAIRS.iter().enumerate() {
+                vectors
+                    .entry((*a).to_string())
+                    .or_insert_with(|| basis(base + 2 * j));
+                vectors
+                    .entry((*b).to_string())
+                    .or_insert_with(|| basis(base + 2 * j + 1));
+            }
+            Self { vectors, dims }
+        }
+
+        /// Every text maps to the same vector: paraphrase and unrelated
+        /// cosines are all 1.0, which no threshold can separate.
+        fn degenerate() -> Self {
+            let mut vectors = HashMap::new();
+            for (a, b) in PARAPHRASE_PAIRS.iter().chain(UNRELATED_PAIRS.iter()) {
+                vectors.insert((*a).to_string(), vec![1.0, 0.0]);
+                vectors.insert((*b).to_string(), vec![1.0, 0.0]);
+            }
+            Self { vectors, dims: 2 }
+        }
+    }
+
+    impl EmbeddingProvider for DesignedProvider {
+        fn embed(&self, text: &str) -> MenteResult<Vec<f32>> {
+            Ok(self
+                .vectors
+                .get(text)
+                .cloned()
+                .unwrap_or_else(|| vec![0.0; self.dims]))
+        }
+
+        fn embed_batch(&self, texts: &[&str]) -> MenteResult<Vec<Vec<f32>>> {
+            texts.iter().map(|t| self.embed(t)).collect()
+        }
+
+        fn dimensions(&self) -> usize {
+            self.dims
+        }
+
+        fn model_name(&self) -> &str {
+            "designed-test-provider"
+        }
+    }
+
+    #[test]
+    fn separable_provider_calibrates() {
+        let cal = calibrate(&DesignedProvider::separable()).expect("calibratable");
+        // Paraphrase pairs sit near 1.0, unrelated near 0.0.
+        assert!(cal.paraphrase_p25 > 0.9);
+        assert!(cal.unrelated_p95 < 0.1);
+        assert!(cal.dedup_cosine > cal.topical_floor);
+        assert!(cal.dedup_cosine < cal.paraphrase_p25);
+        assert_eq!(cal.probe_version, PROBE_VERSION);
+    }
+
+    #[test]
+    fn degenerate_provider_fails_closed() {
+        assert!(calibrate(&DesignedProvider::degenerate()).is_err());
+    }
+
+    #[test]
+    fn calibration_roundtrips_through_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let provider = DesignedProvider::separable();
+        let first = load_or_calibrate(dir.path(), &provider).expect("calibrate");
+        // Second load must come from the file, not a recompute; equality of
+        // every derived field is the observable.
+        let second = load_or_calibrate(dir.path(), &provider).expect("load");
+        assert_eq!(first.dedup_cosine, second.dedup_cosine);
+        assert_eq!(first.topical_floor, second.topical_floor);
+        assert!(
+            calibration_path(dir.path(), provider.model_name(), provider.dimensions()).exists()
+        );
+    }
+
+    #[test]
+    fn percentile_nearest_rank() {
+        let mut v = vec![0.9, 0.1, 0.5, 0.3, 0.7];
+        assert!((percentile(&mut v, 0.5) - 0.5).abs() < f32::EPSILON);
+        assert!((percentile(&mut v.clone(), 0.0) - 0.1).abs() < f32::EPSILON);
+        assert!((percentile(&mut v.clone(), 1.0) - 0.9).abs() < f32::EPSILON);
+        assert_eq!(percentile(&mut [], 0.5), 0.0);
+    }
+}

--- a/crates/mentedb/src/lib.rs
+++ b/crates/mentedb/src/lib.rs
@@ -101,6 +101,10 @@ pub mod process_turn;
 /// Engine-native injection attention (selection policy for context injection).
 pub mod injection;
 
+/// Embedder self-calibration: cosine thresholds derived from measured score
+/// distributions instead of embedder-coupled absolute constants.
+pub mod calibration;
+
 /// LLM-driven memory consolidation (semantic dedup via a pluggable LlmJudge).
 pub mod llm_consolidation;
 pub use llm_consolidation::ConsolidationParams;
@@ -394,6 +398,14 @@ pub struct CognitiveConfig {
     /// gate). Value updates share a frame but swap a value token, which drops
     /// them below this and keeps them storable.
     pub memory_dedup_token_overlap: f32,
+    /// Whether to derive the cosine-based thresholds (paraphrase dedup,
+    /// standing-rule dedup, value-update floor) from the installed embedder's
+    /// measured score distributions at open. Absolute cosine constants are
+    /// embedder-coupled and have twice silently disabled cognition in
+    /// production; calibration replaces them with distribution-derived values
+    /// and keeps the configured defaults when the embedder cannot separate
+    /// paraphrase from noise.
+    pub calibration_enabled: bool,
 }
 
 impl Default for CognitiveConfig {
@@ -431,6 +443,7 @@ impl Default for CognitiveConfig {
             memory_dedup: true,
             memory_dedup_threshold: 0.97,
             memory_dedup_token_overlap: 0.85,
+            calibration_enabled: true,
         }
     }
 }
@@ -466,6 +479,9 @@ pub struct MenteDb {
     path: PathBuf,
     /// Optional embedding provider for auto-embedding on store and search.
     embedder: Option<Box<dyn EmbeddingProvider>>,
+    /// Distribution-derived thresholds for the installed embedder, when
+    /// calibration succeeded. None means configured defaults are in effect.
+    calibration: Option<calibration::EmbedderCalibration>,
     /// Optional second-pass reranker applied to the fused candidate pool on the
     /// hybrid recall path. None (the default) leaves recall a pure vector/BM25 +
     /// decay ranking; when set, a larger pool is fetched and reordered by this
@@ -642,6 +658,7 @@ impl MenteDb {
             embedding_dim: 0,
             path: path.to_path_buf(),
             embedder: None,
+            calibration: None,
             reranker: None,
             cognitive_config,
             write_inference,
@@ -669,6 +686,7 @@ impl MenteDb {
         let mut db = Self::open(path)?;
         db.embedding_dim = embedder.dimensions();
         db.embedder = Some(embedder);
+        db.apply_calibration();
         Ok(db)
     }
 
@@ -681,6 +699,7 @@ impl MenteDb {
         let mut db = Self::open_with_config(path, cognitive_config)?;
         db.embedding_dim = embedder.dimensions();
         db.embedder = Some(embedder);
+        db.apply_calibration();
         Ok(db)
     }
 
@@ -688,6 +707,45 @@ impl MenteDb {
     pub fn set_embedder(&mut self, embedder: Box<dyn EmbeddingProvider>) {
         self.embedding_dim = embedder.dimensions();
         self.embedder = Some(embedder);
+        self.apply_calibration();
+    }
+
+    /// The distribution-derived thresholds in effect for the installed
+    /// embedder, when calibration succeeded. None means configured defaults.
+    pub fn calibration(&self) -> Option<&calibration::EmbedderCalibration> {
+        self.calibration.as_ref()
+    }
+
+    /// Replace the cosine-coupled thresholds with values derived from the
+    /// installed embedder's measured score distributions (see [`calibration`]).
+    /// The stored file makes this a one-time cost per embedder; a swap to a
+    /// different model or dimension recomputes automatically. On any failure
+    /// (embedder down, or a provider whose paraphrase and noise distributions
+    /// overlap, like the hash test provider) the configured defaults stay in
+    /// effect, so tests and degraded environments keep deterministic behavior.
+    fn apply_calibration(&mut self) {
+        if !self.cognitive_config.calibration_enabled {
+            return;
+        }
+        let Some(embedder) = self.embedder.as_deref() else {
+            return;
+        };
+        match calibration::load_or_calibrate(&self.path, embedder) {
+            Ok(cal) => {
+                self.cognitive_config.memory_dedup_threshold = cal.dedup_cosine;
+                self.cognitive_config.always_dedup_threshold = cal.dedup_cosine;
+                self.cognitive_config
+                    .inference_config
+                    .value_update_min_similarity = cal.topical_floor;
+                self.write_inference = WriteInferenceEngine::with_config(
+                    self.cognitive_config.inference_config.clone(),
+                );
+                self.calibration = Some(cal);
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "embedder calibration unavailable, keeping configured thresholds");
+            }
+        }
     }
 
     /// Install a second-pass [`Reranker`](crate::reranker::Reranker) applied to
@@ -829,6 +887,14 @@ impl MenteDb {
     /// `memory_dedup_token_overlap`, the two-gate design that keeps genuine
     /// value updates storable.
     fn is_paraphrase_duplicate(&self, node: &MemoryNode) -> bool {
+        self.find_paraphrase_duplicate_of(node).is_some()
+    }
+
+    /// The stored memory `node` duplicates, if any: same owner, same scope
+    /// tags, cosine at the (calibrated) dedup gate AND token-set jaccard at
+    /// the overlap gate. Shared by the write-time skip and the retroactive
+    /// sweep so both apply identical policy.
+    fn find_paraphrase_duplicate_of(&self, node: &MemoryNode) -> Option<MemoryId> {
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
@@ -845,11 +911,11 @@ impl MenteDb {
             Some(node.user_id),
             None,
         ) else {
-            return false;
+            return None;
         };
         let new_tokens = Self::token_set(&node.content);
         if new_tokens.is_empty() {
-            return false;
+            return None;
         }
         for (id, _) in candidates {
             if id == node.id {
@@ -894,10 +960,68 @@ impl MenteDb {
             let inter = new_tokens.intersection(&old_tokens).count() as f32;
             let union = new_tokens.union(&old_tokens).count() as f32;
             if union > 0.0 && inter / union >= self.cognitive_config.memory_dedup_token_overlap {
-                return true;
+                return Some(id);
             }
         }
-        false
+        None
+    }
+
+    /// Retroactively merge paraphrase duplicates among the given memories,
+    /// returning how many were merged away. For each memory that still exists,
+    /// the same two-gate policy as write-time dedup finds a duplicate; the
+    /// OLDER memory is kept (stable identity for edges and references), the
+    /// newer one is forgotten after folding its tags, access count, and peak
+    /// salience into the keeper. Idempotent, and work is bounded by the slice,
+    /// so callers migrating a whole database chunk `memory_ids()` and release
+    /// any external write lock between chunks, the same pattern as
+    /// `reembed_ids`. Requires an embedder-backed index only insofar as the
+    /// stored embeddings exist; no new embeddings are computed.
+    pub fn dedup_sweep_ids(&self, ids: &[MemoryId]) -> MenteResult<usize> {
+        let mut merged = 0usize;
+        for id in ids {
+            let Ok(node) = self.get_memory(*id) else {
+                continue;
+            };
+            let Some(dup_id) = self.find_paraphrase_duplicate_of(&node) else {
+                continue;
+            };
+            let Ok(dup) = self.get_memory(dup_id) else {
+                continue;
+            };
+            // Keep the older memory; forget the newer restatement.
+            let (keep, drop) = if node.created_at <= dup.created_at {
+                (node, dup)
+            } else {
+                (dup, node)
+            };
+            let keep_pid = {
+                let pm = self.page_map.read();
+                match pm.get(&keep.id) {
+                    Some(p) => *p,
+                    None => continue,
+                }
+            };
+            let mut keeper = match self.storage.load_memory(keep_pid) {
+                Ok(k) => k,
+                Err(_) => continue,
+            };
+            for tag in &drop.tags {
+                if !keeper.tags.contains(tag) {
+                    keeper.tags.push(tag.clone());
+                }
+            }
+            keeper.access_count = keeper.access_count.saturating_add(drop.access_count);
+            if drop.salience > keeper.salience {
+                keeper.salience = drop.salience;
+            }
+            self.storage.update_memory(keep_pid, &keeper)?;
+            self.forget(drop.id)?;
+            merged += 1;
+        }
+        if merged > 0 {
+            info!("dedup sweep merged {merged} paraphrase duplicates");
+        }
+        Ok(merged)
     }
 
     /// Lowercased alphanumeric token set of a content string, for the

--- a/crates/mentedb/src/process_turn.rs
+++ b/crates/mentedb/src/process_turn.rs
@@ -120,6 +120,80 @@ pub struct ProcessTurnResult {
     pub delta_removed: Vec<MemoryId>,
 }
 
+/// The read half of a turn: what the caller needs to build its next prompt.
+/// Produced by [`MenteDb::recall_turn_context`]; feed `context` to
+/// [`MenteDb::ingest_turn`] so analysis sees what the caller saw.
+#[derive(Debug, Clone)]
+pub struct RecallContextResult {
+    /// Retrieved context memories (scored and ranked).
+    pub context: Vec<ScoredMemory>,
+    /// Pain warnings triggered by the user message.
+    pub pain_warnings: Vec<PainWarning>,
+    /// Whether context came from the speculative cache.
+    pub cache_hit: bool,
+    /// Delta: memory IDs added since last turn.
+    pub delta_added: Vec<MemoryId>,
+    /// Delta: memory IDs removed since last turn.
+    pub delta_removed: Vec<MemoryId>,
+}
+
+/// The write half of a turn: everything [`MenteDb::ingest_turn`] produced
+/// after the caller's response no longer depends on it.
+#[derive(Debug, Clone)]
+pub struct IngestTurnResult {
+    /// IDs of newly stored memories this turn.
+    pub stored_ids: Vec<MemoryId>,
+    /// The episodic memory ID for this turn.
+    pub episodic_id: Option<MemoryId>,
+    /// Number of write-inference actions applied.
+    pub inference_actions: u32,
+    /// Detected actions in the conversation.
+    pub detected_actions: Vec<DetectedAction>,
+    /// Proactively recalled memories.
+    pub proactive_recalls: Vec<ProactiveRecall>,
+    /// Auto-correction memory ID if a correction was detected.
+    pub correction_id: Option<MemoryId>,
+    /// Sentiment score (-1.0 to 1.0).
+    pub sentiment: f32,
+    /// Number of phantom (knowledge gap) entities detected.
+    pub phantom_count: usize,
+    /// Number of stream contradictions detected.
+    pub contradiction_count: usize,
+    /// Predicted next topics from trajectory analysis.
+    pub predicted_topics: Vec<String>,
+    /// Number of facts extracted and linked.
+    pub facts_extracted: usize,
+    /// Number of edges created from fact extraction.
+    pub edges_created: u32,
+    /// Whether enrichment is pending (caller should invoke enrichment pipeline).
+    pub enrichment_pending: bool,
+}
+
+/// Recompose the split halves into the classic single-call result, so
+/// `process_turn` keeps its exact shape for existing callers.
+fn compose_turn_result(recall: RecallContextResult, ingest: IngestTurnResult) -> ProcessTurnResult {
+    ProcessTurnResult {
+        context: recall.context,
+        stored_ids: ingest.stored_ids,
+        episodic_id: ingest.episodic_id,
+        pain_warnings: recall.pain_warnings,
+        cache_hit: recall.cache_hit,
+        inference_actions: ingest.inference_actions,
+        detected_actions: ingest.detected_actions,
+        proactive_recalls: ingest.proactive_recalls,
+        correction_id: ingest.correction_id,
+        sentiment: ingest.sentiment,
+        phantom_count: ingest.phantom_count,
+        contradiction_count: ingest.contradiction_count,
+        predicted_topics: ingest.predicted_topics,
+        facts_extracted: ingest.facts_extracted,
+        edges_created: ingest.edges_created,
+        enrichment_pending: ingest.enrichment_pending,
+        delta_added: recall.delta_added,
+        delta_removed: recall.delta_removed,
+    }
+}
+
 // ── Action detection keywords ──
 
 const ACTION_KEYWORDS: &[(&str, &str)] = &[
@@ -227,14 +301,22 @@ impl MenteDb {
         input: &ProcessTurnInput,
         delta_tracker: &mut DeltaTracker,
     ) -> crate::MenteResult<ProcessTurnResult> {
-        let agent_id = AgentId(input.agent_id.unwrap_or(Uuid::nil()));
-        let user_id = UserId(input.user_id.unwrap_or(Uuid::nil()));
-        let assistant_resp = input.assistant_response.as_deref().unwrap_or("");
-        let conversation = format!(
-            "User: {}\nAssistant: {}",
-            input.user_message, assistant_resp
-        );
+        let recall = self.recall_turn_context(input, delta_tracker)?;
+        let ingest = self.ingest_turn(input, &recall.context)?;
+        Ok(compose_turn_result(recall, ingest))
+    }
 
+    /// The read half of a turn: everything the caller needs to build its next
+    /// prompt (recalled context, pain warnings, delta), and nothing else. The
+    /// write half is [`MenteDb::ingest_turn`]; callers on a latency budget
+    /// respond after this returns and run ingestion behind the response.
+    /// `process_turn` composes the two halves and is behavior-identical to the
+    /// original single-call pipeline.
+    pub fn recall_turn_context(
+        &self,
+        input: &ProcessTurnInput,
+        delta_tracker: &mut DeltaTracker,
+    ) -> crate::MenteResult<RecallContextResult> {
         // §1: Embed query
         let query_embedding = self.embed_or_empty(&input.user_message)?;
 
@@ -253,6 +335,34 @@ impl MenteDb {
         // §2b: Delta tracking
         let delta = delta_tracker.compute_delta(&current_ids, &delta_tracker.last_served.clone());
         delta_tracker.update(&current_ids);
+
+        Ok(RecallContextResult {
+            context,
+            pain_warnings,
+            cache_hit,
+            delta_added: delta.added,
+            delta_removed: delta.removed,
+        })
+    }
+
+    /// The write half of a turn: store, reconcile, analyze, maintain. Takes
+    /// the context recalled by [`MenteDb::recall_turn_context`] so phantom and
+    /// stream analysis see exactly what the caller saw, without re-running
+    /// recall. Safe to run after the caller's response has already been sent;
+    /// the single-writer discipline is the caller's (hold the account write
+    /// lock while this runs, as with any write).
+    pub fn ingest_turn(
+        &self,
+        input: &ProcessTurnInput,
+        context: &[ScoredMemory],
+    ) -> crate::MenteResult<IngestTurnResult> {
+        let agent_id = AgentId(input.agent_id.unwrap_or(Uuid::nil()));
+        let user_id = UserId(input.user_id.unwrap_or(Uuid::nil()));
+        let assistant_resp = input.assistant_response.as_deref().unwrap_or("");
+        let conversation = format!(
+            "User: {}\nAssistant: {}",
+            input.user_message, assistant_resp
+        );
 
         // §3: Store episodic turn (write inference runs automatically inside store)
         let (stored_ids, episodic_id) = self.store_episodic(
@@ -302,7 +412,7 @@ impl MenteDb {
         let (phantom_count, contradiction_count) = self.detect_phantoms_and_check_stream(
             &conversation,
             assistant_resp,
-            &context,
+            context,
             input.turn_id,
         );
 
@@ -322,12 +432,9 @@ impl MenteDb {
         // §13: Auto-maintenance
         self.maybe_run_maintenance(input.turn_id);
 
-        Ok(ProcessTurnResult {
-            context,
-            stored_ids: stored_ids.clone(),
+        Ok(IngestTurnResult {
+            stored_ids,
             episodic_id,
-            pain_warnings,
-            cache_hit,
             inference_actions,
             detected_actions,
             proactive_recalls,
@@ -339,8 +446,6 @@ impl MenteDb {
             facts_extracted,
             edges_created,
             enrichment_pending: self.needs_enrichment(),
-            delta_added: delta.added,
-            delta_removed: delta.removed,
         })
     }
 


### PR DESCRIPTION
## Summary
Three engine capabilities, one batch: self-calibrating cosine thresholds, a retroactive paraphrase-dedup sweep, and the process_turn read/write split for sub-second callers.

## Changes
- **Calibration** (new module `calibration`): embeds a built-in probe set (12 paraphrase, 14 unrelated pairs) once per embedder, derives `dedup_cosine` and `topical_floor` from the measured distributions, persists keyed by model+dim, recomputes on embedder swap. `apply_calibration` patches `memory_dedup_threshold`, `always_dedup_threshold`, and `value_update_min_similarity` at open and rebuilds write inference. Fails closed to configured defaults when distributions overlap (hash provider, degraded embedder), so tests keep deterministic behavior. `calibration_enabled` config flag, default true.
- **Dedup sweep**: `dedup_sweep_ids(&[MemoryId])` merges paraphrase duplicates under the exact write-time two-gate policy (shared `find_paraphrase_duplicate_of`), keeps the older memory, folds tags/access/salience, forgets the newer. Bounded work per call for the chunked-lock migration pattern.
- **Turn split**: `recall_turn_context` (embed, recall, pain, delta) + `ingest_turn` (store, inference, facts, analysis, maintenance) with `process_turn` recomposed on top, behavior identical for existing callers. Callers on a latency budget respond after recall and run ingest behind the response.

## Verification
- `cargo fmt --all`, `cargo clippy --workspace -- -D warnings`: clean.
- `cargo test -p mentedb`: all suites pass (includes 4 new calibration tests: separable derivation, degenerate fail-closed, file roundtrip, percentile).