### PR TITLE
feat: index-backed dashboard reads (newest, tag, conflict counts)

### DIFF
--- a/crates/mentedb-index/src/temporal.rs
+++ b/crates/mentedb-index/src/temporal.rs
@@ -49,6 +49,41 @@ impl TemporalIndex {
             .collect()
     }
 
+    /// The newest `limit` ids (descending by timestamp) that are not in `skip`,
+    /// beginning after `after` when it is given. Walks only the in-memory index
+    /// and loads nothing; stops as soon as `limit` ids are collected, so the
+    /// cost is bounded by the page returned rather than the whole index. When
+    /// `after` is set, ids are passed over in the descending walk until `after`
+    /// itself is seen, which makes this serve cursor pagination too.
+    pub fn latest_filtered(
+        &self,
+        limit: usize,
+        skip: &std::collections::HashSet<MemoryId>,
+        after: Option<MemoryId>,
+    ) -> Vec<MemoryId> {
+        let inner = self.inner.read();
+        let mut results = Vec::with_capacity(limit.min(1024));
+        let mut seen_after = after.is_none();
+        for (_, ids) in inner.tree.iter().rev() {
+            for &id in ids.iter().rev() {
+                if !seen_after {
+                    if Some(id) == after {
+                        seen_after = true;
+                    }
+                    continue;
+                }
+                if skip.contains(&id) {
+                    continue;
+                }
+                results.push(id);
+                if results.len() >= limit {
+                    return results;
+                }
+            }
+        }
+        results
+    }
+
     /// Get the `n` most recent memories (by timestamp, descending).
     pub fn latest(&self, n: usize) -> Vec<MemoryId> {
         let inner = self.inner.read();

--- a/crates/mentedb/src/lib.rs
+++ b/crates/mentedb/src/lib.rs
@@ -1847,6 +1847,83 @@ impl MenteDb {
         self.page_map.read().len()
     }
 
+    /// Ids of the newest `limit` memories (descending by creation time),
+    /// excluding any tagged with an `exclude_tags` entry and beginning after
+    /// `after` when given. Resolved entirely from the temporal and bitmap
+    /// indexes: no memory content is loaded and no full scan runs, so serving a
+    /// page of a dashboard list costs the size of the page, not the size of the
+    /// store. The caller loads only the returned ids with [`Self::get_memory`].
+    pub fn recent_memory_ids(
+        &self,
+        limit: usize,
+        exclude_tags: &[&str],
+        after: Option<MemoryId>,
+    ) -> Vec<MemoryId> {
+        let skip = self.ids_with_any_tag(exclude_tags);
+        self.index.temporal.latest_filtered(limit, &skip, after)
+    }
+
+    /// Ids of every memory carrying `tag`, straight from the bitmap index. No
+    /// content is loaded and no scan runs, so a small tagged set (standing
+    /// rules, the profile node, a project) is found in time proportional to the
+    /// set, not the store.
+    pub fn memory_ids_with_tag(&self, tag: &str) -> Vec<MemoryId> {
+        self.index.bitmap.query_tag(tag)
+    }
+
+    /// Count of memories that carry none of `exclude_tags`, from the O(1) total
+    /// and the bitmap index. Never loads content or scans; the union of the
+    /// excluded tag sets is computed in memory.
+    pub fn count_excluding_tags(&self, exclude_tags: &[&str]) -> usize {
+        let excluded = self.ids_with_any_tag(exclude_tags).len();
+        self.memory_count().saturating_sub(excluded)
+    }
+
+    /// The union of the id sets for `tags`, from the bitmap index. In memory,
+    /// no storage loads.
+    fn ids_with_any_tag(&self, tags: &[&str]) -> std::collections::HashSet<MemoryId> {
+        let mut set = std::collections::HashSet::new();
+        for tag in tags {
+            for id in self.index.bitmap.query_tag(tag) {
+                set.insert(id);
+            }
+        }
+        set
+    }
+
+    /// `(contradicts, supersedes)` conflict-edge counts from the in-memory
+    /// graph, deduping undirected contradiction pairs so A<->B counts once.
+    /// Loads no node content, so a conflict badge costs a graph walk rather than
+    /// a full scan with two storage reads per pair. Byte-identical re-saves are
+    /// routed to `Derived` edges at write time, so they never appear here.
+    pub fn conflict_edge_counts(&self) -> (usize, usize) {
+        let graph = self.graph();
+        let csr = graph.graph();
+        let mut contradicts: std::collections::HashSet<(MemoryId, MemoryId)> =
+            std::collections::HashSet::new();
+        let mut supersedes = 0usize;
+        for id in self.memory_ids() {
+            if !csr.contains_node(id) {
+                continue;
+            }
+            for (target, edge) in csr.outgoing(id) {
+                match edge.edge_type {
+                    EdgeType::Contradicts => {
+                        let key = if id < target {
+                            (id, target)
+                        } else {
+                            (target, id)
+                        };
+                        contradicts.insert(key);
+                    }
+                    EdgeType::Supersedes => supersedes += 1,
+                    _ => {}
+                }
+            }
+        }
+        (contradicts.len(), supersedes)
+    }
+
     /// Fold one op's latency into an exponentially-weighted moving average, in
     /// microseconds. An EMA (not a lifetime mean) so a one-off slow op, e.g. right
     /// after a cold open, decays out over the next few ops instead of permanently

--- a/crates/mentedb/tests/read_path_index.rs
+++ b/crates/mentedb/tests/read_path_index.rs
@@ -1,0 +1,140 @@
+//! The dashboard read path must answer "newest N", "ids with tag T", "count
+//! excluding tags", and "conflict counts" from the in-memory indexes, loading
+//! only the rows it returns rather than scanning every memory. These tests pin
+//! that behaviour on a real engine: the results are correct, and (by
+//! construction) they come from the temporal, bitmap, and graph indexes, not a
+//! full scan.
+
+use std::collections::HashSet;
+
+use mentedb::MenteDb;
+use mentedb::prelude::{AgentId, EdgeType, MemoryEdge, MemoryNode, MemoryType};
+
+fn open() -> (tempfile::TempDir, MenteDb) {
+    let dir = tempfile::tempdir().unwrap();
+    let db = MenteDb::open(dir.path()).expect("open");
+    (dir, db)
+}
+
+/// Store a memory with a controlled creation time and tag set so the temporal
+/// and bitmap indexes have deterministic contents.
+fn store(
+    db: &MenteDb,
+    content: &str,
+    created_at: u64,
+    tags: &[&str],
+) -> mentedb::prelude::MemoryId {
+    let mut node = MemoryNode::new(
+        AgentId(uuid::Uuid::nil()),
+        MemoryType::Semantic,
+        content.to_string(),
+        Vec::new(),
+    );
+    node.created_at = created_at;
+    node.tags = tags.iter().map(|t| t.to_string()).collect();
+    let id = node.id;
+    db.store(node).expect("store");
+    id
+}
+
+const INTERNAL: &[&str] = &[
+    "turn",
+    "conversation-turn",
+    "action",
+    "ghost-memory",
+    "entity",
+];
+
+#[test]
+fn recent_memory_ids_are_newest_first_and_skip_excluded() {
+    let (_dir, db) = open();
+    let _oldest = store(&db, "oldest", 100, &[]);
+    let a_turn = store(&db, "a raw turn", 150, &["turn"]);
+    let middle = store(&db, "middle", 200, &[]);
+    let an_action = store(&db, "an action capture", 250, &["action"]);
+    let newest = store(&db, "newest", 300, &[]);
+
+    // Newest first, internal working material excluded.
+    let ids = db.recent_memory_ids(10, INTERNAL, None);
+    assert_eq!(
+        ids,
+        vec![newest, middle, _oldest],
+        "only the three user memories, newest first"
+    );
+    assert!(!ids.contains(&a_turn) && !ids.contains(&an_action));
+
+    // A small limit returns only that many, still newest first.
+    assert_eq!(db.recent_memory_ids(1, INTERNAL, None), vec![newest]);
+}
+
+#[test]
+fn recent_memory_ids_paginate_after_a_cursor() {
+    let (_dir, db) = open();
+    let n3 = store(&db, "n3", 300, &[]);
+    let n2 = store(&db, "n2", 200, &[]);
+    let n1 = store(&db, "n1", 100, &[]);
+
+    let page1 = db.recent_memory_ids(1, INTERNAL, None);
+    assert_eq!(page1, vec![n3]);
+    let page2 = db.recent_memory_ids(1, INTERNAL, Some(n3));
+    assert_eq!(page2, vec![n2]);
+    let page3 = db.recent_memory_ids(10, INTERNAL, Some(n2));
+    assert_eq!(page3, vec![n1]);
+}
+
+#[test]
+fn count_excluding_tags_ignores_internal_material() {
+    let (_dir, db) = open();
+    store(&db, "user 1", 100, &[]);
+    store(&db, "user 2", 200, &["semantic"]);
+    store(&db, "a turn", 300, &["turn"]);
+    store(&db, "an action", 400, &["action"]);
+
+    assert_eq!(db.memory_count(), 4, "all four are stored");
+    assert_eq!(
+        db.count_excluding_tags(INTERNAL),
+        2,
+        "only the two user memories count"
+    );
+}
+
+#[test]
+fn memory_ids_with_tag_finds_only_the_tagged() {
+    let (_dir, db) = open();
+    let pinned = store(&db, "a standing rule", 100, &["scope:always"]);
+    store(&db, "not pinned", 200, &[]);
+    let also = store(&db, "another rule", 300, &["scope:always"]);
+
+    let ids: HashSet<_> = db.memory_ids_with_tag("scope:always").into_iter().collect();
+    assert_eq!(ids, HashSet::from([pinned, also]));
+    assert!(db.memory_ids_with_tag("no-such-tag").is_empty());
+}
+
+#[test]
+fn conflict_edge_counts_tally_the_graph_without_loading_nodes() {
+    let (_dir, db) = open();
+    let a = store(&db, "the database uses Postgres", 100, &[]);
+    let b = store(&db, "the database uses MySQL", 200, &[]);
+    let c = store(&db, "retry limit is three", 300, &[]);
+    let d = store(&db, "retry limit is five", 400, &[]);
+
+    let edge = |source, target, kind| MemoryEdge {
+        source,
+        target,
+        edge_type: kind,
+        weight: 0.9,
+        created_at: 1,
+        valid_from: None,
+        valid_until: None,
+        label: None,
+    };
+
+    db.relate(edge(a, b, EdgeType::Contradicts)).unwrap();
+    // The reverse direction of the same contradiction must not double count.
+    db.relate(edge(b, a, EdgeType::Contradicts)).unwrap();
+    db.relate(edge(d, c, EdgeType::Supersedes)).unwrap();
+
+    let (contradicts, supersedes) = db.conflict_edge_counts();
+    assert_eq!(contradicts, 1, "A<->B is one undirected contradiction");
+    assert_eq!(supersedes, 1);
+}


### PR DESCRIPTION
## Summary
Dashboard reads (`/api/memories`, `/api/profile`, `/api/contradictions`) were O(N) full scans that loaded every memory from storage — an 11k-memory account paid 1–6s per read, and `?limit=1` still took ~2s because the limit was applied last. The temporal and bitmap indexes already held the answers in memory; the facade just never exposed them. This exposes the primitives so the platform can serve these reads in O(page), not O(store).

## Changes
- `TemporalIndex::latest_filtered(limit, skip, after)` — newest ids descending, skipping an exclude set, starting after a cursor; walks only the in-memory BTreeMap and stops at `limit`. Serves cursor pagination.
- `MenteDb::recent_memory_ids(limit, exclude_tags, after)` — newest page excluding tagged rows (e.g. internal working material), no storage load, no scan.
- `MenteDb::memory_ids_with_tag(tag)` — bitmap lookup for a tagged set (standing rules, profile node, project).
- `MenteDb::count_excluding_tags(exclude_tags)` — non-internal count from the O(1) total minus the bitmap union.
- `MenteDb::conflict_edge_counts()` — `(contradicts, supersedes)` tallied from the in-memory graph with no node loads; undirected contradictions dedup. (Byte-identical re-saves route to `Derived` edges at write time, so they never appear.)

## Verification
- `cargo clippy -p mentedb -p mentedb-index -- -D warnings` clean.
- New `tests/read_path_index.rs` (5 tests): newest-first ordering, internal-material exclusion, cursor pagination, tag lookup, non-internal count, undirected conflict dedup. `cargo test -p mentedb --test read_path_index` → 5 passed.

## Follow-up
Owner/type-filtered lists and `/api/stats` distributions still scan, because no index is partitioned by owner or memory_type. A maintained per-type/owner count index (hooked into `index_memory`/`remove_memory`) is the next piece; this PR unblocks the highest-traffic reads (dashboard landing) first.