### PR TITLE
perf: count conflict edges in one O(edges) pass

### DIFF
--- a/crates/mentedb-graph/src/csr.rs
+++ b/crates/mentedb-graph/src/csr.rs
@@ -353,6 +353,55 @@ impl CsrGraph {
         results
     }
 
+    /// Count conflict edges in a single pass over the graph: `(contradicts,
+    /// supersedes)`, with undirected contradictions deduped so A<->B counts
+    /// once. Calling `outgoing` per node instead rescans the entire delta log
+    /// for every node (O(nodes * delta)); this walks the compressed edges and
+    /// the delta log once each (O(edges)) and loads no node content, so a
+    /// conflict badge on a large store is a cheap graph tally.
+    pub fn conflict_edge_counts(&self) -> (usize, usize) {
+        let norm = |a: u32, b: u32| if a <= b { (a, b) } else { (b, a) };
+        let mut contradicts: std::collections::HashSet<(u32, u32)> =
+            std::collections::HashSet::new();
+        let mut supersedes = 0usize;
+
+        // Compressed edges: one pass over each node's neighbor slice (not the
+        // delta log), so the total work is the number of compressed edges.
+        let node_count = self.idx_to_id.len() as u32;
+        for idx in 0..node_count {
+            let neighbors = self.csr.neighbors(idx);
+            let data = self.csr.edge_data_for(idx);
+            for (i, &nbr) in neighbors.iter().enumerate() {
+                if self.is_removed(idx, nbr) {
+                    continue;
+                }
+                match data[i].edge_type {
+                    EdgeType::Contradicts => {
+                        contradicts.insert(norm(idx, nbr));
+                    }
+                    EdgeType::Supersedes => supersedes += 1,
+                    _ => {}
+                }
+            }
+        }
+
+        // Delta edges: one pass over the whole log, not once per node.
+        for d in &self.delta_edges {
+            if self.is_removed(d.source_idx, d.target_idx) {
+                continue;
+            }
+            match d.data.edge_type {
+                EdgeType::Contradicts => {
+                    contradicts.insert(norm(d.source_idx, d.target_idx));
+                }
+                EdgeType::Supersedes => supersedes += 1,
+                _ => {}
+            }
+        }
+
+        (contradicts.len(), supersedes)
+    }
+
     /// Get all incoming edges to a node (CSC + delta, minus removed).
     pub fn incoming(&self, id: MemoryId) -> Vec<(MemoryId, StoredEdge)> {
         let Some(&idx) = self.id_to_idx.get(&id) else {
@@ -570,6 +619,33 @@ mod tests {
         let idx2 = g.add_node(id);
         assert_eq!(idx1, idx2);
         assert_eq!(g.node_count(), 1);
+    }
+
+    #[test]
+    fn conflict_edge_counts_span_compressed_and_delta_and_dedup() {
+        let mut g = CsrGraph::new();
+        let (a, b, c, d) = (
+            MemoryId::new(),
+            MemoryId::new(),
+            MemoryId::new(),
+            MemoryId::new(),
+        );
+
+        // A contradiction that gets compacted into CSR, plus unrelated edge
+        // types that must not be counted.
+        g.add_edge(&make_edge(a, b, EdgeType::Contradicts));
+        g.add_edge(&make_edge(a, c, EdgeType::Related));
+        g.compact();
+
+        // A supersession and the reverse direction of the same contradiction,
+        // both still in the delta log. The reverse must dedup against the
+        // compacted forward edge.
+        g.add_edge(&make_edge(d, c, EdgeType::Supersedes));
+        g.add_edge(&make_edge(b, a, EdgeType::Contradicts));
+
+        let (contradicts, supersedes) = g.conflict_edge_counts();
+        assert_eq!(contradicts, 1, "A<->B is one undirected contradiction");
+        assert_eq!(supersedes, 1);
     }
 
     #[test]

--- a/crates/mentedb-graph/src/manager.rs
+++ b/crates/mentedb-graph/src/manager.rs
@@ -264,6 +264,13 @@ impl GraphManager {
     pub fn graph(&self) -> parking_lot::RwLockReadGuard<'_, CsrGraph> {
         self.graph.read()
     }
+
+    /// Conflict-edge counts `(contradicts, supersedes)` in a single O(edges)
+    /// pass, deduping undirected contradictions. See
+    /// [`CsrGraph::conflict_edge_counts`].
+    pub fn conflict_edge_counts(&self) -> (usize, usize) {
+        self.graph.read().conflict_edge_counts()
+    }
 }
 
 impl Default for GraphManager {

--- a/crates/mentedb/src/lib.rs
+++ b/crates/mentedb/src/lib.rs
@@ -1893,35 +1893,12 @@ impl MenteDb {
 
     /// `(contradicts, supersedes)` conflict-edge counts from the in-memory
     /// graph, deduping undirected contradiction pairs so A<->B counts once.
-    /// Loads no node content, so a conflict badge costs a graph walk rather than
-    /// a full scan with two storage reads per pair. Byte-identical re-saves are
-    /// routed to `Derived` edges at write time, so they never appear here.
+    /// One O(edges) pass, no node content loaded and no per-node delta-log
+    /// rescan, so a conflict badge costs a graph tally rather than a full scan.
+    /// Byte-identical re-saves are routed to `Derived` edges at write time, so
+    /// they never appear here.
     pub fn conflict_edge_counts(&self) -> (usize, usize) {
-        let graph = self.graph();
-        let csr = graph.graph();
-        let mut contradicts: std::collections::HashSet<(MemoryId, MemoryId)> =
-            std::collections::HashSet::new();
-        let mut supersedes = 0usize;
-        for id in self.memory_ids() {
-            if !csr.contains_node(id) {
-                continue;
-            }
-            for (target, edge) in csr.outgoing(id) {
-                match edge.edge_type {
-                    EdgeType::Contradicts => {
-                        let key = if id < target {
-                            (id, target)
-                        } else {
-                            (target, id)
-                        };
-                        contradicts.insert(key);
-                    }
-                    EdgeType::Supersedes => supersedes += 1,
-                    _ => {}
-                }
-            }
-        }
-        (contradicts.len(), supersedes)
+        self.graph().conflict_edge_counts()
     }
 
     /// Fold one op's latency into an exponentially-weighted moving average, in


### PR DESCRIPTION
## Summary
`conflict_edge_counts` (added last release for the dashboard conflict badge) avoided loading node content but still walked every node and called the graph's `outgoing()`. `outgoing()` **rescans the entire uncompacted delta-edge log on every call**, so the tally was O(nodes × delta-edges) — measured at **3.4s** on an 11k-memory account, no faster than the old full scan it replaced.

## Change
- `CsrGraph::conflict_edge_counts`: one pass over the compressed edges plus one pass over the delta log (not `outgoing()` per node), deduping undirected contradictions. O(edges), loads nothing.
- `GraphManager` and `MenteDb::conflict_edge_counts` delegate to it.

## Verification
- New csr test: counts span compacted CSR edges + delta edges and dedup the reverse direction of a contradiction.
- `cargo test -p mentedb-graph` and `-p mentedb --test read_path_index` pass; `cargo clippy -p mentedb -p mentedb-graph -- -D warnings` clean.
- Post-deploy I will re-measure `/api/contradictions?summary=true` against the 11k account (target <100ms).