### PR TITLE
feat: recall_similar SDK binding for explicit embedding queries

### DIFF
--- a/sdks/python/Cargo.lock
+++ b/sdks/python/Cargo.lock
@@ -1525,7 +1525,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "mentedb-cognitive",
  "mentedb-consolidation",
@@ -1547,7 +1547,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-cognitive"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "ahash",
  "crossbeam",
@@ -1562,7 +1562,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-consolidation"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "ahash",
  "mentedb-core",
@@ -1573,7 +1573,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-context"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "ahash",
  "mentedb-core",
@@ -1585,7 +1585,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-core"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1600,7 +1600,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-embedding"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -1621,7 +1621,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-extraction"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "mentedb-cognitive",
  "mentedb-core",
@@ -1637,7 +1637,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-graph"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "ahash",
  "bincode",
@@ -1652,7 +1652,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-index"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "ahash",
  "bincode",
@@ -1690,7 +1690,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-query"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "mentedb-core",
  "serde",
@@ -1701,7 +1701,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-storage"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "ahash",
  "bincode",

--- a/sdks/python/python/mentedb/client.py
+++ b/sdks/python/python/mentedb/client.py
@@ -119,6 +119,10 @@ class MenteDB:
         """
         return self._db.ingest_agent_file(content, agent_id, source_tag)
 
+    def recall_similar(self, embedding: list[float], k: int = 10) -> list[tuple[str, float]]:
+        """Nearest neighbours for an explicit embedding, any embedding space."""
+        return self._db.recall_similar(embedding, k)
+
     def recall_for_injection(self, query: str, k: int = 8,
                              agent_id: str | None = None) -> list[dict]:
         """Injection ready context for a turn: relevance, pins, mode rules.

--- a/sdks/python/src/lib.rs
+++ b/sdks/python/src/lib.rs
@@ -376,6 +376,22 @@ impl MenteDB {
         })
     }
 
+    /// Nearest neighbours for an explicit embedding: query in whatever
+    /// embedding space the caller stored with, independent of the engine's
+    /// configured provider. Returns (id, score) pairs.
+    #[pyo3(signature = (embedding, k = 10))]
+    fn recall_similar(&self, embedding: Vec<f32>, k: usize) -> PyResult<Vec<(String, f32)>> {
+        let db = self
+            .db
+            .as_ref()
+            .ok_or_else(|| PyRuntimeError::new_err("database is closed"))?;
+        let hits = db.recall_similar(&embedding, k).map_err(to_pyerr)?;
+        Ok(hits
+            .into_iter()
+            .map(|(id, score)| (id.to_string(), score))
+            .collect())
+    }
+
     /// Injection ready context for a turn: relevance selection, pins, and
     /// mode rules, exactly what get_injection_context serves in production.
     /// Returns a list of dicts with content, reason, and score.


### PR DESCRIPTION
## Summary
- Python SDK gains recall_similar(embedding, k) so callers can query in whatever embedding space they stored with, independent of the engine's configured provider

## Changes
- sdks/python/src/lib.rs: recall_similar binding returning (id, score) pairs
- client.py wrapper

## Verification
- Wheel built and exercised by the agent file benchmark harness measuring retrieval in the hosted Cohere 1024 space