### PR TITLE
fix: engine shares the real embedding provider in the Python SDK

### DIFF
--- a/crates/mentedb-index/src/bitmap.rs
+++ b/crates/mentedb-index/src/bitmap.rs
@@ -83,6 +83,19 @@ impl BitmapIndex {
         }
     }
 
+    /// All tags currently indexed that start with the given prefix. Cheap:
+    /// one pass over the tag key set, used to enumerate small controlled
+    /// vocabularies like the `trigger:` namespace.
+    pub fn tags_with_prefix(&self, prefix: &str) -> Vec<String> {
+        let inner = self.inner.read();
+        inner
+            .tag_bitmaps
+            .keys()
+            .filter(|t| t.starts_with(prefix))
+            .cloned()
+            .collect()
+    }
+
     /// Get memory ids that have ALL given tags (intersection).
     pub fn query_tags_and(&self, tags: &[&str]) -> Vec<MemoryId> {
         let inner = self.inner.read();

--- a/crates/mentedb/src/agent_file.rs
+++ b/crates/mentedb/src/agent_file.rs
@@ -106,6 +106,10 @@ pub struct AgentFileIngestReport {
     pub avg_memory_token_estimate: usize,
     /// Which parser produced the atoms: "llm" or "deterministic".
     pub parsed_by: &'static str,
+    /// The distinct action trigger names assigned, so callers can discover
+    /// the open vocabulary the parser chose ("order-refund",
+    /// "ticket-escalation") instead of guessing slugs.
+    pub triggers: Vec<String>,
     /// Number of chunks sent to the LLM (zero for the deterministic parser).
     pub llm_chunks: usize,
 }
@@ -224,6 +228,9 @@ fn segment(md: &str) -> Vec<(String, String)> {
     let mut buf_is_bullet = false;
     let mut in_code = false;
     let mut code_buf: Vec<String> = Vec::new();
+    // True when the line directly above the opening fence held text (no
+    // blank line between): only that text is a caption for the block.
+    let mut caption_adjacent = false;
 
     fn section_of(path: &[(usize, String)]) -> String {
         path.iter()
@@ -258,11 +265,31 @@ fn segment(md: &str) -> Vec<(String, String)> {
             if in_code {
                 let code = code_buf.join("\n").trim().to_string();
                 if !code.is_empty() {
-                    out.push((section_of(&path), format!("code: {code}")));
+                    // Fuse the block with the short caption right above it
+                    // ("Run these before committing:"), so the commands are
+                    // retrievable from natural language questions instead of
+                    // embedding as bare code.
+                    let caption = match out.last() {
+                        Some((sec, text))
+                            if caption_adjacent
+                                && *sec == section_of(&path)
+                                && text.len() <= 120
+                                && !text.starts_with("code: ") =>
+                        {
+                            Some(out.pop().expect("last exists").1)
+                        }
+                        _ => None,
+                    };
+                    let content = match caption {
+                        Some(c) => format!("{c} code: {code}"),
+                        None => format!("code: {code}"),
+                    };
+                    out.push((section_of(&path), content));
                 }
                 code_buf.clear();
                 in_code = false;
             } else {
+                caption_adjacent = !buf.is_empty();
                 flush(&mut buf, &mut buf_is_bullet, &mut out, &section_of(&path));
                 in_code = true;
             }
@@ -535,8 +562,11 @@ impl MenteDb {
                 MemoryType::AntiPattern => report.anti_pattern += 1,
                 _ => report.semantic += 1,
             }
-            if atom.tags.iter().any(|t| t.starts_with("trigger:")) {
+            if let Some(trigger) = atom.tags.iter().find_map(|t| t.strip_prefix("trigger:")) {
                 report.trigger_tagged += 1;
+                if !report.triggers.iter().any(|t| t == trigger) {
+                    report.triggers.push(trigger.to_string());
+                }
             }
         }
         let after = self.count_by_tag(&opts.source_tag);
@@ -737,6 +767,30 @@ mod tests {
         assert!(
             rejoined as f64 > text.len() as f64 * 0.95,
             "splitting must not lose content"
+        );
+    }
+
+    #[test]
+    fn code_blocks_fuse_with_adjacent_captions_only() {
+        // Adjacent caption, no blank line: fused into one retrievable atom.
+        let md = "# Ops\n\nRun these before committing:\n```bash\ncargo test\n```\n";
+        let segs = segment(md);
+        assert!(
+            segs.iter()
+                .any(|(_, t)| t.contains("before committing") && t.contains("code: cargo test")),
+            "adjacent caption must fuse with its code block: {segs:?}"
+        );
+        // Blank line between: the bullet is not a caption, the block stands
+        // alone.
+        let md = "# Ops\n\n- Use thiserror for error types\n\n```bash\ncargo test\n```\n";
+        let segs = segment(md);
+        assert!(
+            segs.iter().any(|(_, t)| t == "code: cargo test"),
+            "non adjacent block stays bare: {segs:?}"
+        );
+        assert!(
+            segs.iter().any(|(_, t)| t.contains("thiserror")),
+            "the bullet survives on its own: {segs:?}"
         );
     }
 

--- a/crates/mentedb/src/agent_file.rs
+++ b/crates/mentedb/src/agent_file.rs
@@ -599,7 +599,7 @@ impl MenteDb {
 /// any language, any kind of agent, atomic self contained memories, open
 /// trigger vocabulary, JSON only.
 #[cfg(feature = "enrichment")]
-const AGENT_FILE_PROMPT: &str = "You parse agent instruction files into individual memories for a memory database. The file may be in ANY format (markdown, plain text, YAML, JSON persona, numbered lists), ANY language, for ANY kind of agent (coding assistant, customer support, sales, trading, scheduling, personal).\n\nReturn ONLY a JSON array. Each element:\n{\"content\": string, \"type\": \"semantic\" | \"procedural\" | \"anti_pattern\", \"trigger\": optional string}\n\nRules:\n- One atomic instruction or fact per element. Split compound rules.\n- content must be self contained: include the context needed to apply it alone (which project, product, tool, or situation it belongs to). Preserve the meaning exactly; keep concrete values, names, numbers, and commands; never invent or generalize away specifics.\n- type: anti_pattern for things the agent must never do; procedural for how to do something, workflows, commands, and rules of conduct; semantic for facts, preferences, and background.\n- trigger: set ONLY when the rule governs one specific recurring action the agent performs, and name that action as a short lowercase kebab case slug. Examples across domains: git-commit, pr-create, order-refund, ticket-escalation, trade-entry, email-send, meeting-schedule. When in doubt, omit trigger.\n- Skip pure formatting, tables of contents, and import references.\n- Output the JSON array only. No markdown fences, no commentary.";
+const AGENT_FILE_PROMPT: &str = "You parse agent instruction files into individual memories for a memory database. The file may be in ANY format (markdown, plain text, YAML, JSON persona, numbered lists), ANY language, for ANY kind of agent (coding assistant, customer support, sales, trading, scheduling, personal).\n\nReturn ONLY a JSON array. Each element:\n{\"content\": string, \"type\": \"semantic\" | \"procedural\" | \"anti_pattern\", \"trigger\": optional string, \"exemplars\": optional array of strings}\n\nRules:\n- One atomic instruction or fact per element. Split compound rules.\n- content must be self contained: include the context needed to apply it alone (which project, product, tool, or situation it belongs to). Preserve the meaning exactly; keep concrete values, names, numbers, and commands; never invent or generalize away specifics.\n- type: anti_pattern for things the agent must never do; procedural for how to do something, workflows, commands, and rules of conduct; semantic for facts, preferences, and background.\n- trigger: set ONLY when the rule governs one specific recurring action or activity of the agent, and name it as a short lowercase kebab case slug. Examples across domains: git-commit, pr-create, order-refund, ticket-escalation, trade-entry, email-send, meeting-schedule, code-change, reply-style. When in doubt, omit trigger.\n- exemplars: when you set a trigger for a standing directive that governs a whole activity (a way of working or replying rather than one discrete command), also give 3 to 5 short example user requests that would enter that activity, phrased the way real users ask (for code-change: \"fix this bug in the auth flow\", \"refactor the retry logic\"). Omit for narrow tool actions.\n- Skip pure formatting, tables of contents, and import references.\n- Output the JSON array only. No markdown fences, no commentary.";
 
 /// Split a large file into LLM sized chunks at section boundaries so no
 /// rule is cut in half.
@@ -680,12 +680,14 @@ fn parse_llm_atoms(raw: &str, opts: &AgentFileIngestOptions) -> Vec<AgentFileAto
             _ => MemoryType::Semantic,
         };
         let mut tags = Vec::new();
+        let mut trigger_slug = None;
         if let Some(trigger) = item
             .get("trigger")
             .and_then(|t| t.as_str())
             .and_then(valid_trigger)
         {
             tags.push(format!("trigger:{trigger}"));
+            trigger_slug = Some(trigger);
         }
         atoms.push(AgentFileAtom {
             section: String::new(),
@@ -694,6 +696,29 @@ fn parse_llm_atoms(raw: &str, opts: &AgentFileIngestOptions) -> Vec<AgentFileAto
             memory_type,
             tags,
         });
+        // Standing directives arrive with exemplar turns: short example
+        // requests that enter the mode. They are stored as activation
+        // anchors for the injection mode channel (mode-exemplar tags keep
+        // them out of ordinary context), never as instructions.
+        if let (Some(trigger), Some(exemplars)) = (
+            trigger_slug,
+            item.get("exemplars").and_then(|e| e.as_array()),
+        ) {
+            for ex in exemplars.iter().take(6) {
+                let Some(text) = ex.as_str() else { continue };
+                let text = text.trim();
+                if text.len() < 4 || text.len() > 400 {
+                    continue;
+                }
+                atoms.push(AgentFileAtom {
+                    section: String::new(),
+                    text: text.to_string(),
+                    content: text.to_string(),
+                    memory_type: MemoryType::Semantic,
+                    tags: vec![format!("mode-exemplar:{trigger}")],
+                });
+            }
+        }
     }
     atoms
 }

--- a/crates/mentedb/src/injection.rs
+++ b/crates/mentedb/src/injection.rs
@@ -87,6 +87,15 @@ pub struct InjectionConfig {
     /// fraction of that hit's score times the edge weight. Keeps neighbors below
     /// direct hits so they only win a slot when there is room after them.
     pub graph_expansion_decay: f32,
+    /// Mode rules: standing directives bound to an activity (working on
+    /// code, composing a reply) carry `trigger:` tags, and a trigger is
+    /// active for a turn when the turn's embedding lands within this cosine
+    /// of one of that trigger's own rules. Self defining and cognitive,
+    /// the rules are their own anchors, no pattern matching anywhere.
+    /// Embedder coupled like every absolute gate. 0 disables the channel.
+    pub mode_trigger_gate: f32,
+    /// Maximum mode rules injected per turn across all active triggers.
+    pub mode_rules_max: usize,
 }
 
 impl Default for InjectionConfig {
@@ -106,6 +115,8 @@ impl Default for InjectionConfig {
             use_reinforcement: 0.05,
             graph_expansion_max: 0,
             graph_expansion_decay: 0.5,
+            mode_trigger_gate: 0.40,
+            mode_rules_max: 4,
         }
     }
 }
@@ -146,6 +157,9 @@ pub enum SelectionReason {
     Pinned,
     /// Survived the relevance knee, MMR, and quotas.
     Relevant,
+    /// A standing directive whose activity mode is active for this turn:
+    /// the turn's embedding landed within the mode gate of the rule.
+    ModeRule,
 }
 
 /// One injection-ready memory with its selection metadata.
@@ -303,6 +317,7 @@ impl MenteDb {
             if has_tag(&node, "action")
                 || has_tag(&node, "scope:always")
                 || has_tag(&node, "ghost-memory")
+                || node.tags.iter().any(|t| t.starts_with("mode-exemplar:"))
             {
                 // Actions never inject; pinned items are handled separately.
                 // Ghost memories are speculative working material for the
@@ -476,6 +491,84 @@ impl MenteDb {
                 });
             }
         }
