### PR TITLE
feat: hybrid action recall, robust under a weak embedder

### DIFF
--- a/crates/mentedb/src/agent_file.rs
+++ b/crates/mentedb/src/agent_file.rs
@@ -12,9 +12,12 @@
 //!   nothing here is specific to developer files.
 //! - The fallback parser (`ingest_agent_file`) is deterministic markdown
 //!   segmentation for installs with no LLM configured: heading paths for
-//!   self contained memories, sentence level atomization, type
-//!   classification, and action triggers by embedding similarity to anchor
-//!   sentences, never string matching.
+//!   self contained memories, sentence level atomization, and type
+//!   classification.
+//!
+//! Which memories bear on an action the agent is about to take is answered at
+//! recall time by [`MenteDb::recall_for_action`], semantic recall re ranked by
+//! how strongly a memory governs behavior, not by any stored action tag.
 //! - Nothing is marked `scope:always` by either parser. The point of
 //!   ingesting an agent file is that no rule rides every turn; rules arrive
 //!   by topic or by action.
@@ -51,16 +54,6 @@ pub struct AgentFileIngestOptions {
     pub max_content_chars: usize,
     /// Batch size for embedding calls.
     pub embed_batch_size: usize,
-    /// Minimum cosine similarity between an atom and a trigger anchor for
-    /// the atom to receive that action trigger tag. Embedding thresholds are
-    /// embedder coupled; the default is backed by measured separations on
-    /// the bundled candle embedder (2026-07: true commit rules 0.53 to 0.72
-    /// including rephrasings, nearest non commit rules 0.35, unrelated prose
-    /// under 0.22), and prefers erring high, a rule firing at the wrong
-    /// moment erodes trust faster than a missing rule. Non semantic hash
-    /// embeddings show no separation at all, so installs on the hash
-    /// fallback assign no anchor triggers.
-    pub trigger_min_similarity: f32,
     /// Chunk size in characters for LLM parsing of large files; chunks split
     /// at section boundaries.
     pub llm_chunk_chars: usize,
@@ -91,7 +84,6 @@ impl Default for AgentFileIngestOptions {
             min_atom_chars: 12,
             max_content_chars: 1800,
             embed_batch_size: 256,
-            trigger_min_similarity: 0.45,
             llm_chunk_chars: 24_000,
             sync: true,
             sync_keep_similarity: 0.97,
@@ -148,39 +140,6 @@ pub struct AgentFileAtom {
     pub tags: Vec<String>,
 }
 
-/// Action trigger anchors: each trigger is defined by exemplar sentences,
-/// and an atom gets the trigger when its embedding lands close enough to an
-/// anchor. Phrasing independent by construction: "no co-author trailers",
-/// "when committing, keep the subject to one line", and "commit style is
-/// conventional" all land near the same anchors without any string
-/// matching. The gate is embedding based, so its threshold is embedder
-/// coupled and lives in [`AgentFileIngestOptions::trigger_min_similarity`],
-/// never hardcoded.
-const TRIGGER_ANCHORS: &[(&str, &[&str])] = &[
-    (
-        "git-commit",
-        &[
-            "rules for writing git commit messages, their style, format, and subject lines",
-            "what a commit message must look like when committing code changes",
-            "conventions for commit trailers, signing, and commit authorship",
-        ],
-    ),
-    (
-        "pr-create",
-        &[
-            "rules for opening pull requests and writing PR descriptions, titles, and bodies",
-            "what to include when creating a pull request for review",
-        ],
-    ),
-    (
-        "git-push",
-        &[
-            "rules about pushing code to remote branches, force pushing, and protected branches",
-            "when it is allowed to push commits to the main branch",
-        ],
-    ),
-];
-
 /// Whitespace and case insensitive content identity, the verbatim leg of
 /// sync survival matching.
 fn norm_content(s: &str) -> String {
@@ -206,26 +165,6 @@ fn cosine(a: &[f32], b: &[f32]) -> f32 {
         return 0.0;
     }
     dot / (na.sqrt() * nb.sqrt())
-}
-
-/// Best matching trigger for an atom embedding, if any anchor clears the
-/// gate. Anchors are grouped per trigger; the best anchor wins.
-fn trigger_for_embedding(
-    atom: &[f32],
-    anchor_embeddings: &[(usize, Vec<f32>)],
-    gate: f32,
-) -> Option<&'static str> {
-    let mut best: Option<(usize, f32)> = None;
-    for (group, emb) in anchor_embeddings {
-        let sim = cosine(atom, emb);
-        if best.is_none_or(|(_, b)| sim > b) {
-            best = Some((*group, sim));
-        }
-    }
-    match best {
-        Some((group, sim)) if sim >= gate => Some(TRIGGER_ANCHORS[group].0),
-        _ => None,
-    }
 }
 
 const RULE_STARTS: &[&str] = &[
@@ -516,7 +455,7 @@ impl MenteDb {
             parsed_by: "deterministic",
             ..Default::default()
         };
-        self.store_atoms(atoms, opts, &mut report, true)?;
+        self.store_atoms(atoms, opts, &mut report)?;
         Ok(report)
     }
 
@@ -525,10 +464,9 @@ impl MenteDb {
     /// store through the full write pipeline, and fill the report.
     fn store_atoms(
         &self,
-        mut atoms: Vec<AgentFileAtom>,
+        atoms: Vec<AgentFileAtom>,
         opts: &AgentFileIngestOptions,
         report: &mut AgentFileIngestReport,
-        assign_anchor_triggers: bool,
     ) -> MenteResult<()> {
         // Batch embed ahead of the stores so a large file pays one provider
         // round trip per batch, not per line.
@@ -539,33 +477,6 @@ impl MenteDb {
                 Some(mut batch) => embeddings.append(&mut batch),
                 None => {
                     embeddings.extend(std::iter::repeat_n(Vec::new(), texts.len()));
-                }
-            }
-        }
-
-        // Fallback trigger assignment: embedding similarity to anchor
-        // sentences, phrasing independent by construction. Skipped when the
-        // LLM already named triggers.
-        if assign_anchor_triggers {
-            let anchor_texts: Vec<&str> = TRIGGER_ANCHORS
-                .iter()
-                .flat_map(|(_, anchors)| anchors.iter().copied())
-                .collect();
-            if let Some(anchor_embs) = self.embed_batch(&anchor_texts)? {
-                let mut grouped: Vec<(usize, Vec<f32>)> = Vec::new();
-                let mut i = 0;
-                for (group, (_, anchors)) in TRIGGER_ANCHORS.iter().enumerate() {
-                    for _ in anchors.iter() {
-                        grouped.push((group, anchor_embs[i].clone()));
-                        i += 1;
-                    }
-                }
-                for (atom, emb) in atoms.iter_mut().zip(&embeddings) {
-                    if let Some(trigger) =
-                        trigger_for_embedding(emb, &grouped, opts.trigger_min_similarity)
-                    {
-                        atom.tags.push(format!("trigger:{trigger}"));
-                    }
                 }
             }
         }
@@ -858,7 +769,7 @@ impl MenteDb {
             llm_chunks: chunks.len(),
             ..Default::default()
         };
-        self.store_atoms(atoms, opts, &mut report, false)?;
+        self.store_atoms(atoms, opts, &mut report)?;
         Ok(report)
     }
 }

