### PR TITLE
feat(server): expose process_turn on the REST API and tolerate mid-turn memory loss

### DIFF
--- a/crates/mentedb-server/src/handlers.rs
+++ b/crates/mentedb-server/src/handlers.rs
@@ -416,6 +416,143 @@ pub async fn ingest_conversation(
     Ok((StatusCode::OK, Json(stats)))
 }
 
+// ---------------------------------------------------------------------------
+// POST /v1/process_turn
+// ---------------------------------------------------------------------------
+
+/// Run the full cognitive turn pipeline: embed, recall context, store the
+/// turn, reconcile, analyze. The same engine call the hosted platform serves;
+/// self-hosters get the one-call pipeline instead of assembling it from the
+/// store and recall primitives. Delta serving is tracked per agent across
+/// requests via `AppState::turn_trackers`.
+pub async fn process_turn(
+    State(state): State<Arc<AppState>>,
+    agent: Option<Extension<AuthenticatedAgent>>,
+    Json(req): Json<Value>,
+) -> Result<impl IntoResponse, ApiError> {
+    let user_message = req
+        .get("user_message")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| ApiError::BadRequest("missing or invalid 'user_message'".into()))?
+        .to_string();
+    let assistant_response = req
+        .get("assistant_response")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string());
+    let turn_id = req.get("turn_id").and_then(|v| v.as_u64()).unwrap_or(0);
+    let project_context = req
+        .get("project_context")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string());
+    let session_id = req
+        .get("session_id")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string());
+    let agent_id = req
+        .get("agent_id")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .map(|s| {
+            Uuid::parse_str(s).map_err(|_| ApiError::BadRequest("invalid 'agent_id' UUID".into()))
+        })
+        .transpose()?;
+    let user_id = req
+        .get("user_id")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .map(|s| {
+            Uuid::parse_str(s).map_err(|_| ApiError::BadRequest("invalid 'user_id' UUID".into()))
+        })
+        .transpose()?;
+
+    // A scoped token must only process turns for its own agent.
+    if let (Some(Extension(authed)), Some(aid)) = (&agent, agent_id) {
+        let tid: AgentId = authed
+            .agent_id
+            .parse()
+            .map_err(|_| ApiError::Internal("token contains invalid agent_id UUID".into()))?;
+        if tid != AgentId(aid) {
+            return Err(ApiError::Forbidden(
+                "agent_id in request body does not match token".into(),
+            ));
+        }
+    }
+
+    let input = mentedb::process_turn::ProcessTurnInput {
+        user_message,
+        assistant_response,
+        turn_id,
+        project_context,
+        agent_id,
+        user_id,
+        session_id,
+    };
+
+    // The tracker is keyed by agent (nil for the shared/global agent) so a
+    // multi-agent server keeps one delta stream per agent. Taken out of the
+    // map for the duration of the blocking call, then put back, so the mutex
+    // is never held across the engine turn.
+    let tracker_key = agent_id.unwrap_or_else(Uuid::nil).to_string();
+    let mut tracker = {
+        let mut map = state.turn_trackers.lock().await;
+        map.remove(&tracker_key)
+            .unwrap_or_else(mentedb::context::DeltaTracker::new)
+    };
+
+    let db = Arc::clone(&state.db);
+    let joined = tokio::task::spawn_blocking(move || {
+        let result = db.process_turn(&input, &mut tracker);
+        (result, tracker)
+    })
+    .await
+    .map_err(|e| ApiError::Internal(format!("process_turn task failed: {e}")))?;
+    let (result, tracker) = joined;
+    {
+        let mut map = state.turn_trackers.lock().await;
+        map.insert(tracker_key, tracker);
+    }
+    let result = result.map_err(|e| {
+        error!("process_turn failed: {e}");
+        ApiError::Internal(format!("process_turn failed: {e}"))
+    })?;
+
+    let context: Vec<Value> = result
+        .context
+        .iter()
+        .map(|sm| {
+            json!({
+                "id": sm.memory.id.to_string(),
+                "content": sm.memory.content,
+                "memory_type": format!("{:?}", sm.memory.memory_type).to_lowercase(),
+                "relevance_score": sm.score,
+                "created_at": sm.memory.created_at,
+            })
+        })
+        .collect();
+
+    Ok((
+        StatusCode::OK,
+        Json(json!({
+            "ok": true,
+            "context": context,
+            "cache_hit": result.cache_hit,
+            "stored_ids": result.stored_ids.iter().map(|id| id.to_string()).collect::<Vec<_>>(),
+            "episodic_id": result.episodic_id.map(|id| id.to_string()),
+            "contradictions": result.contradiction_count,
+            "facts_extracted": result.facts_extracted,
+            "edges_created": result.edges_created,
+            "inference_actions": result.inference_actions,
+            "pain_warnings": result.pain_warnings.len(),
+            "predicted_topics": result.predicted_topics,
+            "delta_added": result.delta_added.iter().map(|id| id.to_string()).collect::<Vec<_>>(),
+            "delta_removed": result.delta_removed.iter().map(|id| id.to_string()).collect::<Vec<_>>(),
+        })),
+    ))
+}
+
 /// Run the extraction pipeline and store accepted memories. Returns JSON stats.
 async fn run_extraction(
     config: &ExtractionConfig,

--- a/crates/mentedb-server/src/main.rs
+++ b/crates/mentedb-server/src/main.rs
@@ -464,6 +464,7 @@ async fn main() -> Result<()> {
         auto_extract,
         extraction_tx,
         cluster,
+        turn_trackers: Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new())),
     });
 
     let app = routes::build_router(state.clone())
