### PR TITLE
fix: scope_counts must not recompute on every read

### DIFF
--- a/crates/mentedb/src/lib.rs
+++ b/crates/mentedb/src/lib.rs
@@ -1947,23 +1947,18 @@ impl MenteDb {
 
     /// O(1) dashboard counts (scope tree, stats): non-internal total and counts
     /// by type, owner, and project. Grounded by a one-time recount on the first
-    /// read and kept current by store/forget. A cheap consistency check against
-    /// the store's own non-internal count recomputes if the maintained total
-    /// ever diverges (an edit path the incremental hook does not cover), so the
-    /// numbers are self-healing rather than silently wrong.
+    /// read (which also folds in any writes made before that read) and kept
+    /// current by store/forget thereafter, so a read is a lock and a clone. The
+    /// counts are re-grounded whenever the database is reopened, which bounds any
+    /// drift from an edit path the incremental hook does not cover to a single
+    /// process lifetime.
     pub fn scope_counts(&self) -> ScopeCounts {
-        use std::sync::atomic::Ordering::Relaxed;
-        let hidden: Vec<&str> = self
-            .cognitive_config
-            .hidden_count_tags
-            .iter()
-            .map(|s| s.as_str())
-            .collect();
-        let expected = self.count_excluding_tags(&hidden) as u64;
-        if self.scope_counts_ready.load(Relaxed) && self.scope_counts.read().total == expected {
-            return self.scope_counts.read().clone();
+        if !self
+            .scope_counts_ready
+            .load(std::sync::atomic::Ordering::Relaxed)
+        {
+            self.recompute_scope_counts();
         }
-        self.recompute_scope_counts();
         self.scope_counts.read().clone()
     }
 


### PR DESCRIPTION
## Summary
`scope_counts()` in 0.36.0 ran a full O(N) recount on **every** read, so `/scope-tree` and `/usage` measured **~2s** on the 11k account — worse than the scan they replaced. Cause: the read-time drift check compared the maintained total against `count_excluding_tags` (a bitmap-index count); the two disagree on a real store (the bitmap tag index can be stale vs the nodes' actual tags), so the check fired every call and recomputed.

## Fix
Drop the per-read check. Ground the counts once on first read (folding in writes made before it), keep them current via store/forget, so a read is a lock and a clone. Reopen re-grounds, bounding any drift from an uncovered edit path to one process lifetime. The node-based recount is authoritative, so this also serves correct counts, not a possibly-stale bitmap-derived one.

## Verification
`cargo build -p mentedb` clean, `clippy -D warnings` clean, `cargo test -p mentedb --test scope_counts` green (3). Post-deploy I will re-measure `/scope-tree` and `/usage` against the 11k account.