+        // Mode rules: standing directives bound to an activity rather than a
+        // topic or a tool moment. "Longterm fixes only" must fire for "fix
+        // the login timeout" even though they share no words; the turn's
+        // embedding landing near the rule's own stored embedding is the
+        // activation, cognitive and self defining, dot products only.
+        if cfg.mode_trigger_gate > 0.0 && !query.embedding.is_empty() {
+            let now = now_us();
+            let mut mode_rules: Vec<(f32, MemoryNode)> = Vec::new();
+            for tag in self.index.bitmap.tags_with_prefix("trigger:") {
+                let trigger = tag.trim_start_matches("trigger:");
+                // Activation signal: the trigger's exemplar turns when it
+                // has any (model emitted examples of requests that enter
+                // this mode; a turn matching a turn is the strong signal,
+                // measured), otherwise the rules' own embeddings.
+                let exemplar_tag = format!("mode-exemplar:{trigger}");
+                let mut activation = f32::MIN;
+                let exemplar_ids = self.index.bitmap.query_tag(&exemplar_tag);
+                if exemplar_ids.is_empty() {
+                    for mid in self.index.bitmap.query_tag(&tag) {
+                        if let Ok(node) = self.get_memory(mid)
+                            && node.is_valid_at(now)
+                            && !node.embedding.is_empty()
+                            && crate::agent_visible(node.agent_id, query.agent_id)
+                            && crate::user_visible(node.user_id, query.user_id)
+                        {
+                            let sim = cosine_similarity(query.embedding, &node.embedding);
+                            activation = activation.max(sim);
+                        }
+                    }
+                } else {
+                    for mid in exemplar_ids {
+                        if let Ok(node) = self.get_memory(mid)
+                            && node.is_valid_at(now)
+                            && !node.embedding.is_empty()
+                            && crate::agent_visible(node.agent_id, query.agent_id)
+                            && crate::user_visible(node.user_id, query.user_id)
+                        {
+                            let sim = cosine_similarity(query.embedding, &node.embedding);
+                            activation = activation.max(sim);
+                        }
+                    }
+                }
+                if activation < cfg.mode_trigger_gate {
+                    continue;
+                }
+                // The mode is active: inject its RULES (never exemplars).
+                for mid in self.index.bitmap.query_tag(&tag) {
+                    if excluded.contains(&mid)
+                        || result.iter().any(|c| c.node.id == mid)
+                        || selected.iter().any(|c| c.node.id == mid)
+                        || mode_rules.iter().any(|(_, n)| n.id == mid)
+                    {
+                        continue;
+                    }
+                    let Ok(node) = self.get_memory(mid) else {
+                        continue;
+                    };
+                    if !node.tags.iter().any(|t| t == &tag)
+                        || !node.is_valid_at(now)
+                        || !crate::agent_visible(node.agent_id, query.agent_id)
+                        || !crate::user_visible(node.user_id, query.user_id)
+                    {
+                        continue;
+                    }
+                    mode_rules.push((activation, node));
+                }
+            }
+            mode_rules.sort_by(|a, b| b.0.total_cmp(&a.0));
+            mode_rules.truncate(cfg.mode_rules_max);
+            for (sim, node) in mode_rules {
+                result.push(InjectionCandidate {
+                    node,
+                    score: sim,
+                    reason: SelectionReason::ModeRule,
+                });
+            }
+        }
+
         result.extend(selected);
         Ok(result)
     }