@@ -497,6 +498,7 @@ async fn main() -> Result<()> {
     println!("  POST   /v1/edges            create an edge");
     println!("  GET    /v1/stats            database statistics");
     println!("  POST   /v1/ingest           extract & store from conversation");
+    println!("  POST   /v1/process_turn     full cognitive turn pipeline");
     println!("  POST   /v1/auth/token       generate JWT");
     println!("  GET    /v1/ws/stream        WebSocket cognition stream");
     println!();

--- a/crates/mentedb-server/src/routes.rs
+++ b/crates/mentedb-server/src/routes.rs
@@ -23,6 +23,7 @@ pub fn build_router(state: Arc<AppState>) -> Router {
         .route("/v1/edges", post(handlers::create_edge))
         .route("/v1/stats", get(handlers::stats))
         .route("/v1/ingest", post(handlers::ingest_conversation))
+        .route("/v1/process_turn", post(handlers::process_turn))
         .route("/v1/auth/token", post(crate::auth::generate_token))
         .route(
             "/v1/spaces",

--- a/crates/mentedb-server/src/state.rs
+++ b/crates/mentedb-server/src/state.rs
@@ -21,4 +21,9 @@ pub struct AppState {
     pub extraction_tx: Option<ExtractionSender>,
     /// Self-organizing sharding handle. `None` unless `MENTEDB_SHARDING` is set.
     pub cluster: Option<crate::cluster::Cluster>,
+    /// Per-agent delta trackers for `/v1/process_turn`, so delta-aware context
+    /// serving (only what changed since the agent's last turn) works across
+    /// requests instead of resetting every call.
+    pub turn_trackers:
+        Arc<tokio::sync::Mutex<std::collections::HashMap<String, mentedb::context::DeltaTracker>>>,
 }

--- a/crates/mentedb/src/process_turn.rs
+++ b/crates/mentedb/src/process_turn.rs
@@ -624,7 +624,13 @@ impl MenteDb {
         agent: Option<AgentId>,
         user: Option<UserId>,
     ) -> crate::MenteResult<u32> {
-        let target = self.get_memory(id)?;
+        // The turn's memory can legitimately be gone by now: paraphrase dedup
+        // can skip the store, and write inference inside store can supersede
+        // or forget it (a correction resolving against an earlier fact). A
+        // missing target ends this step, never the whole turn.
+        let Ok(target) = self.get_memory(id) else {
+            return Ok(0);
+        };
         // Scope to the turn's owner on BOTH axes: contradiction and dedup edges
         // must not form across users or agents. Nil owned (shared/global)
         // memories remain in scope.
@@ -787,7 +793,12 @@ impl MenteDb {
         agent: Option<AgentId>,
         user: Option<UserId>,
     ) -> crate::MenteResult<(usize, u32)> {
-        let target = self.get_memory(id)?;
+        // Same tolerance as run_explicit_write_inference: the turn's memory
+        // can have been deduped, superseded, or forgotten between store and
+        // this step; a missing target ends this step, never the whole turn.
+        let Ok(target) = self.get_memory(id) else {
+            return Ok((0, 0));
+        };
         let extractor = FactExtractor::new();
         let facts = extractor.extract_facts(&target);
         if facts.is_empty() {


### PR DESCRIPTION
## Summary
Self-hosters get the documented one-call pipeline: POST /v1/process_turn now exists on the OSS REST server, and a turn-500 robustness bug found by the ablation harness is fixed.

## Changes
- New route POST /v1/process_turn: full cognitive pipeline (embed, recall, store, reconcile, analyze) with per-agent DeltaTracker state in AppState so delta serving works across requests; optional scoped-token agent binding mirrors /v1/ingest; response carries context, stored_ids, contradiction and fact counters, and deltas.
- Robustness: run_explicit_write_inference and extract_and_link_facts no longer fail the whole turn when the turn's memory vanished between store and analysis (dedup skip, supersession, forget); each step ends gracefully instead. Reproduced by the harness's correction task and fixed.

## Verification
- cargo build --release -p mentedb-server (both default and --features local-embeddings) clean.
- 40-task ablation ran end to end against this server: mentedb 95% accuracy at 49% of full-context tokens, correction supersession 12/12.