### PR TITLE
fix: violated-rule escalation actually re-ranks injection

### DIFF
--- a/crates/mentedb/src/injection.rs
+++ b/crates/mentedb/src/injection.rs
@@ -68,6 +68,18 @@ pub struct InjectionConfig {
     /// account's shared nil owned memories; measured on a busy account,
     /// shared memories otherwise flood the relevant slots. 1.0 disables.
     pub own_agent_boost: f32,
+    /// Score multiplier for a memory tagged `escalated:violation`: a standing
+    /// rule the agent was shown and then broke. Escalation exists so a rule
+    /// that was violated once surfaces at the FRONT the next time its context
+    /// recurs, not buried mid-list where it was ignored. Without this the
+    /// escalation only bumps salience, which injection does not rank on, so the
+    /// correction would not stick. 1.0 disables.
+    pub escalation_boost: f32,
+    /// The boost applies only to an escalated rule whose cosine is at least
+    /// this fraction of the query's best cosine, so escalation reorders rules
+    /// that are genuinely on topic and never drags an unrelated escalated rule
+    /// into the context on the strength of the boost alone.
+    pub escalation_min_relevance: f32,
     /// MMR relevance weight; the remainder weighs redundancy.
     pub mmr_lambda: f32,
     /// Consecutive score ratio treated as the relevance knee.
@@ -133,6 +145,8 @@ impl Default for InjectionConfig {
             cluster_max_span: 12,
             use_lexical_leg: true,
             own_agent_boost: 1.25,
+            escalation_boost: 2.5,
+            escalation_min_relevance: 0.5,
             mmr_lambda: 0.7,
             knee_gap_ratio: 2.0,
             demotion_shown_min: 5,
@@ -419,6 +433,26 @@ impl MenteDb {
             idx += 1;
             keep
         });
+
+        // Escalation re-ranks AMONG the relevance survivors: a rule the agent
+        // was shown and then broke leads the next time its context recurs. It
+        // runs here, after the cosine gates, so the boost can never drag an
+        // irrelevant escalated rule into the context, only reorder rules that
+        // already earned their place.
+        if cfg.escalation_boost != 1.0
+            && candidates
+                .iter()
+                .any(|(n, _, _)| has_tag(n, "escalated:violation"))
+        {
+            let relevance_floor = best_cos * cfg.escalation_min_relevance;
+            for (node, adjusted, cos) in candidates.iter_mut() {
+                if has_tag(node, "escalated:violation") && *cos >= relevance_floor {
+                    *adjusted *= cfg.escalation_boost;
+                }
+            }
+            candidates.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        }
+
         let mut scored: Vec<(MemoryNode, f32)> =
             candidates.into_iter().map(|(n, s, _)| (n, s)).collect();
 

--- a/crates/mentedb/tests/injection_escalation.rs
+++ b/crates/mentedb/tests/injection_escalation.rs
@@ -1,0 +1,104 @@
+//! Violated-rule escalation must change what gets INJECTED, not just bump a
+//! salience number injection never reads. A rule the agent was shown and then
+//! broke (tagged `escalated:violation`) must surface at the front the next
+//! time its context recurs, so the correction sticks instead of being ignored
+//! again from mid-list.
+
+use mentedb::MenteDb;
+use mentedb::injection::InjectionQuery;
+use mentedb::prelude::*;
+use mentedb_core::types::AgentId;
+
+const DIM: usize = 8;
+
+fn axis(i: usize) -> Vec<f32> {
+    let mut v = vec![0.0f32; DIM];
+    v[i] = 1.0;
+    v
+}
+
+fn inject<'a>(emb: &'a [f32]) -> InjectionQuery<'a> {
+    InjectionQuery {
+        embedding: emb,
+        query_text: None,
+        session_id: None,
+        exclude_ids: &[],
+        max_items: 6,
+        max_episodic: 2,
+        agent_id: None,
+        user_id: None,
+        current_project: None,
+    }
+}
+
+#[test]
+fn escalated_rule_leads_over_an_equally_similar_peer() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = MenteDb::open(dir.path()).unwrap();
+
+    // Two procedures with the SAME embedding as the query, so cosine cannot
+    // separate them. Same type too, so type quotas cannot. Only the escalation
+    // tag differs.
+    let peer = MemoryNode::new(
+        AgentId::nil(),
+        MemoryType::Procedural,
+        "prefer conventional commit prefixes for messages".to_string(),
+        axis(0),
+    );
+    db.store(peer).unwrap();
+
+    let mut escalated = MemoryNode::new(
+        AgentId::nil(),
+        MemoryType::Procedural,
+        "read the run output before reporting a deploy as green".to_string(),
+        axis(0),
+    );
+    escalated.tags = vec!["escalated:violation".to_string()];
+    let escalated_id = escalated.id;
+    db.store(escalated).unwrap();
+
+    let q = axis(0);
+    let out = db.recall_for_injection(&inject(&q)).unwrap();
+
+    assert!(!out.is_empty(), "both rules should be injectable");
+    assert_eq!(
+        out[0].node.id,
+        escalated_id,
+        "the violated rule must lead, got order: {:?}",
+        out.iter().map(|c| &c.node.content).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn escalation_does_not_resurrect_an_irrelevant_rule() {
+    // The boost re-ranks among relevant candidates; it must not drag an
+    // escalated rule that is unrelated to the turn into the context.
+    let dir = tempfile::tempdir().unwrap();
+    let db = MenteDb::open(dir.path()).unwrap();
+
+    let mut escalated = MemoryNode::new(
+        AgentId::nil(),
+        MemoryType::Procedural,
+        "escalated rule about a completely unrelated activity".to_string(),
+        axis(3),
+    );
+    escalated.tags = vec!["escalated:violation".to_string()];
+    db.store(escalated).unwrap();
+
+    let relevant = MemoryNode::new(
+        AgentId::nil(),
+        MemoryType::Procedural,
+        "the rule that actually matches this action".to_string(),
+        axis(0),
+    );
+    let relevant_id = relevant.id;
+    db.store(relevant).unwrap();
+
+    let q = axis(0);
+    let out = db.recall_for_injection(&inject(&q)).unwrap();
+    assert_eq!(
+        out.first().map(|c| c.node.id),
+        Some(relevant_id),
+        "an orthogonal escalated rule must not outrank the relevant one"
+    );
+}


### PR DESCRIPTION
## Summary
The accountability pass (shipped v0.8.57) escalates a violated rule by setting salience to 1.0 and tagging escalated:violation. But injection ranking never reads salience, so the escalation was cosmetic: a rule the agent broke did not surface higher next time. This makes escalation real.

- Injection boosts escalated:violation memories (escalation_boost, 2.5), applied AFTER the cosine relevance gates and only when the rule's cosine is at least escalation_min_relevance (0.5) of the query's best. So it re-ranks genuinely on-topic rules to the front and never resurfaces an unrelated escalated rule.
- The tag string matches the platform accountability pass exactly (escalated:violation).

## Verification
- 2 new tests: escalated rule leads over an equal-cosine peer; an orthogonal escalated rule does not outrank the relevant one.
- Full workspace green (749), clippy --all-features clean, fmt applied.