### PR TITLE
feat: offline dedup sweep profile and multi-arch docker image

### DIFF
--- a/.github/workflows/publish-sdks.yml
+++ b/.github/workflows/publish-sdks.yml
@@ -219,9 +219,60 @@ jobs:
           packages-dir: dist/
           skip-existing: true
 
+  # Build each architecture on its own native runner (no QEMU emulation, which
+  # would make the Rust + Candle release build take tens of minutes for arm64),
+  # push each by digest, then assemble a multi-arch manifest so
+  # `docker run ghcr.io/nambok/mentedb:latest` works on both amd64 and Apple
+  # Silicon (arm64). The Dockerfile is architecture-agnostic and unchanged.
   publish-docker:
-    name: Publish Docker image
+    name: Build Docker image (${{ matrix.platform }})
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v7
+      - name: Prepare platform slug
+        run: echo "PLATFORM_SLUG=$(echo '${{ matrix.platform }}' | tr '/' '-')" >> "$GITHUB_ENV"
+      - uses: docker/setup-buildx-action@v4
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=ghcr.io/nambok/mentedb,push-by-digest=true,name-canonical=true,push=true
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          touch "/tmp/digests/${DIGEST#sha256:}"
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: docker-digest-${{ env.PLATFORM_SLUG }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  publish-docker-manifest:
+    name: Publish multi-arch Docker manifest
     runs-on: ubuntu-latest
+    needs: [publish-docker]
     permissions:
       contents: read
       packages: write
@@ -238,17 +289,24 @@ jobs:
             VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "mentedb") | .version')
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: docker-digest-*
+          merge-multiple: true
       - uses: docker/setup-buildx-action@v4
       - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@v7
-        with:
-          context: .
-          platforms: linux/amd64
-          push: true
-          tags: |
-            ghcr.io/nambok/mentedb:latest
-            ghcr.io/nambok/mentedb:${{ steps.version.outputs.version }}
+      - name: Create and push manifest
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            -t ghcr.io/nambok/mentedb:latest \
+            -t "ghcr.io/nambok/mentedb:${{ steps.version.outputs.version }}" \
+            $(printf 'ghcr.io/nambok/mentedb@sha256:%s ' *)
+      - name: Inspect manifest
+        run: docker buildx imagetools inspect "ghcr.io/nambok/mentedb:${{ steps.version.outputs.version }}"

--- a/crates/mentedb-cognitive/src/write_inference.rs
+++ b/crates/mentedb-cognitive/src/write_inference.rs
@@ -203,6 +203,21 @@ impl WriteInferenceEngine {
         Self { config }
     }
 
+    /// Whether `new` and `old` look like a value update (same sentence frame,
+    /// changed value tail) under this engine's configured thresholds. A
+    /// deduplication pass that merges near-duplicates uses this as a guard so a
+    /// correction ("coffee is a cortado" then "coffee is a flat white") is
+    /// never collapsed into the fact it corrects; the two must stay distinct
+    /// for supersession to resolve them.
+    pub fn looks_like_value_update(&self, new: &str, old: &str) -> bool {
+        is_value_update(
+            new,
+            old,
+            self.config.value_update_prefix_share,
+            self.config.value_update_max_tail,
+        )
+    }
+
     pub fn infer_on_write(
         &self,
         new_memory: &MemoryNode,

--- a/crates/mentedb-server/src/grpc.rs
+++ b/crates/mentedb-server/src/grpc.rs
@@ -467,6 +467,7 @@ mod tests {
             auto_extract: false,
             extraction_tx: None,
             cluster: None,
+            turn_trackers: Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new())),
         });
         (state, tmp)
     }
@@ -779,6 +780,7 @@ mod tests {
                 auto_extract: false,
                 extraction_tx: None,
                 cluster: None,
+                turn_trackers: Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new())),
             }),
             tmp,
         )

--- a/crates/mentedb-server/tests/extraction_integration.rs
+++ b/crates/mentedb-server/tests/extraction_integration.rs
@@ -30,6 +30,7 @@ fn test_state(
         auto_extract,
         extraction_tx: None,
         cluster: None,
+        turn_trackers: Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new())),
     });
     (state, tmp)
 }

