### PR TITLE
chore: ignore .claude directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ cargo_errors.txt
 .venv/
 __pycache__/
 *.dSYM/
+.claude/


### PR DESCRIPTION
## Summary
- Adds .claude/ to gitignore so local worktree artifacts can never be committed