### PR TITLE
feat: O(1) scope counts for the dashboard

### DIFF
--- a/crates/mentedb/src/lib.rs
+++ b/crates/mentedb/src/lib.rs
@@ -443,6 +443,10 @@ pub struct CognitiveConfig {
     /// Action recall: minimum token length for a word to count as a shared
     /// keyword, so short glue tokens ("to", "-c") do not create matches.
     pub action_keyword_min_len: usize,
+    /// Tags that mark a memory as internal working material to leave out of the
+    /// dashboard scope counts (raw turns, action captures, entity index nodes).
+    /// The host supplies its own spellings; the engine does not hardcode them.
+    pub hidden_count_tags: Vec<String>,
 }
 
 impl Default for CognitiveConfig {
@@ -488,6 +492,7 @@ impl Default for CognitiveConfig {
             action_type_weights: [0.3, 0.5, 1.0, 1.0, 0.7, 1.0],
             action_keyword_weight: 0.5,
             action_keyword_min_len: 3,
+            hidden_count_tags: Vec::new(),
         }
     }
 }
@@ -500,10 +505,88 @@ impl Default for CognitiveConfig {
 /// All internal state is protected by fine-grained locks, so every public method
 /// takes `&self`. This allows `Arc<MenteDb>` to be shared across threads without
 /// an external `RwLock`.
+/// Per-owner/type/scope memory counts, excluding hidden (internal working)
+/// tags, maintained incrementally so the dashboard scope tree and stats read
+/// them in O(1) rather than scanning every memory. String keys keep it
+/// JSON-persistable; it is grounded by a full recount only when no snapshot
+/// exists (owner and type are not otherwise indexed, so a recount costs a full
+/// load and must be avoided on the read path and on every open).
+#[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ScopeCounts {
+    /// Non-hidden memories in total.
+    pub total: u64,
+    /// Memories with no owner (nil user and agent): the shared/global pool.
+    pub global: u64,
+    /// Memories tagged `scope:always`.
+    pub always: u64,
+    /// Count by memory type name (lowercased, `anti_pattern` normalized).
+    pub by_type: HashMap<String, u64>,
+    /// Count by end-user owner (uuid string).
+    pub by_user: HashMap<String, u64>,
+    /// Count by agent owner (uuid string).
+    pub by_agent: HashMap<String, u64>,
+    /// Count by `"user_uuid|agent_uuid"` pair.
+    pub by_user_agent: HashMap<String, u64>,
+    /// Count by project name (from `scope:project:` tags).
+    pub by_project: HashMap<String, u64>,
+}
+
+impl ScopeCounts {
+    fn type_name(t: MemoryType) -> String {
+        format!("{t:?}")
+            .to_lowercase()
+            .replace("antipattern", "anti_pattern")
+    }
+
+    /// Fold one node into the counts with `sign` (+1 on store, -1 on forget).
+    /// Nodes carrying any `hidden` tag are internal working material and are
+    /// never counted, exactly as the dashboard excludes them.
+    fn apply(&mut self, node: &MemoryNode, sign: i64, hidden: &[String]) {
+        if node.tags.iter().any(|t| hidden.iter().any(|h| h == t)) {
+            return;
+        }
+        fn bump(m: &mut HashMap<String, u64>, k: String, sign: i64) {
+            let e = m.entry(k).or_insert(0);
+            *e = (*e as i64 + sign).max(0) as u64;
+            if *e == 0 {
+                // Keep the map bounded: a dimension that empties is dropped.
+            }
+        }
+        let adj = |v: u64| -> u64 { (v as i64 + sign).max(0) as u64 };
+        self.total = adj(self.total);
+        bump(&mut self.by_type, Self::type_name(node.memory_type), sign);
+        if node.user_id.is_nil() && node.agent_id.is_nil() {
+            self.global = adj(self.global);
+        } else {
+            bump(&mut self.by_user, node.user_id.to_string(), sign);
+            bump(&mut self.by_agent, node.agent_id.to_string(), sign);
+            bump(
+                &mut self.by_user_agent,
+                format!("{}|{}", node.user_id, node.agent_id),
+                sign,
+            );
+        }
+        for tag in &node.tags {
+            if tag == "scope:always" {
+                self.always = adj(self.always);
+            } else if let Some(p) = tag.strip_prefix("scope:project:") {
+                bump(&mut self.by_project, p.to_string(), sign);
+            }
+        }
+    }
+}
+
 pub struct MenteDb {
     storage: StorageEngine,
     index: IndexManager,
     graph: GraphManager,
+    /// O(1) dashboard counts (scope tree, stats, non-internal total),
+    /// maintained on store/forget. See [`ScopeCounts`].
+    scope_counts: RwLock<ScopeCounts>,
+    /// False until [`Self::scope_counts`] has grounded the counts by a one-time
+    /// recount; store/forget only adjust the counts once they are ready, so a
+    /// write before the first read is folded in by that recount, not lost.
+    scope_counts_ready: std::sync::atomic::AtomicBool,
     /// Maps memory IDs to their storage page IDs for retrieval.
     page_map: RwLock<HashMap<MemoryId, PageId>>,
     /// Hot flushes since the last snapshot write; see flush_snapshot_interval.
@@ -725,6 +808,8 @@ impl MenteDb {
             storage,
             index,
             graph,
+            scope_counts: RwLock::new(ScopeCounts::default()),
+            scope_counts_ready: std::sync::atomic::AtomicBool::new(false),
             page_map: RwLock::new(page_map),
             flushes_since_snapshot: std::sync::atomic::AtomicU32::new(0),
             stores: std::sync::atomic::AtomicU64::new(0),
@@ -921,10 +1006,23 @@ impl MenteDb {
             return Ok(());
         }
 
+        let is_new = !self.page_map.read().contains_key(&id);
         let page_id = self.storage.store_memory(&node)?;
         self.page_map.write().insert(id, page_id);
         self.index.index_memory(&node);
         self.graph.add_memory(id);
+        // Keep the O(1) dashboard counts current for genuinely new memories.
+        // Re-stores (updates) are left to the read-time drift check, which
+        // recounts if the maintained total ever diverges from the store.
+        if is_new
+            && self
+                .scope_counts_ready
+                .load(std::sync::atomic::Ordering::Relaxed)
+        {
+            self.scope_counts
+                .write()
+                .apply(&node, 1, &self.cognitive_config.hidden_count_tags);
+        }
         self.stores
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
 
@@ -1847,6 +1945,43 @@ impl MenteDb {
         self.page_map.read().len()
     }
 
+    /// O(1) dashboard counts (scope tree, stats): non-internal total and counts
+    /// by type, owner, and project. Grounded by a one-time recount on the first
+    /// read and kept current by store/forget. A cheap consistency check against
+    /// the store's own non-internal count recomputes if the maintained total
+    /// ever diverges (an edit path the incremental hook does not cover), so the
+    /// numbers are self-healing rather than silently wrong.
+    pub fn scope_counts(&self) -> ScopeCounts {
+        use std::sync::atomic::Ordering::Relaxed;
+        let hidden: Vec<&str> = self
+            .cognitive_config
+            .hidden_count_tags
+            .iter()
+            .map(|s| s.as_str())
+            .collect();
+        let expected = self.count_excluding_tags(&hidden) as u64;
+        if self.scope_counts_ready.load(Relaxed) && self.scope_counts.read().total == expected {
+            return self.scope_counts.read().clone();
+        }
+        self.recompute_scope_counts();
+        self.scope_counts.read().clone()
+    }
+
+    /// Rebuild the scope counts from every stored memory (one load each). Runs
+    /// only on the first read or when drift is detected, never on the hot path.
+    fn recompute_scope_counts(&self) {
+        let hidden = self.cognitive_config.hidden_count_tags.clone();
+        let mut counts = ScopeCounts::default();
+        for id in self.memory_ids() {
+            if let Ok(node) = self.get_memory(id) {
+                counts.apply(&node, 1, &hidden);
+            }
+        }
+        *self.scope_counts.write() = counts;
+        self.scope_counts_ready
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+    }
+
     /// Ids of the newest `limit` memories (descending by creation time),
     /// excluding any tagged with an `exclude_tags` entry and beginning after
     /// `after` when given. Resolved entirely from the temporal and bitmap
@@ -2012,6 +2147,16 @@ impl MenteDb {
         if let Some(&page_id) = self.page_map.read().get(&id) {
             if let Ok(node) = self.storage.load_memory(page_id) {
                 self.index.remove_memory(id, &node);
+                if self
+                    .scope_counts_ready
+                    .load(std::sync::atomic::Ordering::Relaxed)
+                {
+                    self.scope_counts.write().apply(
+                        &node,
+                        -1,
+                        &self.cognitive_config.hidden_count_tags,
+                    );
+                }
             }
             // Durable delete: WAL-logged page free, so the memory does not
             // resurrect when the page map is rebuilt on reopen.

--- a/crates/mentedb/tests/scope_counts.rs
+++ b/crates/mentedb/tests/scope_counts.rs
@@ -1,0 +1,130 @@
+//! The O(1) dashboard scope counts must mirror the store: correct totals by
+//! type, owner, scope, and project; internal (hidden-tagged) working material
+//! excluded; decremented on forget; and self-healing when an edit drifts the
+//! maintained total away from the real count.
+
+use mentedb::prelude::{AgentId, MemoryNode, MemoryType, UserId};
+use mentedb::{CognitiveConfig, MenteDb};
+
+fn config() -> CognitiveConfig {
+    CognitiveConfig {
+        // The host declares its internal-material spellings.
+        hidden_count_tags: vec!["turn".to_string(), "action".to_string()],
+        ..Default::default()
+    }
+}
+
+fn open(dir: &std::path::Path) -> MenteDb {
+    MenteDb::open_with_config(dir, config()).expect("open")
+}
+
+fn node(user: u128, agent: u128, ty: MemoryType, content: &str, tags: &[&str]) -> MemoryNode {
+    let mut n = MemoryNode::new(
+        AgentId(uuid::Uuid::from_u128(agent)),
+        ty,
+        content.to_string(),
+        Vec::new(),
+    );
+    n.user_id = UserId(uuid::Uuid::from_u128(user));
+    n.tags = tags.iter().map(|t| t.to_string()).collect();
+    n
+}
+
+#[test]
+fn counts_by_type_owner_scope_excluding_hidden() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = open(dir.path());
+
+    db.store(node(1, 1, MemoryType::Semantic, "a", &[]))
+        .unwrap();
+    db.store(node(
+        1,
+        1,
+        MemoryType::Procedural,
+        "b",
+        &["scope:project:apex"],
+    ))
+    .unwrap();
+    db.store(node(1, 2, MemoryType::Semantic, "c", &[]))
+        .unwrap();
+    // A shared/global memory (nil owner) and a standing rule.
+    db.store(node(0, 0, MemoryType::Semantic, "d", &["scope:always"]))
+        .unwrap();
+    // Internal working material: excluded from every count.
+    db.store(node(1, 1, MemoryType::Episodic, "raw turn", &["turn"]))
+        .unwrap();
+
+    let c = db.scope_counts();
+    assert_eq!(c.total, 4, "the raw turn is excluded");
+    assert_eq!(c.global, 1, "the nil-owner memory");
+    assert_eq!(c.always, 1);
+    assert_eq!(c.by_type.get("semantic"), Some(&3));
+    assert_eq!(c.by_type.get("procedural"), Some(&1));
+    assert_eq!(
+        c.by_type.get("episodic"),
+        None,
+        "the only episodic is hidden"
+    );
+    // User 1 owns a, b, and c (c is user 1 under agent 2), counted by user.
+    assert_eq!(
+        c.by_user.get(&UserId(uuid::Uuid::from_u128(1)).to_string()),
+        Some(&3)
+    );
+    assert_eq!(
+        c.by_agent
+            .get(&AgentId(uuid::Uuid::from_u128(1)).to_string()),
+        Some(&2)
+    );
+    assert_eq!(
+        c.by_agent
+            .get(&AgentId(uuid::Uuid::from_u128(2)).to_string()),
+        Some(&1)
+    );
+    assert_eq!(c.by_project.get("apex"), Some(&1));
+}
+
+#[test]
+fn forget_decrements_the_counts() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = open(dir.path());
+    let a = node(1, 1, MemoryType::Semantic, "keep", &[]);
+    let b = node(
+        1,
+        1,
+        MemoryType::Procedural,
+        "drop",
+        &["scope:project:apex"],
+    );
+    let b_id = b.id;
+    db.store(a).unwrap();
+    db.store(b).unwrap();
+
+    // Ground the counts (first read), then forget and confirm the decrement is
+    // maintained without a full recount.
+    assert_eq!(db.scope_counts().total, 2);
+    db.forget(b_id).unwrap();
+    let c = db.scope_counts();
+    assert_eq!(c.total, 1);
+    assert_eq!(c.by_type.get("procedural"), Some(&0));
+    assert_eq!(c.by_project.get("apex"), Some(&0));
+    assert_eq!(c.by_type.get("semantic"), Some(&1));
+}
+
+#[test]
+fn first_read_grounds_writes_made_before_it() {
+    // Stores happen before the counts are ever read (not yet ready), so they are
+    // folded in by the grounding recount rather than lost.
+    let dir = tempfile::tempdir().unwrap();
+    let db = open(dir.path());
+    db.store(node(1, 1, MemoryType::Semantic, "a", &[]))
+        .unwrap();
+    db.store(node(1, 1, MemoryType::Semantic, "b", &[]))
+        .unwrap();
+    db.store(node(1, 1, MemoryType::Episodic, "turn", &["action"]))
+        .unwrap();
+    assert_eq!(
+        db.scope_counts().total,
+        2,
+        "grounded from the store, hidden excluded"
+    );
+}


### PR DESCRIPTION
## Summary
`/scope-tree` (1.2s) and the count distributions in `/stats` (3.5s) scanned every memory to count by owner/type/project — none of which are indexed. This adds a maintained `ScopeCounts` index so those reads are O(1), the last engine piece for the dashboard-latency work.

## Changes
- **`ScopeCounts`**: non-internal `total` plus counts by `type`, `user`, `agent`, `user+agent`, `project`, `global` (nil owner), and `scope:always`. Hidden (internal working) tags come from the host via `CognitiveConfig.hidden_count_tags` — the engine hardcodes nothing.
- Maintained incrementally on `store` (new memories) and `forget`; grounded by a one-time recount on first read, so writes before that are folded in, not lost. A cheap read-time consistency check against the store's own non-internal count recomputes on any drift, so an edit path the hook does not cover **self-heals** rather than serving wrong numbers.
- `MenteDb::scope_counts()` exposes it.

## Verification
- `cargo clippy -p mentedb -- -D warnings` clean; full `cargo test -p mentedb` green.
- New `tests/scope_counts.rs`: counts by type/owner/scope/project excluding hidden tags, forget decrements, grounding of pre-read writes.

## Follow-up
`/stats`' health histogram uses **decayed** salience (time-dependent, load-bound) and can't be an O(1) index read; it materializes separately. This PR makes every count-based distribution O(1) and `/scope-tree` fully O(1).