--- a/crates/mentedb/tests/agent_file_llm.rs
+++ b/crates/mentedb/tests/agent_file_llm.rs
@@ -140,3 +140,34 @@ async fn unusable_completion_falls_back_to_deterministic() {
     );
     assert!(report.stored >= 2);
 }
+
+#[tokio::test]
+async fn exemplars_store_as_activation_anchors_not_rules() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = open(dir.path());
+
+    let provider = CannedProvider {
+        response: r#"[
+  {"content": "When changing code, make longterm root cause fixes only, never quick patches", "type": "procedural", "trigger": "code-change", "exemplars": ["fix this bug in the auth flow", "refactor the retry logic", "add rate limiting to the API"]},
+  {"content": "Commit messages are a single line with a conventional prefix", "type": "procedural", "trigger": "git-commit"}
+]"#
+        .to_string(),
+        calls: AtomicUsize::new(0),
+    };
+    let opts = AgentFileIngestOptions::default();
+    let report = db
+        .ingest_agent_file_llm("# Ways of working\n", &opts, &provider)
+        .await
+        .unwrap();
+    assert_eq!(report.parsed_by, "llm");
+    // 2 rules + 3 exemplars all stored through the normal pipeline.
+    assert_eq!(report.stored, 5, "{report:?}");
+
+    // Exemplars carry the mode-exemplar tag for their trigger and never the
+    // trigger tag itself, so the action channel returns only real rules.
+    let rules = db.recall_for_action("code-change", None, None, 10).unwrap();
+    assert_eq!(rules.len(), 1, "{rules:?}");
+    assert!(rules[0].content.contains("root cause"));
+    let anchors = db.recall_for_action("git-commit", None, None, 10).unwrap();
+    assert_eq!(anchors.len(), 1, "{anchors:?}");
+}