--- a/crates/mentedb/src/lib.rs
+++ b/crates/mentedb/src/lib.rs
@@ -433,6 +433,16 @@ pub struct CognitiveConfig {
     /// system, not a hardcoded action vocabulary. Order matches `MemoryType`:
     /// [episodic, semantic, procedural, anti_pattern, reasoning, correction].
     pub action_type_weights: [f32; 6],
+    /// Action recall: relevance added to a candidate that shares a keyword
+    /// with the action text (a BM25/lexical signal). This is what keeps action
+    /// recall working when the embedder is weak or a non-semantic fallback: a
+    /// rule about "git commit" is still found by the words when the vector is
+    /// noise. A candidate is admitted on EITHER a semantic signal (cosine over
+    /// `action_min_similarity`) OR a lexical one (a shared keyword).
+    pub action_keyword_weight: f32,
+    /// Action recall: minimum token length for a word to count as a shared
+    /// keyword, so short glue tokens ("to", "-c") do not create matches.
+    pub action_keyword_min_len: usize,
 }
 
 impl Default for CognitiveConfig {
@@ -476,6 +486,8 @@ impl Default for CognitiveConfig {
             action_overfetch: 5,
             // episodic, semantic, procedural, anti_pattern, reasoning, correction
             action_type_weights: [0.3, 0.5, 1.0, 1.0, 0.7, 1.0],
+            action_keyword_weight: 0.5,
+            action_keyword_min_len: 3,
         }
     }
 }
