### PR TITLE
feat(embed): expose embed/embed_batch + honest benchmark timing

### DIFF
--- a/README.md
+++ b/README.md
@@ -833,26 +833,33 @@ Multi-session reasoning is the weakest category: synthesizing facts scattered ac
 
 **How we measured:** each conversation is ingested chronologically with timestamps; MenteDB extracts memories (gpt-4o-mini) into vectors, BM25, and graph. For each question it runs hybrid retrieval (BM25 + vector, RRF-merged, time-filtered to memories dated before the question) and answers with gpt-4o. Embeddings are text-embedding-3-small. Grading uses the official LongMemEval judge, unmodified. The raw per-question hypotheses and judge labels are committed under `benchmarks/longmemeval/results/` for audit.
 
-### 10K Scale Test (OpenAI text-embedding-3-small)
+### 10K Scale Test (engine latency vs embedding provider)
+
+Run: `python3 benchmarks/scale_10k.py candle` (local Candle embeddings, no API key). The embedding round trip is timed separately from the engine, so the two are never conflated. A remote provider (OpenAI, Cohere) swaps the local embed for a network call of a few hundred ms, but the engine numbers below are unchanged.
 
 | Metric | Value |
 |--------|-------|
-| Total memories | 10,000 |
-| Avg insert | 457ms (includes OpenAI API round trip) |
-| Avg search at 10K | 431ms |
-| Belief changes | 6/6 correctly tracked |
+| Total memories | 10,006 |
+| Engine search at 10K (no embed) | 1.05ms |
+| Engine insert, full write pipeline (no embed) | 13.9ms/mem |
+| Query embed (local Candle, per query) | 40ms |
+| Batch embed (amortized, one provider call per 512 inputs) | 30ms/mem |
+| Belief supersessions tracked | 6/6 |
 | Stale beliefs returned | 0 |
+
+Engine search stays near 1ms at 10,000 memories. An earlier version of this table reported roughly 431ms search: that figure was almost entirely the OpenAI round trip to embed the query, not engine work. Bulk inserts precompute embeddings in one batched provider call and pass them to `store(embedding=...)`, so the per item network round trip is paid once per batch instead of once per memory. To reproduce with OpenAI embeddings, set `OPENAI_API_KEY` before running.
 
 ### Candle (Local) vs OpenAI Embedding Quality
 
 | Metric | Candle (all-MiniLM-L6-v2) | OpenAI (text-embedding-3-small) |
 |--------|---------------------------|----------------------------------|
-| Retrieval accuracy | 62% (5/8) | Requires API key to compare |
-| Avg search | 41ms | 431ms (includes API latency) |
+| Retrieval accuracy (8 queries) | 62% (5/8) | Requires API key to compare |
+| Engine search (identical code path) | 0.3ms | 0.3ms |
+| Query embed | 39ms (local, no network) | network round trip (hundreds of ms) |
 | Setup required | None (auto-downloads model) | OPENAI_API_KEY |
 | Cost | Free | ~$0.02 per 1M tokens |
 
-Candle provides good quality for zero-config local use. OpenAI offers higher accuracy for production workloads. Run `python3 benchmarks/candle_vs_openai.py` with OPENAI_API_KEY set to get a head-to-head comparison.
+The engine search is the same for both providers, so the practical difference is embed latency (local model vs API round trip) and retrieval quality. Candle is zero-config and free but a smaller 384-dim model; OpenAI trades an API round trip for higher accuracy. Run `python3 benchmarks/candle_vs_openai.py` with OPENAI_API_KEY set for a head-to-head comparison.
 
 ### Performance Benchmarks (Criterion)
 