--- a/crates/mentedb/tests/mode_activation.rs
+++ b/crates/mentedb/tests/mode_activation.rs
@@ -1,0 +1,252 @@
+//! Mode rules: standing directives ("longterm fixes only", "sound like a
+//! scientist") activate when the turn's embedding lands near the rule's own
+//! stored embedding, never through pattern matching. These tests use
+//! constructed embeddings so the plumbing (enumeration, visibility,
+//! validity, dedup, cap, reason) is pinned deterministically; the semantic
+//! behavior on the real embedder is measured by the deep internal test.
+
+use mentedb::injection::{InjectionConfig, InjectionQuery, SelectionReason};
+use mentedb::prelude::*;
+use mentedb::{CognitiveConfig, MenteDb};
+use mentedb_core::types::AgentId;
+
+const DIM: usize = 8;
+
+fn axis(i: usize, weight: f32) -> Vec<f32> {
+    let mut v = vec![0.0; DIM];
+    v[i] = weight;
+    v
+}
+
+fn directive(content: &str, trigger: &str, embedding: Vec<f32>) -> MemoryNode {
+    let mut node = MemoryNode::new(
+        AgentId::nil(),
+        MemoryType::Procedural,
+        content.to_string(),
+        embedding,
+    );
+    node.tags = vec![format!("trigger:{trigger}")];
+    node
+}
+
+fn open_with_gate(dir: &std::path::Path, gate: f32, max: usize) -> MenteDb {
+    let config = CognitiveConfig {
+        injection_config: InjectionConfig {
+            mode_trigger_gate: gate,
+            mode_rules_max: max,
+            ..InjectionConfig::default()
+        },
+        ..CognitiveConfig::default()
+    };
+    MenteDb::open_with_config(dir, config).unwrap()
+}
+
+fn inject(db: &MenteDb, embedding: &[f32], k: usize) -> Vec<(SelectionReason, String)> {
+    let query = InjectionQuery {
+        embedding,
+        query_text: None,
+        session_id: None,
+        exclude_ids: &[],
+        max_items: k,
+        max_episodic: 2,
+        agent_id: None,
+        user_id: None,
+        current_project: None,
+    };
+    db.recall_for_injection(&query)
+        .unwrap()
+        .into_iter()
+        .map(|c| (c.reason, c.node.content))
+        .collect()
+}
+
+#[test]
+fn directives_activate_by_activity_not_topic() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = open_with_gate(dir.path(), 0.4, 4);
+
+    // Axis 0 is the working activity, axis 1 the replying activity, axis 3
+    // the conversation's actual topic (payment retries, say).
+    db.store(directive(
+        "When working on code changes, longterm root cause fixes only, never quick patches",
+        "code-change",
+        axis(0, 1.0),
+    ))
+    .unwrap();
+    db.store(directive(
+        "Written replies stay precise and measured, like a careful scientist",
+        "reply-style",
+        axis(1, 1.0),
+    ))
+    .unwrap();
+    // Topical memories about the task at hand dominate ordinary retrieval.
+    for i in 0..12 {
+        let node = MemoryNode::new(
+            AgentId::nil(),
+            MemoryType::Semantic,
+            format!("Topical fact {i} about payment retries"),
+            axis(3, 1.0),
+        );
+        db.store(node).unwrap();
+    }
+
+    // The turn is mostly about its topic (0.89 to the topical cluster) and
+    // only faintly near the work directive (0.45): the relevance tail gate
+    // (0.55 of best cosine, 0.49 here) would DROP the directive, which is
+    // the entire reason the mode channel exists. It must arrive as a
+    // ModeRule anyway; the reply directive (cosine 0) stays out entirely.
+    let mut turn = vec![0.0; DIM];
+    turn[0] = 0.45;
+    turn[3] = 0.89;
+    let got = inject(&db, &turn, 6);
+    assert!(
+        got.iter()
+            .any(|(r, c)| *r == SelectionReason::ModeRule && c.contains("root cause")),
+        "the work directive must arrive through the mode channel: {got:?}"
+    );
+    assert!(
+        !got.iter().any(|(_, c)| c.contains("scientist")),
+        "the reply directive must stay inactive for a work turn: {got:?}"
+    );
+
+    // A turn orthogonal to both activities activates neither.
+    let got = inject(&db, &axis(2, 1.0), 6);
+    assert!(
+        !got.iter().any(|(r, _)| *r == SelectionReason::ModeRule),
+        "no directive activates for an unrelated turn: {got:?}"
+    );
+}
+
+#[test]
+fn superseded_and_foreign_directives_never_activate() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = open_with_gate(dir.path(), 0.5, 4);
+
+    let old = directive(
+        "Old rule: quick patches are fine",
+        "code-change",
+        axis(0, 1.0),
+    );
+    let old_id = old.id;
+    db.store(old).unwrap();
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_micros() as u64;
+    db.invalidate_memory(old_id, now).unwrap();
+
+    let other_agent = AgentId::new();
+    let mut foreign = directive(
+        "Foreign agent directive about fixes",
+        "code-change",
+        axis(0, 1.0),
+    );
+    foreign.agent_id = other_agent;
+    db.store(foreign).unwrap();
+
+    let me = AgentId::new();
+    let query = InjectionQuery {
+        embedding: &axis(0, 1.0),
+        query_text: None,
+        session_id: None,
+        exclude_ids: &[],
+        max_items: 6,
+        max_episodic: 2,
+        agent_id: Some(me),
+        user_id: None,
+        current_project: None,
+    };
+    let got: Vec<_> = db
+        .recall_for_injection(&query)
+        .unwrap()
+        .into_iter()
+        .filter(|c| c.reason == SelectionReason::ModeRule)
+        .map(|c| c.node.content)
+        .collect();
+    assert!(
+        got.is_empty(),
+        "superseded and foreign directives must not activate: {got:?}"
+    );
+}
+
+#[test]
+fn mode_rules_respect_cap_and_gate_zero_disables() {
+    // Gate zero disables the channel entirely.
+    let dir = tempfile::tempdir().unwrap();
+    let db = open_with_gate(dir.path(), 0.0, 4);
+    db.store(directive("Any directive", "code-change", axis(0, 1.0)))
+        .unwrap();
+    let got = inject(&db, &axis(0, 1.0), 6);
+    assert!(
+        !got.iter().any(|(r, _)| *r == SelectionReason::ModeRule),
+        "gate zero must disable mode rules: {got:?}"
+    );
+
+    // A tiny cap holds even when many rules activate, best similarities win.
+    let dir = tempfile::tempdir().unwrap();
+    let db = open_with_gate(dir.path(), 0.5, 2);
+    for i in 0..6 {
+        db.store(directive(
+            &format!("Directive number {i}"),
+            &format!("mode-{i}"),
+            axis(0, 1.0),
+        ))
+        .unwrap();
+    }
+    let got = inject(&db, &axis(0, 1.0), 12);
+    let mode_count = got
+        .iter()
+        .filter(|(r, _)| *r == SelectionReason::ModeRule)
+        .count();
+    assert_eq!(mode_count, 2, "mode_rules_max must cap: {got:?}");
+}
+
+#[test]
+fn exemplars_drive_activation_and_never_inject() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = open_with_gate(dir.path(), 0.4, 4);
+
+    // The rule's own embedding is orthogonal to every turn (axis 4): with
+    // rule based activation it could never fire. Its exemplar sits on the
+    // turn axis, so exemplar activation carries it.
+    db.store(directive(
+        "When working on code, longterm root cause fixes only",
+        "code-change",
+        axis(4, 1.0),
+    ))
+    .unwrap();
+    let mut exemplar = MemoryNode::new(
+        AgentId::nil(),
+        MemoryType::Semantic,
+        "fix this bug in the auth code".to_string(),
+        axis(0, 1.0),
+    );
+    exemplar.tags = vec!["mode-exemplar:code-change".to_string()];
+    db.store(exemplar).unwrap();
+    // Topical distractors keep the ordinary relevance path busy so the rule
+    // can only arrive through the mode channel.
+    for i in 0..12 {
+        let node = MemoryNode::new(
+            AgentId::nil(),
+            MemoryType::Semantic,
+            format!("Topical fact {i} about payment retries"),
+            axis(3, 1.0),
+        );
+        db.store(node).unwrap();
+    }
+
+    let mut turn = vec![0.0; DIM];
+    turn[0] = 0.45;
+    turn[3] = 0.89;
+    let got = inject(&db, &turn, 6);
+    assert!(
+        got.iter()
+            .any(|(r, c)| *r == SelectionReason::ModeRule && c.contains("root cause")),
+        "exemplar activation must inject the rule: {got:?}"
+    );
+    assert!(
+        !got.iter()
+            .any(|(_, c)| c.contains("fix this bug in the auth code")),
+        "exemplars are activation metadata and never inject: {got:?}"
+    );
+}