--- a/crates/mentedb-server/tests/integration.rs
+++ b/crates/mentedb-server/tests/integration.rs
@@ -41,6 +41,7 @@ fn build_test_app_with_auth() -> (axum::Router, TempDir) {
         auto_extract: false,
         extraction_tx: None,
         cluster: None,
+        turn_trackers: Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new())),
     });
     let app = routes::build_router(state.clone()).layer(middleware::from_fn_with_state(
         state.clone(),
@@ -63,6 +64,7 @@ fn build_test_app_no_auth() -> (axum::Router, TempDir) {
         auto_extract: false,
         extraction_tx: None,
         cluster: None,
+        turn_trackers: Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new())),
     });
     let app = routes::build_router(state.clone()).layer(middleware::from_fn_with_state(
         state.clone(),
@@ -85,6 +87,7 @@ fn build_test_app_rate_limited(max_tokens: u32) -> (axum::Router, TempDir) {
         auto_extract: false,
         extraction_tx: None,
         cluster: None,
+        turn_trackers: Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new())),
     });
     let app = routes::build_router(state.clone())
         .layer(middleware::from_fn_with_state(
@@ -112,6 +115,7 @@ fn build_test_app_with_auth_no_admin_key() -> (axum::Router, TempDir) {
         auto_extract: false,
         extraction_tx: None,
         cluster: None,
+        turn_trackers: Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new())),
     });
     let app = routes::build_router(state.clone()).layer(middleware::from_fn_with_state(
         state.clone(),

--- a/crates/mentedb/src/lib.rs
+++ b/crates/mentedb/src/lib.rs
@@ -398,6 +398,13 @@ pub struct CognitiveConfig {
     /// gate). Value updates share a frame but swap a value token, which drops
     /// them below this and keeps them storable.
     pub memory_dedup_token_overlap: f32,
+    /// Token-set jaccard overlap gate for the OFFLINE dedup sweep, looser than
+    /// the write-time gate so it catches reworded paraphrases that already
+    /// accumulated. Safe to loosen here only because the sweep also applies a
+    /// value-update structural guard, so a correction is never merged even
+    /// when its overlap clears this bar. The write hot path keeps the strict
+    /// `memory_dedup_token_overlap`.
+    pub sweep_dedup_token_overlap: f32,
     /// Whether to derive the cosine-based thresholds (paraphrase dedup,
     /// standing-rule dedup, value-update floor) from the installed embedder's
     /// measured score distributions at open. Absolute cosine constants are
@@ -443,6 +450,7 @@ impl Default for CognitiveConfig {
             memory_dedup: true,
             memory_dedup_threshold: 0.97,
             memory_dedup_token_overlap: 0.85,
+            sweep_dedup_token_overlap: 0.55,
             calibration_enabled: true,
         }
     }
@@ -895,6 +903,34 @@ impl MenteDb {
     /// the overlap gate. Shared by the write-time skip and the retroactive
     /// sweep so both apply identical policy.
     fn find_paraphrase_duplicate_of(&self, node: &MemoryNode) -> Option<MemoryId> {
+        self.find_duplicate_of(
+            node,
+            self.cognitive_config.memory_dedup_token_overlap,
+            false,
+        )
+    }
+
+    /// Offline dedup sweep variant of the paraphrase finder: a looser
+    /// token-overlap gate catches the reworded paraphrases that pile up below
+    /// the strict write-time gate ("User builds X with Y" vs "the user is
+    /// building X using Y"), while a value-update structural guard ensures a
+    /// correction is never merged into the fact it corrects.
+    fn find_sweep_duplicate_of(&self, node: &MemoryNode) -> Option<MemoryId> {
+        self.find_duplicate_of(node, self.cognitive_config.sweep_dedup_token_overlap, true)
+    }
+
+    /// Shared duplicate finder for the write-time paraphrase gate and the
+    /// offline sweep: a same-owner, same-scope candidate whose embedding cosine
+    /// reaches the (calibrated) dedup threshold AND whose token-set jaccard
+    /// reaches `min_overlap`. With `guard_value_update` set, a candidate that
+    /// reads as a value update (shared frame, changed value tail) is skipped,
+    /// so a correction is never collapsed into the fact it supersedes.
+    fn find_duplicate_of(
+        &self,
+        node: &MemoryNode,
+        min_overlap: f32,
+        guard_value_update: bool,
+    ) -> Option<MemoryId> {
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
@@ -959,7 +995,14 @@ impl MenteDb {
             }
             let inter = new_tokens.intersection(&old_tokens).count() as f32;
             let union = new_tokens.union(&old_tokens).count() as f32;
-            if union > 0.0 && inter / union >= self.cognitive_config.memory_dedup_token_overlap {
+            if union > 0.0 && inter / union >= min_overlap {
+                if guard_value_update
+                    && self
+                        .write_inference
+                        .looks_like_value_update(&node.content, &existing.content)
+                {
+                    continue;
+                }
                 return Some(id);
             }
         }
@@ -982,7 +1025,7 @@ impl MenteDb {
             let Ok(node) = self.get_memory(*id) else {
                 continue;
             };
-            let Some(dup_id) = self.find_paraphrase_duplicate_of(&node) else {
+            let Some(dup_id) = self.find_sweep_duplicate_of(&node) else {
                 continue;
             };
             let Ok(dup) = self.get_memory(dup_id) else {


### PR DESCRIPTION
## Summary
Two engine-repo items in one PR: a real offline paraphrase-dedup sweep, and a multi-arch Docker image so Apple Silicon can run the container.

## Changes
- **Dedup sweep profile**: `dedup_sweep_ids` now uses `find_sweep_duplicate_of`, a looser token-overlap gate (`sweep_dedup_token_overlap`, 0.55 vs the write-time 0.85) that catches reworded paraphrases, guarded by `WriteInferenceEngine::looks_like_value_update` so a correction (shared frame, changed value tail) is never collapsed into the fact it supersedes. Write-time paraphrase dedup is unchanged. Both go through a shared `find_duplicate_of(node, min_overlap, guard_value_update)`.
- **Multi-arch Docker**: the `publish-docker` job builds amd64 and arm64 on native runners (ubuntu-latest / ubuntu-24.04-arm, no QEMU), pushes by digest, and a `publish-docker-manifest` job assembles the multi-arch manifest. Dockerfile unchanged.

## Verification
- `cargo fmt --all`, `cargo clippy --workspace -- -D warnings`: clean.
- `cargo test`: 296 passed.
- Workflow YAML validated (parses clean); the multi-arch build itself only runs on release, verified by inspection against the documented native-runners pattern.