@@ -554,6 +566,25 @@ pub struct MenteDb {
 /// Agent visibility rule for scoped retrieval: a node is visible to an agent
 /// when it is owned by that agent or owned by no agent (nil, shared
 /// knowledge). No scope means global visibility.
+/// Split text into lowercase alphanumeric tokens of at least `min_len`, the
+/// unit of the lexical (keyword) admit signal for action recall.
+fn keyword_tokens(text: &str, min_len: usize) -> Vec<String> {
+    text.split(|c: char| !c.is_alphanumeric())
+        .filter(|t| t.chars().count() >= min_len)
+        .map(str::to_lowercase)
+        .collect()
+}
+
+/// True when `content` contains any of `action_tokens`, so a rule about "git
+/// commit" is found by the words even when the vector similarity is noise.
+fn shares_keyword(action_tokens: &[String], content: &str, min_len: usize) -> bool {
+    let set: std::collections::HashSet<&str> = action_tokens.iter().map(String::as_str).collect();
+    content
+        .split(|c: char| !c.is_alphanumeric())
+        .filter(|t| t.chars().count() >= min_len)
+        .any(|t| set.contains(t.to_lowercase().as_str()))
+}
+
 /// Index into `CognitiveConfig::action_type_weights` for a memory type. The
 /// order is fixed alongside the weights array; keep the two in lockstep.
 fn action_type_index(t: MemoryType) -> usize {
@@ -1321,12 +1352,21 @@ impl MenteDb {
     /// surfaces the commit-signing rule by understanding, and `ls` surfaces
     /// nothing because nothing is meaningfully about listing files.
     ///
-    /// Scoring is `similarity * type_weight`; candidates below
-    /// `action_min_similarity` are dropped, the rest are ranked and truncated
-    /// to `k`. All knobs live in [`CognitiveConfig`].
+    /// The caller passes both the embedding of the action's meaning AND the
+    /// action text. Candidates come from HYBRID recall (vector nearest
+    /// neighbors fused with BM25 keyword matches on the text), and a candidate
+    /// is admitted on EITHER a semantic signal (true cosine over
+    /// `action_min_similarity`) OR a lexical one (a shared keyword). The
+    /// lexical path is deliberate robustness: when the embedder is weak or a
+    /// non-semantic fallback, the vector is noise and only the words find the
+    /// rule, so the old tag lookup's embedder-independence is preserved without
+    /// its hardcoded action vocabulary. Ranking is
+    /// `(cosine + keyword_bonus) * type_weight`, truncated to `k`. All knobs in
+    /// [`CognitiveConfig`].
     pub fn recall_for_action(
         &self,
         action_embedding: &[f32],
+        action_text: Option<&str>,
         agent_id: Option<AgentId>,
         user_id: Option<UserId>,
         k: usize,
@@ -1340,17 +1380,16 @@ impl MenteDb {
             .unwrap_or_default()
             .as_micros() as u64;
 
-        // The index gives fast candidates by approximate nearest neighbor; the
-        // GATE and RANK use true cosine computed from the embeddings, not the
-        // index's fused score. Absolute cosine thresholds are embedder-coupled
-        // (the whole calibration system exists because fused-score constants
-        // silently broke cognition twice), so scoring on real cosine keeps
-        // `action_min_similarity` meaning what it says.
         let pool = k.saturating_mul(cfg.action_overfetch.max(1));
-        let hits = self.recall_similar_at(action_embedding, pool, now)?;
+        let hits =
+            self.recall_hybrid_at(action_embedding, action_text, pool, now, None, None, None)?;
+
+        let action_tokens: Vec<String> = action_text
+            .map(|t| keyword_tokens(t, cfg.action_keyword_min_len))
+            .unwrap_or_default();
 
         let mut scored: Vec<(MemoryNode, f32)> = Vec::new();
-        for (id, _approx) in hits {
+        for (id, _fused) in hits {
             let Ok(node) = self.get_memory(id) else {
                 continue;
             };
@@ -1360,15 +1399,26 @@ impl MenteDb {
             {
                 continue;
             }
-            let sim = Self::cosine(action_embedding, &node.embedding);
-            if sim < cfg.action_min_similarity {
-                continue;
-            }
             let weight = cfg.action_type_weights[action_type_index(node.memory_type)];
             if weight <= 0.0 {
                 continue;
             }
-            scored.push((node, sim * weight));
+            // True cosine is the semantic signal; a shared keyword is the
+            // lexical one. Absolute cosine thresholds are embedder-coupled, so
+            // the keyword path is what carries recall when the vector is weak.
+            let sim = Self::cosine(action_embedding, &node.embedding);
+            let keyword = !action_tokens.is_empty()
+                && shares_keyword(&action_tokens, &node.content, cfg.action_keyword_min_len);
+            if sim < cfg.action_min_similarity && !keyword {
+                continue;
+            }
+            let relevance = sim
+                + if keyword {
+                    cfg.action_keyword_weight
+                } else {
+                    0.0
+                };
+            scored.push((node, relevance * weight));
         }
         scored.sort_by(|a, b| {
             b.1.partial_cmp(&a.1)

--- a/crates/mentedb/src/lib.rs
+++ b/crates/mentedb/src/lib.rs
@@ -416,6 +416,23 @@ pub struct CognitiveConfig {
     /// and keeps the configured defaults when the embedder cannot separate
     /// paraphrase from noise.
     pub calibration_enabled: bool,
+    /// Action recall: minimum semantic similarity between the meaning of an
+    /// action about to happen and a memory, below which the memory does not
+    /// bear on the action. `recall_for_action` is ordinary semantic recall
+    /// re-ranked by how strongly a memory governs behavior, never a tag lookup.
+    pub action_min_similarity: f32,
+    /// Action recall: candidate over-fetch multiple. Recall pulls
+    /// `action_overfetch * k` by raw similarity, then re-ranks by governing
+    /// weight and truncates to k, so a strongly-governing memory ranked just
+    /// outside the top-k by cosine alone can still surface.
+    pub action_overfetch: usize,
+    /// Action recall: per memory-type weight for how strongly that kind of
+    /// memory governs an action about to happen. Procedures, corrections, and
+    /// anti-patterns govern; facts inform; past events least. This encodes
+    /// "what I know that bears on doing this" as cognition over the type
+    /// system, not a hardcoded action vocabulary. Order matches `MemoryType`:
+    /// [episodic, semantic, procedural, anti_pattern, reasoning, correction].
+    pub action_type_weights: [f32; 6],
 }
 
 impl Default for CognitiveConfig {
@@ -455,6 +472,10 @@ impl Default for CognitiveConfig {
             memory_dedup_token_overlap: 0.85,
             sweep_dedup_token_overlap: 0.55,
             calibration_enabled: true,
+            action_min_similarity: 0.3,
+            action_overfetch: 5,
+            // episodic, semantic, procedural, anti_pattern, reasoning, correction
+            action_type_weights: [0.3, 0.5, 1.0, 1.0, 0.7, 1.0],
         }
     }
 }
@@ -533,6 +554,19 @@ pub struct MenteDb {
 /// Agent visibility rule for scoped retrieval: a node is visible to an agent
 /// when it is owned by that agent or owned by no agent (nil, shared
 /// knowledge). No scope means global visibility.
+/// Index into `CognitiveConfig::action_type_weights` for a memory type. The
+/// order is fixed alongside the weights array; keep the two in lockstep.
+fn action_type_index(t: MemoryType) -> usize {
+    match t {
+        MemoryType::Episodic => 0,
+        MemoryType::Semantic => 1,
+        MemoryType::Procedural => 2,
+        MemoryType::AntiPattern => 3,
+        MemoryType::Reasoning => 4,
+        MemoryType::Correction => 5,
+    }
+}
+
 pub(crate) fn agent_visible(owner: AgentId, scope: Option<AgentId>) -> bool {
     match scope {
         None => true,
@@ -1273,46 +1307,77 @@ impl MenteDb {
     ///   kept both an old rule and its correction, the correction leads.
     ///
     /// An unknown or empty trigger returns an empty vec.
+    /// Recall the memories that bear on an action the agent is about to take.
+    ///
+    /// This is ordinary semantic recall, not a tag lookup: the caller passes the
+    /// embedding of the MEANING of the action about to happen (the command, the
+    /// tool call, the intent), and the engine returns memories that are both
+    /// semantically near that meaning and of a kind that GOVERNS behavior. A
+    /// procedure ("sign commits with 1Password"), a correction, or an
+    /// anti-pattern outranks a merely topical fact or a past event, because the
+    /// type system says which memories govern an action, not a hardcoded
+    /// vocabulary of action names. There is no `trigger:` tag, no command
+    /// classifier, and no string equality anywhere in the path: a git commit
+    /// surfaces the commit-signing rule by understanding, and `ls` surfaces
+    /// nothing because nothing is meaningfully about listing files.
+    ///
+    /// Scoring is `similarity * type_weight`; candidates below
+    /// `action_min_similarity` are dropped, the rest are ranked and truncated
+    /// to `k`. All knobs live in [`CognitiveConfig`].
     pub fn recall_for_action(
         &self,
-        trigger: &str,
+        action_embedding: &[f32],
         agent_id: Option<AgentId>,
         user_id: Option<UserId>,
         k: usize,
     ) -> MenteResult<Vec<MemoryNode>> {
-        let trigger = trigger.trim().to_lowercase();
-        if trigger.is_empty() || k == 0 {
+        if action_embedding.is_empty() || k == 0 {
             return Ok(Vec::new());
         }
-        let tag = format!("trigger:{trigger}");
+        let cfg = &self.cognitive_config;
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
             .as_micros() as u64;
-        let mut rules: Vec<MemoryNode> = Vec::new();
-        for id in self.index.bitmap.query_tag(&tag) {
+
+        // The index gives fast candidates by approximate nearest neighbor; the
+        // GATE and RANK use true cosine computed from the embeddings, not the
+        // index's fused score. Absolute cosine thresholds are embedder-coupled
+        // (the whole calibration system exists because fused-score constants
+        // silently broke cognition twice), so scoring on real cosine keeps
+        // `action_min_similarity` meaning what it says.
+        let pool = k.saturating_mul(cfg.action_overfetch.max(1));
+        let hits = self.recall_similar_at(action_embedding, pool, now)?;
+
+        let mut scored: Vec<(MemoryNode, f32)> = Vec::new();
+        for (id, _approx) in hits {
             let Ok(node) = self.get_memory(id) else {
                 continue;
             };
-            // The bitmap can lag a tag removal (see count_standing_rules);
-            // trust the node, not the index.
-            if !node.tags.iter().any(|t| t == &tag) {
+            if !node.is_valid_at(now)
+                || !agent_visible(node.agent_id, agent_id)
+                || !user_visible(node.user_id, user_id)
+            {
                 continue;
             }
-            if !node.is_valid_at(now) {
+            let sim = Self::cosine(action_embedding, &node.embedding);
+            if sim < cfg.action_min_similarity {
                 continue;
             }
-            if !agent_visible(node.agent_id, agent_id) {
+            let weight = cfg.action_type_weights[action_type_index(node.memory_type)];
+            if weight <= 0.0 {
                 continue;
             }
-            if !user_visible(node.user_id, user_id) {
-                continue;
-            }
-            rules.push(node);
+            scored.push((node, sim * weight));
         }
-        rules.sort_by(|a, b| b.created_at.cmp(&a.created_at).then(b.id.cmp(&a.id)));
-        rules.truncate(k);
-        Ok(rules)
+        scored.sort_by(|a, b| {
+            b.1.partial_cmp(&a.1)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then(b.0.created_at.cmp(&a.0.created_at))
+                .then(b.0.id.cmp(&a.0.id))
+        });
+        scored.truncate(k);
+        Ok(scored.into_iter().map(|(node, _)| node).collect())
     }
 
     /// Vector similarity search at a specific point in time.

--- a/crates/mentedb/tests/action_rules.rs
+++ b/crates/mentedb/tests/action_rules.rs
@@ -65,7 +65,7 @@ fn governing_type_outranks_topical_at_equal_similarity() {
     );
     db.store(episode).unwrap();
 
-    let out = db.recall_for_action(&axis(0), None, None, 8).unwrap();
+    let out = db.recall_for_action(&axis(0), None, None, None, 8).unwrap();
     assert!(!out.is_empty(), "the governing rule must surface");
     assert_eq!(out[0].id, rule_id, "procedure outranks the topical episode");
 }
@@ -84,7 +84,7 @@ fn below_similarity_floor_is_excluded() {
     );
     db.store(unrelated).unwrap();
 
-    let out = db.recall_for_action(&axis(0), None, None, 8).unwrap();
+    let out = db.recall_for_action(&axis(0), None, None, None, 8).unwrap();
     assert!(
         out.is_empty(),
         "an unrelated action pulls no governing rules, got {out:?}"
@@ -114,7 +114,7 @@ fn near_rule_surfaces_over_distant_rule() {
     );
     db.store(deploy_rule).unwrap();
 
-    let out = db.recall_for_action(&axis(0), None, None, 8).unwrap();
+    let out = db.recall_for_action(&axis(0), None, None, None, 8).unwrap();
     assert_eq!(out[0].id, commit_id, "the rule near the action wins");
     assert!(
         out.iter()
@@ -148,7 +148,9 @@ fn respects_agent_and_user_visibility() {
     db.store(shared).unwrap();
 
     // Scoped to agent A: sees A's own rule plus the shared (nil) rule, never B's.
-    let out = db.recall_for_action(&axis(0), Some(a), None, 8).unwrap();
+    let out = db
+        .recall_for_action(&axis(0), None, Some(a), None, 8)
+        .unwrap();
     let contents: Vec<&str> = out.iter().map(|n| n.content.as_str()).collect();
     assert!(contents.contains(&"agent A commit rule"));
     assert!(contents.contains(&"shared commit rule"));
@@ -171,8 +173,52 @@ fn honors_the_k_cap() {
         ))
         .unwrap();
     }
-    let out = db.recall_for_action(&axis(0), None, None, 3).unwrap();
+    let out = db.recall_for_action(&axis(0), None, None, None, 3).unwrap();
     assert_eq!(out.len(), 3, "returns at most k");
+}
+
+#[test]
+fn keyword_admits_a_rule_when_the_vector_is_weak() {
+    // The robustness case: the rule's embedding is ORTHOGONAL to the action
+    // (cosine 0, well under the floor), as happens under a weak or
+    // non-semantic embedder. The shared keyword must still surface it, and an
+    // action with no shared keyword must still surface nothing.
+    let dir = tempfile::tempdir().unwrap();
+    let db = MenteDb::open(dir.path()).expect("open");
+
+    let rule = node(
+        AgentId::nil(),
+        MemoryType::Procedural,
+        "always sign the git commit with 1Password",
+        axis(3),
+    );
+    let rule_id = rule.id;
+    db.store(rule).unwrap();
+
+    // Vector says nothing (query is orthogonal), but the words match.
+    let out = db
+        .recall_for_action(
+            &axis(0),
+            Some("about to run git commit -m fix"),
+            None,
+            None,
+            8,
+        )
+        .unwrap();
+    assert_eq!(
+        out.first().map(|n| n.id),
+        Some(rule_id),
+        "a shared keyword must surface the rule even when the vector is weak"
+    );
+
+    // No shared keyword and no vector signal: nothing surfaces.
+    let out = db
+        .recall_for_action(&axis(0), Some("listing directory entries"), None, None, 8)
+        .unwrap();
+    assert!(
+        out.is_empty(),
+        "an unrelated action with no keyword and no vector match stays silent, got {out:?}"
+    );
 }
 
 #[test]
@@ -186,9 +232,13 @@ fn empty_embedding_or_zero_k_returns_empty() {
         axis(0),
     ))
     .unwrap();
-    assert!(db.recall_for_action(&[], None, None, 8).unwrap().is_empty());
     assert!(
-        db.recall_for_action(&axis(0), None, None, 0)
+        db.recall_for_action(&[], None, None, None, 8)
+            .unwrap()
+            .is_empty()
+    );
+    assert!(
+        db.recall_for_action(&axis(0), None, None, None, 0)
             .unwrap()
             .is_empty()
     );

--- a/crates/mentedb/tests/action_rules.rs
+++ b/crates/mentedb/tests/action_rules.rs
@@ -1,324 +1,195 @@
-//! Action-cued recall (`recall_for_action`): standing rules tagged
-//! `trigger:<action>` that surface at the moment an agent performs that
-//! action, not by topic similarity. These tests pin the contract the hook
-//! integrations depend on: strict trigger matching, agent and user
-//! visibility identical to every other scoped recall, exclusion of
-//! superseded rules, newest-first ordering, and the cap.
+//! Action recall (`recall_for_action`): the memories that bear on an action
+//! the agent is about to take, surfaced by MEANING, not by a `trigger:` tag.
+//!
+//! The caller passes the embedding of the meaning of the action about to
+//! happen; the engine returns memories that are both semantically near that
+//! meaning and of a kind that GOVERNS behavior (a procedure, correction, or
+//! anti-pattern outranks a topical fact or a past event). There is no tag, no
+//! command classifier, and no string equality in the path.
+//!
+//! These tests pin the contract with controlled embeddings, so they are
+//! deterministic and need no network embedder. The end-to-end proof that a
+//! real embedder places "about to git commit" near "sign commits with
+//! 1Password" is a separate live smoke against Bedrock; here we prove the
+//! ranking machinery: semantic floor, type-governing weight, visibility, caps.
 
 use mentedb::MenteDb;
 use mentedb::prelude::*;
 use mentedb_core::types::{AgentId, UserId};
 
-fn rule(agent: AgentId, content: &str, tags: &[&str]) -> MemoryNode {
-    let mut node = MemoryNode::new(agent, MemoryType::Procedural, content.to_string(), vec![]);
-    node.tags = tags.iter().map(|t| t.to_string()).collect();
-    node
+const DIM: usize = 8;
+
+/// A unit vector pointing along axis `i`, so two nodes on the same axis are
+/// maximally similar and nodes on different axes are orthogonal (cosine 0).
+fn axis(i: usize) -> Vec<f32> {
+    let mut v = vec![0.0f32; DIM];
+    v[i] = 1.0;
+    v
+}
+
+/// A vector mostly along `i` with a small tilt toward `j`, for a high-but-not
+/// perfect similarity to `axis(i)`.
+fn near(i: usize, j: usize, tilt: f32) -> Vec<f32> {
+    let mut v = vec![0.0f32; DIM];
+    v[i] = 1.0;
+    v[j] = tilt;
+    v
+}
+
+fn node(agent: AgentId, ty: MemoryType, content: &str, emb: Vec<f32>) -> MemoryNode {
+    MemoryNode::new(agent, ty, content.to_string(), emb)
 }
 
 #[test]
-fn returns_only_matching_trigger() {
+fn governing_type_outranks_topical_at_equal_similarity() {
     let dir = tempfile::tempdir().unwrap();
     let db = MenteDb::open(dir.path()).expect("open");
 
-    let commit = rule(
+    // Both sit on the SAME axis as the action, so raw cosine is identical.
+    // The procedure governs the action; the episode is merely topical. Type
+    // weight, not similarity, must decide the order.
+    let rule = node(
         AgentId::nil(),
-        "never add Co-Authored-By trailers",
-        &["trigger:git-commit"],
+        MemoryType::Procedural,
+        "sign commits with 1Password",
+        axis(0),
     );
-    let commit_id = commit.id;
-    db.store(commit).unwrap();
+    let rule_id = rule.id;
+    db.store(rule).unwrap();
 
-    let pr = rule(
+    let episode = node(
         AgentId::nil(),
-        "PR descriptions use Summary and Verification sections",
-        &["trigger:pr-create"],
+        MemoryType::Episodic,
+        "committed the auth fix yesterday",
+        axis(0),
     );
-    db.store(pr).unwrap();
+    db.store(episode).unwrap();
 
-    let untagged = rule(AgentId::nil(), "the user prefers dark mode", &[]);
-    db.store(untagged).unwrap();
+    let out = db.recall_for_action(&axis(0), None, None, 8).unwrap();
+    assert!(!out.is_empty(), "the governing rule must surface");
+    assert_eq!(out[0].id, rule_id, "procedure outranks the topical episode");
+}
 
-    let rules = db.recall_for_action("git-commit", None, None, 8).unwrap();
-    assert_eq!(rules.len(), 1, "only the git-commit rule should match");
-    assert_eq!(rules[0].id, commit_id);
+#[test]
+fn below_similarity_floor_is_excluded() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = MenteDb::open(dir.path()).expect("open");
 
-    // A plain tag that happens to share the name must not match: the channel
-    // is the `trigger:` namespace, not free-form tags.
-    let plain = rule(AgentId::nil(), "notes about git-commit", &["git-commit"]);
-    db.store(plain).unwrap();
-    let rules = db.recall_for_action("git-commit", None, None, 8).unwrap();
-    assert_eq!(
-        rules.len(),
-        1,
-        "plain tags must not enter the trigger channel"
+    // Orthogonal to the action meaning: cosine 0, well under the floor.
+    let unrelated = node(
+        AgentId::nil(),
+        MemoryType::Procedural,
+        "how to file an expense report",
+        axis(3),
+    );
+    db.store(unrelated).unwrap();
+
+    let out = db.recall_for_action(&axis(0), None, None, 8).unwrap();
+    assert!(
+        out.is_empty(),
+        "an unrelated action pulls no governing rules, got {out:?}"
     );
 }
 
 #[test]
-fn agent_isolation_matches_scoped_recall_semantics() {
+fn near_rule_surfaces_over_distant_rule() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = MenteDb::open(dir.path()).expect("open");
+
+    // Two procedures, equal type weight; only similarity separates them.
+    let commit_rule = node(
+        AgentId::nil(),
+        MemoryType::Procedural,
+        "sign commits with 1Password",
+        near(0, 1, 0.1),
+    );
+    let commit_id = commit_rule.id;
+    db.store(commit_rule).unwrap();
+
+    let deploy_rule = node(
+        AgentId::nil(),
+        MemoryType::Procedural,
+        "run terraform plan before apply",
+        axis(4),
+    );
+    db.store(deploy_rule).unwrap();
+
+    let out = db.recall_for_action(&axis(0), None, None, 8).unwrap();
+    assert_eq!(out[0].id, commit_id, "the rule near the action wins");
+    assert!(
+        out.iter()
+            .all(|n| n.content != "run terraform plan before apply"),
+        "the orthogonal deploy rule is below the floor and excluded"
+    );
+}
+
+#[test]
+fn respects_agent_and_user_visibility() {
     let dir = tempfile::tempdir().unwrap();
     let db = MenteDb::open(dir.path()).expect("open");
 
     let a = AgentId::new();
     let b = AgentId::new();
 
-    let a_rule = rule(
-        a,
-        "agent A: single line commit subjects",
-        &["trigger:git-commit"],
-    );
-    let a_id = a_rule.id;
+    let mut a_rule = node(a, MemoryType::Procedural, "agent A commit rule", axis(0));
+    a_rule.user_id = UserId::nil();
     db.store(a_rule).unwrap();
 
-    let b_rule = rule(b, "agent B: sign commits with gpg", &["trigger:git-commit"]);
-    let b_id = b_rule.id;
+    let mut b_rule = node(b, MemoryType::Procedural, "agent B commit rule", axis(0));
+    b_rule.user_id = UserId::nil();
     db.store(b_rule).unwrap();
 
-    let global = rule(
+    let shared = node(
         AgentId::nil(),
-        "account rule: conventional commit prefixes",
-        &["trigger:git-commit"],
+        MemoryType::Procedural,
+        "shared commit rule",
+        axis(0),
     );
-    let global_id = global.id;
-    db.store(global).unwrap();
-
-    // Agent A sees its own rule plus the account-global rule, never B's.
-    let for_a = db
-        .recall_for_action("git-commit", Some(a), None, 8)
-        .unwrap();
-    let ids: Vec<_> = for_a.iter().map(|n| n.id).collect();
-    assert!(ids.contains(&a_id));
-    assert!(ids.contains(&global_id));
-    assert!(
-        !ids.contains(&b_id),
-        "agent B's rule leaked into agent A's action recall"
-    );
-
-    // Agent B: mirror image.
-    let for_b = db
-        .recall_for_action("git-commit", Some(b), None, 8)
-        .unwrap();
-    let ids: Vec<_> = for_b.iter().map(|n| n.id).collect();
-    assert!(ids.contains(&b_id));
-    assert!(ids.contains(&global_id));
-    assert!(!ids.contains(&a_id));
-
-    // Unscoped (admin) sees everything.
-    let all = db.recall_for_action("git-commit", None, None, 8).unwrap();
-    assert_eq!(all.len(), 3);
-}
-
-#[test]
-fn user_isolation_within_shared_agent() {
-    let dir = tempfile::tempdir().unwrap();
-    let db = MenteDb::open(dir.path()).expect("open");
-
-    let agent = AgentId::new();
-    let u1 = UserId::new();
-    let u2 = UserId::new();
-
-    let mut u1_rule = rule(
-        agent,
-        "user one: no emojis in commits",
-        &["trigger:git-commit"],
-    );
-    u1_rule.user_id = u1;
-    let u1_id = u1_rule.id;
-    db.store(u1_rule).unwrap();
-
-    let mut u2_rule = rule(agent, "user two: emoji away", &["trigger:git-commit"]);
-    u2_rule.user_id = u2;
-    let u2_id = u2_rule.id;
-    db.store(u2_rule).unwrap();
-
-    let shared = rule(
-        agent,
-        "shared: imperative mood subjects",
-        &["trigger:git-commit"],
-    );
-    let shared_id = shared.id;
     db.store(shared).unwrap();
 
-    let for_u1 = db
-        .recall_for_action("git-commit", Some(agent), Some(u1), 8)
-        .unwrap();
-    let ids: Vec<_> = for_u1.iter().map(|n| n.id).collect();
-    assert!(ids.contains(&u1_id));
+    // Scoped to agent A: sees A's own rule plus the shared (nil) rule, never B's.
+    let out = db.recall_for_action(&axis(0), Some(a), None, 8).unwrap();
+    let contents: Vec<&str> = out.iter().map(|n| n.content.as_str()).collect();
+    assert!(contents.contains(&"agent A commit rule"));
+    assert!(contents.contains(&"shared commit rule"));
     assert!(
-        ids.contains(&shared_id),
-        "nil-user rules are shared knowledge"
-    );
-    assert!(
-        !ids.contains(&u2_id),
-        "user two's rule leaked into user one's action recall"
+        !contents.contains(&"agent B commit rule"),
+        "must never surface another agent's rule"
     );
 }
 
 #[test]
-fn superseded_rule_stops_firing() {
+fn honors_the_k_cap() {
     let dir = tempfile::tempdir().unwrap();
     let db = MenteDb::open(dir.path()).expect("open");
-
-    let old = rule(
-        AgentId::nil(),
-        "commit messages may include emojis",
-        &["trigger:git-commit"],
-    );
-    let old_id = old.id;
-    db.store(old).unwrap();
-
-    let new = rule(
-        AgentId::nil(),
-        "commit messages must not include emojis",
-        &["trigger:git-commit"],
-    );
-    let new_id = new.id;
-    db.store(new).unwrap();
-
-    // Mirror what supersession does: a Supersedes edge plus temporal
-    // invalidation of the replaced rule (write inference and the platform
-    // both invalidate through this same path).
-    db.relate(MemoryEdge {
-        source: new_id,
-        target: old_id,
-        edge_type: EdgeType::Supersedes,
-        weight: 1.0,
-        created_at: 0,
-        valid_from: None,
-        valid_until: None,
-        label: None,
-    })
-    .unwrap();
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_micros() as u64;
-    db.invalidate_memory(old_id, now).unwrap();
-
-    let rules = db.recall_for_action("git-commit", None, None, 8).unwrap();
-    let ids: Vec<_> = rules.iter().map(|n| n.id).collect();
-    assert!(ids.contains(&new_id), "the correction must fire");
-    assert!(
-        !ids.contains(&old_id),
-        "a superseded rule fired: the exact bug this channel must never have"
-    );
-}
-
-#[test]
-fn newest_first_and_capped() {
-    let dir = tempfile::tempdir().unwrap();
-    let db = MenteDb::open(dir.path()).expect("open");
-
-    // Explicit created_at stamps so the ordering assertion is deterministic.
-    let base = 1_700_000_000_000_000u64;
-    let mut ids = Vec::new();
-    for i in 0..6u64 {
-        let mut node = rule(
+    for i in 0..6 {
+        db.store(node(
             AgentId::nil(),
-            &format!("rule number {i}"),
-            &["trigger:git-commit"],
-        );
-        node.created_at = base + i * 1_000_000;
-        ids.push((node.id, node.created_at));
-        db.store(node).unwrap();
-    }
-
-    let rules = db.recall_for_action("git-commit", None, None, 3).unwrap();
-    assert_eq!(rules.len(), 3, "cap must hold");
-    let got: Vec<_> = rules.iter().map(|n| n.created_at).collect();
-    let mut expected: Vec<_> = ids.iter().map(|(_, t)| *t).collect();
-    expected.sort_unstable_by(|a, b| b.cmp(a));
-    assert_eq!(got, expected[..3].to_vec(), "newest rules must lead");
-}
-
-#[test]
-fn unknown_trigger_empty_trigger_and_zero_k() {
-    let dir = tempfile::tempdir().unwrap();
-    let db = MenteDb::open(dir.path()).expect("open");
-
-    db.store(rule(
-        AgentId::nil(),
-        "never force push to main",
-        &["trigger:git-push"],
-    ))
-    .unwrap();
-
-    assert!(
-        db.recall_for_action("deploy", None, None, 8)
-            .unwrap()
-            .is_empty()
-    );
-    assert!(db.recall_for_action("", None, None, 8).unwrap().is_empty());
-    assert!(
-        db.recall_for_action("   ", None, None, 8)
-            .unwrap()
-            .is_empty()
-    );
-    assert!(
-        db.recall_for_action("git-push", None, None, 0)
-            .unwrap()
-            .is_empty()
-    );
-    // Case-normalized lookup: the documented tag form is lowercase.
-    assert_eq!(
-        db.recall_for_action("Git-Push", None, None, 8)
-            .unwrap()
-            .len(),
-        1
-    );
-}
-
-#[test]
-fn correct_at_scale_without_scanning() {
-    let dir = tempfile::tempdir().unwrap();
-    let db = MenteDb::open(dir.path()).expect("open");
-
-    // A realistic corpus: thousands of ordinary memories, a handful of rules.
-    for i in 0..2000 {
-        db.store(rule(
-            AgentId::nil(),
-            &format!("ordinary memory {i} about work"),
-            &[],
+            MemoryType::Procedural,
+            &format!("commit rule {i}"),
+            near(0, (i % (DIM - 1)) + 1, 0.05),
         ))
         .unwrap();
     }
-    let mut expected = Vec::new();
-    for i in 0..3 {
-        let node = rule(
-            AgentId::nil(),
-            &format!("commit rule {i}"),
-            &["trigger:git-commit"],
-        );
-        expected.push(node.id);
-        db.store(node).unwrap();
-    }
-
-    let rules = db.recall_for_action("git-commit", None, None, 8).unwrap();
-    assert_eq!(rules.len(), 3);
-    for id in expected {
-        assert!(rules.iter().any(|n| n.id == id));
-    }
+    let out = db.recall_for_action(&axis(0), None, None, 3).unwrap();
+    assert_eq!(out.len(), 3, "returns at most k");
 }
 
 #[test]
-fn read_only_no_counter_or_decay_writes() {
+fn empty_embedding_or_zero_k_returns_empty() {
     let dir = tempfile::tempdir().unwrap();
     let db = MenteDb::open(dir.path()).expect("open");
-
-    let node = rule(AgentId::nil(), "squash merge only", &["trigger:git-commit"]);
-    let id = node.id;
-    db.store(node).unwrap();
-
-    let before = db.get_memory(id).unwrap();
-    for _ in 0..5 {
-        db.recall_for_action("git-commit", None, None, 8).unwrap();
-    }
-    let after = db.get_memory(id).unwrap();
-
-    assert_eq!(before.access_count, after.access_count, "no access bumps");
-    assert_eq!(
-        before.accessed_at, after.accessed_at,
-        "no decay clock touch"
+    db.store(node(
+        AgentId::nil(),
+        MemoryType::Procedural,
+        "a rule",
+        axis(0),
+    ))
+    .unwrap();
+    assert!(db.recall_for_action(&[], None, None, 8).unwrap().is_empty());
+    assert!(
+        db.recall_for_action(&axis(0), None, None, 0)
+            .unwrap()
+            .is_empty()
     );
-    assert_eq!(before.salience, after.salience, "no salience change");
 }

--- a/crates/mentedb/tests/agent_file_ingest.rs
+++ b/crates/mentedb/tests/agent_file_ingest.rs
@@ -37,38 +37,18 @@ fn ingests_the_real_claude_md() {
         "section paths must nest: {}",
         report.sections
     );
-    // The hash embedder is non semantic, so anchor triggers must stay
-    // silent rather than false fire (measured: no separation exists under
-    // hash). Positive trigger coverage lives in the LLM parser tests and in
-    // the measured candle separations backing the 0.45 default.
-    assert_eq!(report.trigger_tagged, 0, "no false triggers under hash");
+    // The deterministic parser assigns no action tags at all: which memories
+    // bear on an action is decided at recall time by recall_for_action
+    // (semantic), never stamped at ingest. So the report carries no triggers.
+    assert_eq!(
+        report.trigger_tagged, 0,
+        "deterministic parser stamps no triggers"
+    );
     assert!(report.procedural > 0 && report.semantic > 0);
     assert!(
         report.file_token_estimate > report.avg_memory_token_estimate * 4,
         "atoms must be much smaller than the file"
     );
-}
-
-#[test]
-fn no_false_triggers_under_a_non_semantic_embedder() {
-    // Anchor triggers are embedding based; the hash embedder has no
-    // semantics, so the guarantee that matters here is silence: nothing
-    // fires at the wrong moment. The positive path, rules firing through
-    // recall_for_action after ingest, is covered by the LLM parser tests
-    // (open vocabulary triggers) and by measured candle separations.
-    let dir = tempfile::tempdir().unwrap();
-    let db = open(dir.path());
-    db.ingest_agent_file(CLAUDE_MD, &AgentFileIngestOptions::default())
-        .unwrap();
-
-    for action in ["git-commit", "pr-create", "git-push", "deploy"] {
-        let rules = db.recall_for_action(action, None, None, 8).unwrap();
-        assert!(
-            rules.is_empty(),
-            "hash embedder must never assign triggers, {action} fired: {:?}",
-            rules.iter().map(|r| &r.content).collect::<Vec<_>>()
-        );
-    }
 }
 
 #[test]

--- a/crates/mentedb/tests/agent_file_llm.rs
+++ b/crates/mentedb/tests/agent_file_llm.rs
@@ -32,6 +32,21 @@ fn open(dir: &std::path::Path) -> MenteDb {
     MenteDb::open_with_embedder(dir, Box::new(HashEmbeddingProvider::new(256))).expect("open")
 }
 
+/// Contents of the memories the LLM parser tagged for a given action. The
+/// trigger tag is the mode-activation join key the parser still writes; which
+/// memories bear on an action at RECALL time is answered semantically by
+/// `recall_for_action`, proven under a real embedder in `action_rules` and the
+/// live smoke, not here under the non-semantic hash embedder.
+fn tagged(db: &MenteDb, trigger: &str) -> Vec<String> {
+    let tag = format!("trigger:{trigger}");
+    db.memory_ids()
+        .into_iter()
+        .filter_map(|id| db.get_memory(id).ok())
+        .filter(|n| n.tags.iter().any(|t| t == &tag))
+        .map(|n| n.content)
+        .collect()
+}
+
 #[tokio::test]
 async fn llm_parse_stores_open_vocabulary_triggers() {
     let dir = tempfile::tempdir().unwrap();
@@ -69,15 +84,15 @@ async fn llm_parse_stores_open_vocabulary_triggers() {
     // rejected so that entry stays a plain memory.
     assert_eq!(report.trigger_tagged, 2);
 
-    let refund = db.recall_for_action("order-refund", None, None, 8).unwrap();
+    let refund = tagged(&db, "order-refund");
     assert_eq!(refund.len(), 1);
-    assert!(refund[0].content.contains("manager approval"));
+    assert!(refund[0].contains("manager approval"));
 
-    let trade = db.recall_for_action("trade-entry", None, None, 8).unwrap();
+    let trade = tagged(&db, "trade-entry");
     assert_eq!(trade.len(), 1);
-    assert!(trade[0].content.contains("one percent"));
+    assert!(trade[0].contains("one percent"));
 
-    let none = db.recall_for_action("always", None, None, 8).unwrap();
+    let none = tagged(&db, "always");
     assert!(none.is_empty(), "always must never become a trigger");
 }
 
@@ -164,11 +179,11 @@ async fn exemplars_store_as_activation_anchors_not_rules() {
     assert_eq!(report.stored, 5, "{report:?}");
 
     // Exemplars carry the mode-exemplar tag for their trigger and never the
-    // trigger tag itself, so the action channel returns only real rules.
-    let rules = db.recall_for_action("code-change", None, None, 10).unwrap();
+    // trigger tag itself, so the trigger channel names only real rules.
+    let rules = tagged(&db, "code-change");
     assert_eq!(rules.len(), 1, "{rules:?}");
-    assert!(rules[0].content.contains("root cause"));
-    let anchors = db.recall_for_action("git-commit", None, None, 10).unwrap();
+    assert!(rules[0].contains("root cause"));
+    let anchors = tagged(&db, "git-commit");
     assert_eq!(anchors.len(), 1, "{anchors:?}");
 }
 


### PR DESCRIPTION
## Summary
- recall_for_action takes the action text and uses recall_hybrid_at (vector + BM25). Admit on cosine-over-floor OR a shared keyword; rank by (cosine + keyword_bonus) * type_weight.
- Fixes a real gap the CI surfaced: pure-vector recall returned nothing under a non-semantic embedder (hash fallback), where the old tag lookup worked regardless. The keyword path restores that robustness without a hardcoded action vocabulary.
- New config: action_keyword_weight (0.5), action_keyword_min_len (3).

## Verification
- action_rules.rs 7/7 including a new test: a rule whose embedding is ORTHOGONAL to the action (cosine 0) surfaces via a shared keyword, and an unrelated action stays silent.
- Full workspace green (747), clippy --all-features clean, fmt applied.