--- a/benchmarks/candle_vs_openai.py
+++ b/benchmarks/candle_vs_openai.py
@@ -47,7 +47,12 @@ QUERIES = [
 
 
 def run_provider(provider_name, api_key=None):
-    """Run accuracy test for a given provider. Returns (hits, total, avg_ms, details)."""
+    """Run accuracy test for a given provider.
+
+    Returns (hits, total, avg_search_ms, avg_embed_ms, details). The embedding
+    round trip and the engine search are timed separately so a remote provider's
+    network latency is not misattributed to the engine.
+    """
     import mentedb
 
     kwargs = {"embedding_provider": provider_name}
@@ -70,13 +75,18 @@ def run_provider(provider_name, api_key=None):
     hits = 0
     total = len(QUERIES)
     search_times = []
+    embed_times = []
     details = []
 
     for query, expected_present, expected_absent in QUERIES:
+        # Embedding (provider round trip) timed apart from the engine search.
         t0 = time.perf_counter()
-        results = db.search_text(query, 5)
-        elapsed = (time.perf_counter() - t0) * 1000
-        search_times.append(elapsed)
+        qvec = db.embed(query)
+        embed_times.append((time.perf_counter() - t0) * 1000)
+
+        t0 = time.perf_counter()
+        results = db.search(qvec, 5)
+        search_times.append((time.perf_counter() - t0) * 1000)
 
         filtered = [r for r in results if r.id not in superseded][:3]
         texts = []
@@ -92,8 +102,9 @@ def run_provider(provider_name, api_key=None):
             hits += 1
         details.append((query, passed, texts[0][:60] if texts else "no results"))
 
-    avg_ms = sum(search_times) / len(search_times)
-    return hits, total, avg_ms, details
+    avg_search = sum(search_times) / len(search_times)
+    avg_embed = sum(embed_times) / len(embed_times)
+    return hits, total, avg_search, avg_embed, details
 
 
 def main():
@@ -104,10 +115,10 @@ def main():
     # Candle (always available)
     print("\n--- Candle (all-MiniLM-L6-v2, local) ---")
     t0 = time.perf_counter()
-    c_hits, c_total, c_avg, c_details = run_provider("candle")
+    c_hits, c_total, c_avg, c_embed, c_details = run_provider("candle")
     c_total_ms = (time.perf_counter() - t0) * 1000
     print(f"  Accuracy: {c_hits}/{c_total} ({100*c_hits/c_total:.0f}%)")
-    print(f"  Avg search: {c_avg:.1f}ms")
+    print(f"  Avg engine search: {c_avg:.1f}ms  (+ {c_embed:.1f}ms local embed)")
     print(f"  Total time: {c_total_ms:.0f}ms")
     for q, passed, top in c_details:
         print(f"  {'PASS' if passed else 'FAIL'} | {q} -> {top}")
@@ -118,16 +129,17 @@ def main():
         print_result("Candle vs OpenAI", True, {
             "Candle accuracy": f"{c_hits}/{c_total} ({100*c_hits/c_total:.0f}%)",
             "OpenAI": "skipped (no API key)",
-            "Candle avg search": f"{c_avg:.1f}ms",
+            "Candle engine search": f"{c_avg:.1f}ms",
+            "Candle local embed": f"{c_embed:.1f}ms",
         })
         return
 
     print("\n--- OpenAI (text-embedding-3-small) ---")
     t0 = time.perf_counter()
-    o_hits, o_total, o_avg, o_details = run_provider("openai", os.environ["OPENAI_API_KEY"])
+    o_hits, o_total, o_avg, o_embed, o_details = run_provider("openai", os.environ["OPENAI_API_KEY"])
     o_total_ms = (time.perf_counter() - t0) * 1000
     print(f"  Accuracy: {o_hits}/{o_total} ({100*o_hits/o_total:.0f}%)")
-    print(f"  Avg search: {o_avg:.1f}ms")
+    print(f"  Avg engine search: {o_avg:.1f}ms  (+ {o_embed:.1f}ms OpenAI API round trip)")
     print(f"  Total time: {o_total_ms:.0f}ms")
     for q, passed, top in o_details:
         print(f"  {'PASS' if passed else 'FAIL'} | {q} -> {top}")
@@ -142,16 +154,13 @@ def main():
     else:
         verdict = "Tied"
 
-    speed_ratio = o_total_ms / c_total_ms if c_total_ms > 0 else 0
-
     print_result("Candle vs OpenAI", True, {
         "Candle accuracy": f"{c_hits}/{c_total} ({100*c_hits/c_total:.0f}%)",
         "OpenAI accuracy": f"{o_hits}/{o_total} ({100*o_hits/o_total:.0f}%)",
         "Verdict": verdict,
-        "Candle avg search": f"{c_avg:.1f}ms",
-        "OpenAI avg search": f"{o_avg:.1f}ms",
-        "Candle total": f"{c_total_ms:.0f}ms (no API calls)",
-        "OpenAI total": f"{o_total_ms:.0f}ms (includes API latency)",
+        "Engine search (both, no embed)": f"candle {c_avg:.1f}ms / openai {o_avg:.1f}ms",
+        "Query embed": f"candle {c_embed:.1f}ms local / openai {o_embed:.1f}ms API round trip",
+        "Note": "engine search is the same code path; only the embedder differs",
     })
 
 

--- a/benchmarks/harness.py
+++ b/benchmarks/harness.py
@@ -39,13 +39,37 @@ class MenteDBBenchmark:
             print("Or build from source: cd sdks/python && maturin develop")
             sys.exit(1)
     
-    def store(self, content, memory_type="semantic", tags=None, agent_id=None):
-        """Store a memory and return its ID."""
-        return self.db.store(content, memory_type=memory_type, tags=tags or [])
-    
+    def store(self, content, memory_type="semantic", tags=None, agent_id=None, embedding=None):
+        """Store a memory and return its ID.
+
+        Pass a precomputed ``embedding`` to skip the per item provider call,
+        so bulk inserts can batch embeddings up front (see embed_batch).
+        """
+        return self.db.store(content, memory_type=memory_type, tags=tags or [], embedding=embedding)
+
+    def embed(self, text):
+        """Embed one text through the configured provider (engine binding)."""
+        return self.db.embed(text)
+
+    def embed_batch(self, texts):
+        """Embed many texts in a single provider call, in input order."""
+        return self.db.embed_batch(texts)
+
+    def search_vec(self, embedding, limit=10):
+        """Engine only vector search over a precomputed embedding.
+
+        Same engine path as search_text minus the embedding step, so timing
+        this isolates engine latency from the provider round trip.
+        """
+        try:
+            results = self.db.search(embedding, limit)
+            return [(r.id, r.score) for r in results]
+        except Exception:
+            return []
+
     def search(self, query, limit=10):
         """Search memories using the real HNSW engine via search_text.
-        
+
         Uses hash embedding similarity search through the Rust engine.
         Superseded and contradicted memories are filtered out natively
         by the engine's graph-aware recall_similar.

--- a/benchmarks/scale_10k.py
+++ b/benchmarks/scale_10k.py
@@ -28,6 +28,11 @@ TOPICS = [
     "logging", "ci-cd", "schema", "migration", "config",
 ]
 
+# Texts embedded per provider call. Remote embedders accept many inputs per
+# request, so one call per batch amortizes the network round trip that would
+# otherwise be paid once per memory.
+EMBED_BATCH = 512
+
 BELIEF_CHANGES = {
     500: ("Project alpha uses PostgreSQL for the database.", "Project alpha switched from PostgreSQL to CockroachDB."),
     1500: ("Project beta deploys on AWS ECS.", "Project beta moved from AWS ECS to Kubernetes on GCP."),
@@ -74,52 +79,55 @@ def run_scale_test(force_provider=None):
         embedding_model="text-embedding-3-small" if api_key else None,
     )
 
+    # Build the full ordered insert plan first so embeddings can be batched.
+    # Order within a turn matches the original: any belief original first, then
+    # the regular memory. Belief-change turns insert only the update.
+    ops = []  # (content, tags, role, change_turn)
+    for i in range(10000):
+        turn = generate_memory(i)
+        if i in BELIEF_CHANGES:
+            update_content = BELIEF_CHANGES[i][1]
+            ops.append((update_content, turn["tags"], "update", i))
+            continue
+        for change_turn, (original, _) in BELIEF_CHANGES.items():
+            if i == change_turn - 100:
+                ops.append((original, turn["tags"], "original", change_turn))
+        ops.append((turn["content"], turn["tags"], "regular", None))
+
+    # Phase 1: batch embed every memory. One provider call per EMBED_BATCH
+    # inputs amortizes the network round trip that a naive per item insert pays
+    # once per memory. This time is the embedding provider's, not the engine's.
+    print(f"  Embedding {len(ops)} memories in batches of {EMBED_BATCH}...")
+    contents = [c for (c, _, _, _) in ops]
+    embeddings = []
+    embed_start = time.time()
+    for j in range(0, len(contents), EMBED_BATCH):
+        embeddings.extend(bench.embed_batch(contents[j:j + EMBED_BATCH]))
+    total_embed = time.time() - embed_start
+
+    # Phase 2: store with precomputed embeddings. No provider call on the hot
+    # path, so this times the ENGINE write (storage + index + graph) only.
+    print(f"  Storing {len(ops)} memories (engine write only)...")
     belief_ids = {}
     insert_times = []
     total_start = time.time()
-
-    print(f"  Inserting 10,000 memories...")
-
-    for i in range(10000):
-        turn = generate_memory(i)
-
-        # Insert belief change originals before their supersession turn
-        if i in BELIEF_CHANGES:
-            original, _ = BELIEF_CHANGES[i]
-            # The original was inserted earlier, now insert the update
-            update_content = BELIEF_CHANGES[i][1]
-            t0 = time.time()
-            new_id = bench.store(update_content, memory_type="semantic", tags=turn["tags"])
-            insert_times.append(time.time() - t0)
-
-            if i in belief_ids:
-                bench.relate(new_id, belief_ids[i], "supersedes", weight=1.0)
-            continue
-
-        # Insert belief originals 100 turns before the change
-        for change_turn, (original, _) in BELIEF_CHANGES.items():
-            if i == change_turn - 100:
-                t0 = time.time()
-                orig_id = bench.store(original, memory_type="semantic", tags=turn["tags"])
-                insert_times.append(time.time() - t0)
-                belief_ids[change_turn] = orig_id
-
+    for idx, ((content, tags, role, change_turn), emb) in enumerate(zip(ops, embeddings)):
         t0 = time.time()
-        bench.store(turn["content"], memory_type=turn["type"], tags=turn["tags"])
+        new_id = bench.store(content, memory_type="semantic", tags=tags, embedding=emb)
         insert_times.append(time.time() - t0)
-
-        if (i + 1) % 500 == 0:
-            batch = insert_times[-500:]
-            avg = sum(batch) / len(batch) * 1000
-            elapsed = time.time() - total_start
-            rate = (i + 1) / elapsed
-            remaining = (10000 - i - 1) / rate if rate > 0 else 0
-            print(f"    {i+1}/10000 inserted (avg {avg:.2f}ms last 500, {elapsed:.0f}s elapsed, ~{remaining:.0f}s remaining)")
-
+        if role == "original":
+            belief_ids[change_turn] = new_id
+        elif role == "update" and change_turn in belief_ids:
+            bench.relate(new_id, belief_ids[change_turn], "supersedes", weight=1.0)
+        if (idx + 1) % 2000 == 0:
+            print(f"    {idx+1}/{len(ops)} stored")
     total_insert = time.time() - total_start
 
-    # Search tests
+    # Search tests. Time the provider embed and the engine search SEPARATELY:
+    # a single figure would be dominated by the provider round trip and hide
+    # the engine's real latency.
     search_times = []
+    embed_query_times = []
     stale_found = 0
     correct_found = 0
 
@@ -136,7 +144,11 @@ def run_scale_test(force_provider=None):
 
     for query, expected_keyword, stale_keyword in queries:
         t0 = time.time()
-        results = bench.search(query, limit=10)
+        qvec = bench.embed(query)
+        embed_query_times.append(time.time() - t0)
+
+        t0 = time.time()
+        results = bench.search_vec(qvec, 10)
         search_times.append(time.time() - t0)
 
         for rid, score in results:
@@ -150,14 +162,18 @@ def run_scale_test(force_provider=None):
 
     avg_insert = sum(insert_times) / len(insert_times) * 1000
     avg_search = sum(search_times) / len(search_times) * 1000
+    avg_query_embed = sum(embed_query_times) / len(embed_query_times) * 1000
+    embed_per_mem = total_embed / len(ops) * 1000
+    insert_rate = len(ops) / total_insert if total_insert > 0 else 0
 
     passed = stale_found == 0
     result = {
-        "Total memories": 10000,
+        "Total memories": len(ops),
         "Belief changes": len(BELIEF_CHANGES),
-        "Total insert time": f"{total_insert:.1f}s",
-        "Avg insert": f"{avg_insert:.2f}ms",
-        "Avg search (10K memories)": f"{avg_search:.2f}ms",
+        "Engine insert (write only)": f"{avg_insert:.2f}ms/mem ({insert_rate:.0f} mem/s)",
+        "Batch embed (provider)": f"{embed_per_mem:.2f}ms/mem amortized, {total_embed:.1f}s total",
+        "Engine search at 10K (no embed)": f"{avg_search:.2f}ms",
+        "Query embed (provider round trip)": f"{avg_query_embed:.2f}ms",
         "Correct beliefs found": correct_found,
         "Stale beliefs returned": stale_found,
         "Embedding provider": provider_label,

--- a/crates/mentedb/src/lib.rs
+++ b/crates/mentedb/src/lib.rs
@@ -787,6 +787,19 @@ impl MenteDb {
         }
     }
 
+    /// Generate embeddings for a batch of texts in a single provider call.
+    ///
+    /// Remote embedders accept many inputs per request, so batching amortizes
+    /// the network round trip that otherwise dominates per item insert latency.
+    /// The returned vectors are in the same order as the inputs. Returns None
+    /// if no provider is configured.
+    pub fn embed_batch(&self, texts: &[&str]) -> MenteResult<Option<Vec<Vec<f32>>>> {
+        match &self.embedder {
+            Some(e) => Ok(Some(e.embed_batch(texts)?)),
+            None => Ok(None),
+        }
+    }
+
     /// Stores a memory node into the database.
     ///
     /// The node is persisted to storage, added to all indexes, and registered

--- a/sdks/python/Cargo.lock
+++ b/sdks/python/Cargo.lock
@@ -1525,7 +1525,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb"
-version = "0.13.0"
+version = "0.26.0"
 dependencies = [
  "mentedb-cognitive",
  "mentedb-consolidation",
@@ -1538,6 +1538,8 @@ dependencies = [
  "mentedb-query",
  "mentedb-storage",
  "parking_lot",
+ "serde",
+ "serde_json",
  "thiserror 2.0.18",
  "tracing",
  "uuid",
@@ -1545,7 +1547,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-cognitive"
-version = "0.13.0"
+version = "0.26.0"
 dependencies = [
  "ahash",
  "crossbeam",
@@ -1560,7 +1562,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-consolidation"
-version = "0.13.0"
+version = "0.26.0"
 dependencies = [
  "ahash",
  "mentedb-core",
@@ -1571,7 +1573,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-context"
-version = "0.13.0"
+version = "0.26.0"
 dependencies = [
  "ahash",
  "mentedb-core",
@@ -1583,7 +1585,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-core"
-version = "0.13.0"
+version = "0.26.0"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1598,7 +1600,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-embedding"
-version = "0.13.0"
+version = "0.26.0"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -1619,7 +1621,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-extraction"
-version = "0.13.0"
+version = "0.26.0"
 dependencies = [
  "mentedb-cognitive",
  "mentedb-core",
@@ -1635,7 +1637,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-graph"
-version = "0.13.0"
+version = "0.26.0"
 dependencies = [
  "ahash",
  "bincode",
@@ -1650,7 +1652,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-index"
-version = "0.13.0"
+version = "0.26.0"
 dependencies = [
  "ahash",
  "bincode",
@@ -1688,7 +1690,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-query"
-version = "0.13.0"
+version = "0.26.0"
 dependencies = [
  "mentedb-core",
  "serde",
@@ -1699,7 +1701,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-storage"
-version = "0.13.0"
+version = "0.26.0"
 dependencies = [
  "ahash",
  "bincode",
@@ -1707,6 +1709,7 @@ dependencies = [
  "crc32fast",
  "crossbeam",
  "fs2",
+ "libc",
  "lz4_flex",
  "mentedb-core",
  "parking_lot",

--- a/sdks/python/python/mentedb/client.py
+++ b/sdks/python/python/mentedb/client.py
@@ -107,8 +107,29 @@ class MenteDB:
         """Recall memories using an MQL query string."""
         return self._db.recall(query)
 
+    def embed(self, text: str) -> list[float]:
+        """Embed a single text with the configured provider (hash fallback).
+
+        Useful to time embedding separately from the engine search, or to
+        precompute a vector to pass to ``store(embedding=...)``.
+        """
+        return self._db.embed(text)
+
+    def embed_batch(self, texts: list[str]) -> list[list[float]]:
+        """Embed many texts in one provider call, returned in input order.
+
+        Remote providers accept many inputs per request, so batching amortizes
+        the network round trip that otherwise dominates per item insert latency:
+        embed a batch, then ``store(content, embedding=vec)`` for each.
+        """
+        return self._db.embed_batch(texts)
+
     def search(self, embedding: list[float], k: int = 10):
-        """Vector similarity search. Returns a list of SearchResult."""
+        """Vector similarity search over a precomputed embedding.
+
+        Identical engine path to ``search_text`` without the embedding step,
+        so timing this isolates engine latency from provider round trips.
+        """
         return self._db.search(embedding, k)
 
     def search_text(self, query: str, k: int = 10, tags: list[str] | None = None,

--- a/sdks/python/src/lib.rs
+++ b/sdks/python/src/lib.rs
@@ -306,6 +306,30 @@ impl MenteDB {
             .collect())
     }
 
+    /// Embed a single text with the configured provider (hash fallback when
+    /// none is configured). Lets callers time embedding separately from the
+    /// engine search, or precompute a vector to pass to `store(embedding=...)`.
+    fn embed(&self, text: &str) -> PyResult<Vec<f32>> {
+        Ok(match self.embedder {
+            Some(ref e) => e.embed(text).map_err(to_pyerr)?,
+            None => hash_embedding(text, 384),
+        })
+    }
+
+    /// Embed many texts in a single provider call, returned in input order.
+    /// Remote providers accept many inputs per request, so this amortizes the
+    /// network round trip that otherwise dominates per item insert latency:
+    /// embed a batch, then `store(content, embedding=vec)` for each.
+    fn embed_batch(&self, texts: Vec<String>) -> PyResult<Vec<Vec<f32>>> {
+        Ok(match self.embedder {
+            Some(ref e) => {
+                let refs: Vec<&str> = texts.iter().map(|s| s.as_str()).collect();
+                e.embed_batch(&refs).map_err(to_pyerr)?
+            }
+            None => texts.iter().map(|t| hash_embedding(t, 384)).collect(),
+        })
+    }
+
     /// Text-based similarity search using the configured embedding provider.
     /// Uses OpenAI/Cohere/Voyage if configured, falls back to hash embedding.
     #[pyo3(signature = (query, k=10, tags=None, after=None, before=None))]


### PR DESCRIPTION
## Summary
- Add `embed_batch` to the `MenteDb` facade (batch sibling of `embed_text`) and bind `embed`/`embed_batch` on the Python SDK.
- Rework the scale and candle-vs-openai benchmarks to time the embedding provider round trip separately from the engine, so a remote embedder's network latency is no longer misattributed to search.
- Batch inserts: precompute embeddings in one provider call and pass them to `store(embedding=...)`, paying the round trip once per batch instead of once per memory.
- Update the README benchmark tables to the split numbers.

## Why
The old scale table reported ~431ms search at 10K. That was almost entirely the OpenAI round trip to embed the query, not engine work. Measured with the embedding timed apart, engine search at 10K is ~1.05ms.

## Changes
- `crates/mentedb/src/lib.rs`: `embed_batch` on the facade.
- `sdks/python/src/lib.rs` + `client.py`: `embed`/`embed_batch` bindings; `search` docstring notes engine-only path.
- `benchmarks/harness.py`, `scale_10k.py`, `candle_vs_openai.py`: split embed vs engine timing; batch-embed then store with precomputed vectors.
- `README.md`: honest 10K + candle-vs-openai tables.

## Verification
- `cargo check -p mentedb` and the Python SDK crate build clean.
- Built the SDK with maturin; `embed`, `embed_batch`, `store(embedding=)`, `search(vector)` all work at runtime.
- 10K scale run (candle): engine search 1.05ms, engine insert 13.9ms/mem, 6/6 supersessions tracked, 0 stale returned.
- Verified the supersession invariant through the batched path: superseded original is filtered from recall, update is returned.