### PR TITLE
feat: truncation tolerant LLM parse, section tags, cluster completion, injection SDK binding

### DIFF
--- a/crates/mentedb/src/agent_file.rs
+++ b/crates/mentedb/src/agent_file.rs
@@ -555,7 +555,9 @@ impl MenteDb {
             node.tags = atom.tags.clone();
             node.tags.push(opts.source_tag.clone());
             self.store(node)?;
-            sections.insert(atom.section.clone());
+            if !atom.section.is_empty() {
+                sections.insert(atom.section.clone());
+            }
             stored_tokens += atom.content.len() / 4;
             match atom.memory_type {
                 MemoryType::Procedural => report.procedural += 1,
@@ -599,7 +601,7 @@ impl MenteDb {
 /// any language, any kind of agent, atomic self contained memories, open
 /// trigger vocabulary, JSON only.
 #[cfg(feature = "enrichment")]
-const AGENT_FILE_PROMPT: &str = "You parse agent instruction files into individual memories for a memory database. The file may be in ANY format (markdown, plain text, YAML, JSON persona, numbered lists), ANY language, for ANY kind of agent (coding assistant, customer support, sales, trading, scheduling, personal).\n\nReturn ONLY a JSON array. Each element:\n{\"content\": string, \"type\": \"semantic\" | \"procedural\" | \"anti_pattern\", \"trigger\": optional string, \"exemplars\": optional array of strings}\n\nRules:\n- One atomic instruction or fact per element. Split compound rules.\n- content must be self contained: include the context needed to apply it alone (which project, product, tool, or situation it belongs to). Preserve the meaning exactly; keep concrete values, names, numbers, and commands; never invent or generalize away specifics.\n- type: anti_pattern for things the agent must never do; procedural for how to do something, workflows, commands, and rules of conduct; semantic for facts, preferences, and background.\n- trigger: set ONLY when the rule governs one specific recurring action or activity of the agent, and name it as a short lowercase kebab case slug. Examples across domains: git-commit, pr-create, order-refund, ticket-escalation, trade-entry, email-send, meeting-schedule, code-change, reply-style. When in doubt, omit trigger.\n- exemplars: when you set a trigger for a standing directive that governs a whole activity (a way of working or replying rather than one discrete command), also give 3 to 5 short example user requests that would enter that activity, phrased the way real users ask (for code-change: \"fix this bug in the auth flow\", \"refactor the retry logic\"). Omit for narrow tool actions.\n- Skip pure formatting, tables of contents, and import references.\n- Output the JSON array only. No markdown fences, no commentary.";
+const AGENT_FILE_PROMPT: &str = "You parse agent instruction files into individual memories for a memory database. The file may be in ANY format (markdown, plain text, YAML, JSON persona, numbered lists), ANY language, for ANY kind of agent (coding assistant, customer support, sales, trading, scheduling, personal).\n\nReturn ONLY a JSON array. Each element:\n{\"content\": string, \"type\": \"semantic\" | \"procedural\" | \"anti_pattern\", \"section\": string, \"trigger\": optional string, \"exemplars\": optional array of strings}\n\nRules:\n- One atomic instruction or fact per element. Split compound rules.\n- content must be self contained: include the context needed to apply it alone (which project, product, tool, or situation it belongs to). Preserve the meaning exactly; keep concrete values, names, numbers, and commands; never invent or generalize away specifics.\n- type: anti_pattern for things the agent must never do; procedural for how to do something, workflows, commands, and rules of conduct; semantic for facts, preferences, and background.\n- trigger: set ONLY when the rule governs one specific recurring action or activity of the agent, and name it as a short lowercase kebab case slug. Examples across domains: git-commit, pr-create, order-refund, ticket-escalation, trade-entry, email-send, meeting-schedule, code-change, reply-style. When in doubt, omit trigger.\n- exemplars: when you set a trigger for a standing directive that governs a whole activity (a way of working or replying rather than one discrete command), also give 3 to 5 short example user requests that would enter that activity, phrased the way real users ask (for code-change: \"fix this bug in the auth flow\", \"refactor the retry logic\"). Omit for narrow tool actions.\n- section: the top level heading or theme of the file this element came from, a short stable name repeated exactly for every element of that part (for example \"App-server API\", \"Testing\", \"Refund policy\"). Elements of one part of the file must share the same section string.\n- Skip pure formatting, tables of contents, and import references.\n- Output the JSON array only. No markdown fences, no commentary.";
 
 /// Split a large file into LLM sized chunks at section boundaries so no
 /// rule is cut in half.
@@ -656,13 +658,28 @@ fn parse_llm_atoms(raw: &str, opts: &AgentFileIngestOptions) -> Vec<AgentFileAto
         Some(i) => i,
         None => return Vec::new(),
     };
-    let end = match raw.rfind(']') {
-        Some(i) if i > start => i,
-        _ => return Vec::new(),
-    };
-    let parsed: Vec<serde_json::Value> = match serde_json::from_str(&raw[start..=end]) {
-        Ok(v) => v,
-        Err(_) => return Vec::new(),
+    let parsed: Vec<serde_json::Value> = match raw
+        .rfind(']')
+        .filter(|end| *end > start)
+        .and_then(|end| serde_json::from_str(&raw[start..=end]).ok())
+    {
+        Some(v) => v,
+        None => {
+            // A completion cut by the output token cap loses the closing
+            // bracket or ends mid element. Recover every complete element
+            // up to the cut instead of dropping the whole chunk.
+            let tail = &raw[start..];
+            match tail.rfind('}') {
+                Some(cut) => {
+                    let repaired = format!("{}]", &tail[..=cut]);
+                    match serde_json::from_str(&repaired) {
+                        Ok(v) => v,
+                        Err(_) => return Vec::new(),
+                    }
+                }
+                None => return Vec::new(),
+            }
+        }
     };
     let mut atoms = Vec::new();
     for item in parsed {
@@ -680,6 +697,14 @@ fn parse_llm_atoms(raw: &str, opts: &AgentFileIngestOptions) -> Vec<AgentFileAto
             _ => MemoryType::Semantic,
         };
         let mut tags = Vec::new();
+        let mut section = String::new();
+        if let Some(name) = item.get("section").and_then(|s| s.as_str()) {
+            let slug = section_slug(name);
+            if !slug.is_empty() {
+                tags.push(format!("section:{slug}"));
+                section = slug;
+            }
+        }
         let mut trigger_slug = None;
         if let Some(trigger) = item
             .get("trigger")
@@ -690,7 +715,7 @@ fn parse_llm_atoms(raw: &str, opts: &AgentFileIngestOptions) -> Vec<AgentFileAto
             trigger_slug = Some(trigger);
         }
         atoms.push(AgentFileAtom {
-            section: String::new(),
+            section,
             text: content.clone(),
             content,
             memory_type,

--- a/crates/mentedb/src/injection.rs
+++ b/crates/mentedb/src/injection.rs
@@ -23,7 +23,7 @@
 //!   memory; chronically ignored memories are demoted at selection time and
 //!   used ones are reinforced.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use mentedb_core::error::MenteResult;
 use mentedb_core::memory::{AttributeValue, MemoryNode, MemoryType};
@@ -42,6 +42,21 @@ pub const ATTR_INJECTION_USED: &str = "injection_used";
 pub struct InjectionConfig {
     /// Retrieval pool fanned out before selection.
     pub candidate_pool: usize,
+    /// Cluster completion: when one section tag dominates the selected
+    /// head (at least this fraction of it, minimum two items), the query
+    /// lives inside that cluster, and the lowest ranked non cluster picks
+    /// are swapped for the section's best remaining siblings. A dense
+    /// cluster of sibling rules then arrives together instead of the top
+    /// sibling crowding the rest out. 0 disables. Off by default until the
+    /// offline sweep settles interactions with MMR and the knee and tail
+    /// gates; the mechanism is pinned by tests at 0.34.
+    pub cluster_dominant_fraction: f32,
+    /// Cap on siblings swapped in by cluster completion.
+    pub cluster_fill_max: usize,
+    /// Sections larger than this never count as clusters: a catch all
+    /// section holding half the file dominates any head trivially and its
+    /// siblings are arbitrary, not coherent.
+    pub cluster_max_span: usize,
     /// MMR relevance weight; the remainder weighs redundancy.
     pub mmr_lambda: f32,
     /// Consecutive score ratio treated as the relevance knee.
@@ -102,6 +117,9 @@ impl Default for InjectionConfig {
     fn default() -> Self {
         Self {
             candidate_pool: 48,
+            cluster_dominant_fraction: 0.0,
+            cluster_fill_max: 4,
+            cluster_max_span: 12,
             mmr_lambda: 0.7,
             knee_gap_ratio: 2.0,
             demotion_shown_min: 5,
@@ -349,6 +367,18 @@ impl MenteDb {
             candidates.push((node, adjusted, cos));
         }
 
+        // Pre gate snapshot of section tagged candidates: cluster completion
+        // may need siblings the knee and tail gates are about to drop.
+        let cluster_pool: Vec<(MemoryNode, f32)> = if cfg.cluster_dominant_fraction > 0.0 {
+            candidates
+                .iter()
+                .filter(|(node, _, _)| node.tags.iter().any(|t| t.starts_with("section:")))
+                .map(|(node, _, cos)| (node.clone(), *cos))
+                .collect()
+        } else {
+            Vec::new()
+        };
+
         // Gates are relative to the query's own best cosine, never an absolute
         // threshold, so they hold across embedders (RRF scores are rank
         // compressed and useless for this; the raw cosine is not).
@@ -426,6 +456,43 @@ impl MenteDb {
             }
         }
 
+        // Cluster dominance is read off the score ranking BEFORE MMR: MMR
+        // deliberately de clusters the head, hiding the very signal cluster
+        // completion needs.
+        let dominant_section: Option<String> = if cfg.cluster_dominant_fraction > 0.0 {
+            let head = scored.len().min(query.max_items.max(3));
+            let mut counts: HashMap<String, usize> = HashMap::new();
+            for (node, _) in &scored[..head] {
+                for tag in &node.tags {
+                    if let Some(sec) = tag.strip_prefix("section:") {
+                        *counts.entry(sec.to_string()).or_insert(0) += 1;
+                    }
+                }
+            }
+            // A section wider than cluster_max_span across the whole pool is
+            // a catch all, not a coherent cluster; it dominates any head
+            // trivially and its siblings are arbitrary.
+            let mut span: HashMap<&str, usize> = HashMap::new();
+            for (node, _) in &cluster_pool {
+                for tag in &node.tags {
+                    if let Some(sec) = tag.strip_prefix("section:") {
+                        *span.entry(sec).or_insert(0) += 1;
+                    }
+                }
+            }
+            let need = ((cfg.cluster_dominant_fraction * head as f32).ceil() as usize).max(2);
+            counts
+                .into_iter()
+                .filter(|(sec, n)| {
+                    *n >= need
+                        && span.get(sec.as_str()).copied().unwrap_or(0) <= cfg.cluster_max_span
+                })
+                .max_by_key(|(_, n)| *n)
+                .map(|(sec, _)| sec)
+        } else {
+            None
+        };
+
         // MMR selection with type quotas.
         let top_score = scored
             .first()
@@ -467,6 +534,50 @@ impl MenteDb {
                 score,
                 reason: SelectionReason::Relevant,
             });
+        }
+
+        // Cluster completion: when one section dominates the selected head,
+        // the turn lives inside that cluster of sibling rules, and embedding
+        // rank underestimates the rest of the cluster (the harness measured
+        // exactly this on a real 22KB agent file: two governing rules ranked
+        // below k=24 behind their own section siblings). Swap the weakest
+        // non cluster tail picks for the section's best remaining siblings,
+        // gates overridden deliberately, bounded by cluster_fill_max.
+        if selected.len() >= 3
+            && let Some(sec) = dominant_section
+        {
+            {
+                let sec_tag = format!("section:{sec}");
+                let mut siblings: Vec<(MemoryNode, f32)> = cluster_pool
+                    .into_iter()
+                    .filter(|(node, _)| {
+                        node.tags.iter().any(|t| t == &sec_tag)
+                            && !selected.iter().any(|c| c.node.id == node.id)
+                    })
+                    .collect();
+                siblings.sort_by(|a, b| b.1.total_cmp(&a.1));
+                siblings.truncate(cfg.cluster_fill_max);
+                // Evict the weakest non cluster picks, never the top pick.
+                // The span cap above keeps this to coherent clusters, where
+                // the cluster hypothesis says sibling relevance is
+                // underestimated by embedding rank.
+                let mut evict: Vec<usize> = (1..selected.len())
+                    .filter(|i| !selected[*i].node.tags.iter().any(|t| t == &sec_tag))
+                    .collect();
+                evict.sort_by(|a, b| {
+                    selected[*a]
+                        .score
+                        .partial_cmp(&selected[*b].score)
+                        .unwrap_or(std::cmp::Ordering::Equal)
+                });
+                for (pos, (node, cos)) in evict.into_iter().zip(siblings) {
+                    selected[pos] = InjectionCandidate {
+                        node,
+                        score: cos,
+                        reason: SelectionReason::Relevant,
+                    };
+                }
+            }
         }
 
         // Pinned memories bypass every gate except the ledger, and lead the

--- a/crates/mentedb/tests/agent_file_llm.rs
+++ b/crates/mentedb/tests/agent_file_llm.rs
@@ -171,3 +171,31 @@ async fn exemplars_store_as_activation_anchors_not_rules() {
     let anchors = db.recall_for_action("git-commit", None, None, 10).unwrap();
     assert_eq!(anchors.len(), 1, "{anchors:?}");
 }
+
+#[tokio::test]
+async fn truncated_completion_recovers_complete_atoms() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = open(dir.path());
+
+    // The output token cap cuts the array mid element: no closing bracket,
+    // a dangling half object. Every complete element must survive.
+    let provider = CannedProvider {
+        response: r#"[
+  {"content": "Refunds over 200 dollars require a manager approval note", "type": "procedural", "section": "Refund policy"},
+  {"content": "Escalate chargebacks to the payments team the same day", "type": "procedural", "section": "Refund policy"},
+  {"content": "Never share internal discount codes wi"#
+            .to_string(),
+        calls: AtomicUsize::new(0),
+    };
+    let opts = AgentFileIngestOptions::default();
+    let report = db
+        .ingest_agent_file_llm("# Support playbook\n", &opts, &provider)
+        .await
+        .unwrap();
+    assert_eq!(report.parsed_by, "llm", "{report:?}");
+    assert_eq!(report.stored, 2, "{report:?}");
+
+    // Section names land as section tags, the cluster signal for injection,
+    // and the report counts the distinct sections the model named.
+    assert_eq!(report.sections, 1, "{report:?}");
+}

--- a/crates/mentedb/tests/cluster_completion.rs
+++ b/crates/mentedb/tests/cluster_completion.rs
@@ -1,0 +1,153 @@
+//! Cluster completion: when one section dominates the selected head, the
+//! turn lives inside that cluster and the section's weak siblings must
+//! arrive too, even past the relevance gates. When no section dominates,
+//! selection is untouched.
+
+use mentedb::injection::{InjectionConfig, InjectionQuery};
+use mentedb::prelude::*;
+use mentedb::{CognitiveConfig, MenteDb};
+use mentedb_core::types::AgentId;
+
+const DIM: usize = 8;
+
+fn axis(i: usize, weight: f32) -> Vec<f32> {
+    let mut v = vec![0.0; DIM];
+    v[i] = weight;
+    v
+}
+
+fn open_with(dir: &std::path::Path, fraction: f32) -> MenteDb {
+    let config = CognitiveConfig {
+        injection_config: InjectionConfig {
+            cluster_dominant_fraction: fraction,
+            ..InjectionConfig::default()
+        },
+        ..CognitiveConfig::default()
+    };
+    MenteDb::open_with_config(dir, config).unwrap()
+}
+
+fn node(content: &str, embedding: Vec<f32>, tags: &[&str]) -> MemoryNode {
+    let mut n = MemoryNode::new(
+        AgentId::nil(),
+        MemoryType::Procedural,
+        content.to_string(),
+        embedding,
+    );
+    n.tags = tags.iter().map(|t| t.to_string()).collect();
+    n
+}
+
+fn seed(db: &MenteDb) {
+    // Four strong cluster leaders and three medium off cluster distractors.
+    for i in 0..4 {
+        db.store(node(
+            &format!("API sibling rule {i} about payload naming"),
+            axis(0, 1.0),
+            &["section:app-server-api"],
+        ))
+        .unwrap();
+    }
+    for i in 0..3 {
+        let mut v = vec![0.0; DIM];
+        v[0] = 0.62;
+        v[5 + (i % 3).min(2)] = 0.78;
+        db.store(node(&format!("Unrelated working note {i}"), v, &[]))
+            .unwrap();
+    }
+    // The governing sibling: same section, but its own embedding sits at
+    // cosine 0.36 to the turn, under the 0.55 relevance tail gate.
+    let mut v = vec![0.0; DIM];
+    v[0] = 0.35;
+    v[4] = 0.90;
+    db.store(node(
+        "Wire fields are camelCase via serde rename_all",
+        v,
+        &["section:app-server-api"],
+    ))
+    .unwrap();
+}
+
+fn contents(db: &MenteDb, k: usize) -> Vec<String> {
+    let turn = axis(0, 1.0);
+    let query = InjectionQuery {
+        embedding: &turn,
+        query_text: None,
+        session_id: None,
+        exclude_ids: &[],
+        max_items: k,
+        max_episodic: 2,
+        agent_id: None,
+        user_id: None,
+        current_project: None,
+    };
+    db.recall_for_injection(&query)
+        .unwrap()
+        .into_iter()
+        .map(|c| c.node.content)
+        .collect()
+}
+
+#[test]
+fn dominant_cluster_pulls_its_gated_sibling_in() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = open_with(dir.path(), 0.34);
+    seed(&db);
+    let got = contents(&db, 6);
+    assert!(
+        got.iter().any(|c| c.contains("camelCase")),
+        "the gated sibling must arrive once its section dominates: {got:?}"
+    );
+}
+
+#[test]
+fn disabled_completion_leaves_gates_in_charge() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = open_with(dir.path(), 0.0);
+    seed(&db);
+    let got = contents(&db, 6);
+    assert!(
+        !got.iter().any(|c| c.contains("camelCase")),
+        "without completion the weak sibling stays gated: {got:?}"
+    );
+}
+
+#[test]
+fn no_dominant_section_means_no_swap() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = open_with(dir.path(), 0.34);
+    // Every atom in its own section: nothing dominates, output matches the
+    // plain selection exactly.
+    for i in 0..6 {
+        db.store(node(
+            &format!("Standalone rule {i}"),
+            axis(0, 1.0 - i as f32 * 0.05),
+            &[&format!("section:sec-{i}")],
+        ))
+        .unwrap();
+    }
+    let mut v = vec![0.0; DIM];
+    v[0] = 0.30;
+    v[4] = 0.9;
+    db.store(node("Far away rule", v, &["section:sec-far"]))
+        .unwrap();
+    let got = contents(&db, 5);
+
+    let dir2 = tempfile::tempdir().unwrap();
+    let db2 = open_with(dir2.path(), 0.0);
+    for i in 0..6 {
+        db2.store(node(
+            &format!("Standalone rule {i}"),
+            axis(0, 1.0 - i as f32 * 0.05),
+            &[&format!("section:sec-{i}")],
+        ))
+        .unwrap();
+    }
+    let mut v = vec![0.0; DIM];
+    v[0] = 0.30;
+    v[4] = 0.9;
+    db2.store(node("Far away rule", v, &["section:sec-far"]))
+        .unwrap();
+    let base = contents(&db2, 5);
+    assert_eq!(got, base, "no dominance means output identical to disabled");
+}

--- a/sdks/python/Cargo.lock
+++ b/sdks/python/Cargo.lock
@@ -1525,7 +1525,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb"
-version = "0.27.3"
+version = "0.28.0"
 dependencies = [
  "mentedb-cognitive",
  "mentedb-consolidation",
@@ -1547,7 +1547,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-cognitive"
-version = "0.27.3"
+version = "0.28.0"
 dependencies = [
  "ahash",
  "crossbeam",
@@ -1562,7 +1562,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-consolidation"
-version = "0.27.3"
+version = "0.28.0"
 dependencies = [
  "ahash",
  "mentedb-core",
@@ -1573,7 +1573,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-context"
-version = "0.27.3"
+version = "0.28.0"
 dependencies = [
  "ahash",
  "mentedb-core",
@@ -1585,7 +1585,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-core"
-version = "0.27.3"
+version = "0.28.0"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1600,7 +1600,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-embedding"
-version = "0.27.3"
+version = "0.28.0"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -1621,7 +1621,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-extraction"
-version = "0.27.3"
+version = "0.28.0"
 dependencies = [
  "mentedb-cognitive",
  "mentedb-core",
@@ -1637,7 +1637,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-graph"
-version = "0.27.3"
+version = "0.28.0"
 dependencies = [
  "ahash",
  "bincode",
@@ -1652,7 +1652,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-index"
-version = "0.27.3"
+version = "0.28.0"
 dependencies = [
  "ahash",
  "bincode",
@@ -1690,7 +1690,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-query"
-version = "0.27.3"
+version = "0.28.0"
 dependencies = [
  "mentedb-core",
  "serde",
@@ -1701,7 +1701,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-storage"
-version = "0.27.3"
+version = "0.28.0"
 dependencies = [
  "ahash",
  "bincode",

--- a/sdks/python/python/mentedb/client.py
+++ b/sdks/python/python/mentedb/client.py
@@ -119,6 +119,15 @@ class MenteDB:
         """
         return self._db.ingest_agent_file(content, agent_id, source_tag)
 
+    def recall_for_injection(self, query: str, k: int = 8,
+                             agent_id: str | None = None) -> list[dict]:
+        """Injection ready context for a turn: relevance, pins, mode rules.
+
+        The same selection get_injection_context serves in production, with
+        content, reason (relevant, pinned, mode_rule), score, and tags.
+        """
+        return self._db.recall_for_injection(query, k, agent_id)
+
     def recall_for_action(self, trigger: str, agent_id: str | None = None,
                           k: int = 6) -> list[dict]:
         """Standing rules for a class of agent actions.

--- a/sdks/python/src/lib.rs
+++ b/sdks/python/src/lib.rs
@@ -376,6 +376,61 @@ impl MenteDB {
         })
     }
 
+    /// Injection ready context for a turn: relevance selection, pins, and
+    /// mode rules, exactly what get_injection_context serves in production.
+    /// Returns a list of dicts with content, reason, and score.
+    #[pyo3(signature = (query, k = 8, agent_id = None))]
+    fn recall_for_injection(
+        &self,
+        query: &str,
+        k: usize,
+        agent_id: Option<&str>,
+    ) -> PyResult<Py<PyAny>> {
+        let db = self
+            .db
+            .as_ref()
+            .ok_or_else(|| PyRuntimeError::new_err("database is closed"))?;
+        let aid = match agent_id {
+            Some(s) => Some(parse_agent_id(s)?),
+            None => None,
+        };
+        let embedding = db
+            .embed_text(query)
+            .map_err(to_pyerr)?
+            .unwrap_or_default();
+        let iq = mentedb::injection::InjectionQuery {
+            embedding: &embedding,
+            query_text: Some(query),
+            session_id: None,
+            exclude_ids: &[],
+            max_items: k,
+            max_episodic: 2,
+            agent_id: aid,
+            user_id: None,
+            current_project: None,
+        };
+        let out = db.recall_for_injection(&iq).map_err(to_pyerr)?;
+        Python::attach(|py| {
+            let list = pyo3::types::PyList::empty(py);
+            for c in out {
+                let dict = pyo3::types::PyDict::new(py);
+                dict.set_item("id", c.node.id.to_string())?;
+                dict.set_item("content", &c.node.content)?;
+                dict.set_item("score", c.score)?;
+                let reason = match c.reason {
+                    mentedb::injection::SelectionReason::Pinned => "pinned",
+                    mentedb::injection::SelectionReason::Relevant => "relevant",
+                    mentedb::injection::SelectionReason::ModeRule => "mode_rule",
+                };
+                dict.set_item("reason", reason)?;
+                let tags: Vec<&str> = c.node.tags.iter().map(|s| s.as_str()).collect();
+                dict.set_item("tags", tags)?;
+                list.append(dict)?;
+            }
+            Ok(list.into())
+        })
+    }
+
     /// Standing rules for a class of agent actions (memories tagged
     /// `trigger:<action>`), newest first, superseded rules excluded. The
     /// action cued recall channel; see the docs on action rules.


### PR DESCRIPTION
## Summary
- Two delivery defects found by the public agent file harness (openai/codex AGENTS.md, temporalio/temporal AGENTS.md), fixed at the root
- Truncated parse completions now recover every complete atom instead of dropping the chunk
- Atoms carry model named section tags; injection gains cluster completion for dense rule clusters, default off pending the tuning sweep
- Python SDK exposes recall_for_injection

## Changes
- agent_file.rs: parse recovers complete elements from completions cut by the output token cap (a rule dense 22KB chunk overflowed 8192 output tokens and stored zero atoms); AGENT_FILE_PROMPT adds a section field, stored as section:<slug> tags and counted in report.sections
- injection.rs: cluster_dominant_fraction / cluster_fill_max / cluster_max_span; dominance read off the pre MMR ranking (MMR de clusters the head by design); catch all sections excluded by span; weakest non cluster picks swapped for the dominant section's best gated siblings; default off, mechanism pinned by tests at 0.34
- sdks/python: recall_for_injection binding + client wrapper (production selection path, benchmarkable)

## Verification
- cargo fmt, clippy -D warnings, test --workspace green; enrichment suite 5 passed (truncation recovery + section tag test added); cluster_completion suite 3 passed including the no dominance no swap identity case
- Measured on the real codex AGENTS.md: recovery turned a zero atom parse into 87 atoms; completion iterations were driven by harness measurements (flattening lift withdrawn, span guard added after the catch all pathology appeared in the data)