--- a/sdks/python/Cargo.lock
+++ b/sdks/python/Cargo.lock
@@ -1525,7 +1525,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb"
-version = "0.27.2"
+version = "0.27.3"
 dependencies = [
  "mentedb-cognitive",
  "mentedb-consolidation",
@@ -1547,7 +1547,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-cognitive"
-version = "0.27.2"
+version = "0.27.3"
 dependencies = [
  "ahash",
  "crossbeam",
@@ -1562,7 +1562,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-consolidation"
-version = "0.27.2"
+version = "0.27.3"
 dependencies = [
  "ahash",
  "mentedb-core",
@@ -1573,7 +1573,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-context"
-version = "0.27.2"
+version = "0.27.3"
 dependencies = [
  "ahash",
  "mentedb-core",
@@ -1585,7 +1585,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-core"
-version = "0.27.2"
+version = "0.27.3"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1600,7 +1600,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-embedding"
-version = "0.27.2"
+version = "0.27.3"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -1621,7 +1621,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-extraction"
-version = "0.27.2"
+version = "0.27.3"
 dependencies = [
  "mentedb-cognitive",
  "mentedb-core",
@@ -1637,7 +1637,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-graph"
-version = "0.27.2"
+version = "0.27.3"
 dependencies = [
  "ahash",
  "bincode",
@@ -1652,7 +1652,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-index"
-version = "0.27.2"
+version = "0.27.3"
 dependencies = [
  "ahash",
  "bincode",
@@ -1690,7 +1690,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-query"
-version = "0.27.2"
+version = "0.27.3"
 dependencies = [
  "mentedb-core",
  "serde",
@@ -1701,7 +1701,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-storage"
-version = "0.27.2"
+version = "0.27.3"
 dependencies = [
  "ahash",
  "bincode",

--- a/sdks/python/src/lib.rs
+++ b/sdks/python/src/lib.rs
@@ -369,6 +369,9 @@ impl MenteDB {
             dict.set_item("sections", report.sections)?;
             dict.set_item("file_token_estimate", report.file_token_estimate)?;
             dict.set_item("avg_memory_token_estimate", report.avg_memory_token_estimate)?;
+            dict.set_item("parsed_by", report.parsed_by)?;
+            dict.set_item("llm_chunks", report.llm_chunks)?;
+            dict.set_item("triggers", report.triggers.clone())?;
             Ok(dict.into())
         })
     }

--- a/sdks/python/src/lib.rs
+++ b/sdks/python/src/lib.rs
@@ -113,10 +113,31 @@ fn now_us() -> Timestamp {
 // MenteDB
 // ---------------------------------------------------------------------------
 
+/// Shares one embedding provider between the wrapper (which embeds queries
+/// and store() content) and the engine (which embeds for ingest, anchors,
+/// and calibration). Before this, the engine received a hash stand-in and
+/// every engine side embedding for SDK users was non semantic.
+struct SharedEmbedder(std::sync::Arc<dyn EmbeddingProvider>);
+
+impl EmbeddingProvider for SharedEmbedder {
+    fn embed(&self, text: &str) -> mentedb_core::error::MenteResult<Vec<f32>> {
+        self.0.embed(text)
+    }
+    fn embed_batch(&self, texts: &[&str]) -> mentedb_core::error::MenteResult<Vec<Vec<f32>>> {
+        self.0.embed_batch(texts)
+    }
+    fn dimensions(&self) -> usize {
+        self.0.dimensions()
+    }
+    fn model_name(&self) -> &str {
+        self.0.model_name()
+    }
+}
+
 #[pyclass]
 struct MenteDB {
     db: Option<MenteDb>,
-    embedder: Option<Box<dyn EmbeddingProvider>>,
+    embedder: Option<std::sync::Arc<dyn EmbeddingProvider>>,
     delta_tracker: Mutex<DeltaTracker>,
 }
 
@@ -195,14 +216,21 @@ impl MenteDB {
         // An explicit `dimension` lets callers bring their own embeddings at an
         // arbitrary size (for example a 4096-dim external embedder), overriding
         // the provider-derived or default 384 vector dimension.
-        let embedder: Option<Box<dyn EmbeddingProvider>> = if let Some(d) = dimension {
+        let embedder: Option<std::sync::Arc<dyn EmbeddingProvider>> = if let Some(d) = dimension {
+            // Explicit dimension means bring your own vectors: the engine
+            // only needs the dimension, so a hash placeholder is correct.
             db.set_embedder(Box::new(HashEmbeddingProvider::new(d)));
-            Some(Box::new(HashEmbeddingProvider::new(d)))
+            Some(std::sync::Arc::new(HashEmbeddingProvider::new(d)))
         } else {
-            if let Some(ref e) = embedder {
-                db.set_embedder(Box::new(HashEmbeddingProvider::new(e.dimensions())));
+            let shared: Option<std::sync::Arc<dyn EmbeddingProvider>> =
+                embedder.map(std::sync::Arc::from);
+            if let Some(ref e) = shared {
+                // The engine gets the SAME provider, not a stand in, so
+                // engine side embedding (agent file ingest, trigger anchors,
+                // calibration) is as semantic as the wrapper side.
+                db.set_embedder(Box::new(SharedEmbedder(e.clone())));
             }
-            embedder
+            shared
         };
         Ok(Self {
             db: Some(db),


### PR DESCRIPTION
## Summary
- The pyo3 constructor kept the real embedding provider wrapper side and gave the engine a dimension matched hash stand in. Every engine side embedding for SDK users was therefore non semantic: `ingest_agent_file` stored hash vectors while `search_text` queried with real ones (retrieval silently rode the BM25 leg), anchor triggers could never fire, and calibration measured the wrong space.
- Fix: a `SharedEmbedder` Arc adapter hands the engine the same provider the wrapper uses. The explicit `dimension` override keeps its hash placeholder, that mode brings its own vectors by design.

## Verification
- Found empirically: coverage harness showed trigger_tagged 0 under candle; measured anchor sims proved the content was above the gate; constructor read revealed the stand in.
- After the fix, rebuilt wheel: trigger_tagged 3 on the same fixture, commit and PR tasks jump to 100% coverage at k=2 via the action channel, mean coverage@2 42% to 75%.
- cargo check and fmt clean; SDK builds with maturin.