### PR TITLE
feat: oldest-first temporal browse (no scan for oldest/contextual)

### DIFF
--- a/crates/mentedb-index/src/temporal.rs
+++ b/crates/mentedb-index/src/temporal.rs
@@ -84,6 +84,39 @@ impl TemporalIndex {
         results
     }
 
+    /// The oldest `limit` ids (ascending by timestamp) not in `skip`, beginning
+    /// after `after` when given. The ascending mirror of [`Self::latest_filtered`]:
+    /// walks only the in-memory index, loads nothing, and stops at `limit`, so
+    /// oldest-first browse is bounded by the page, never a full scan.
+    pub fn oldest_filtered(
+        &self,
+        limit: usize,
+        skip: &std::collections::HashSet<MemoryId>,
+        after: Option<MemoryId>,
+    ) -> Vec<MemoryId> {
+        let inner = self.inner.read();
+        let mut results = Vec::with_capacity(limit.min(1024));
+        let mut seen_after = after.is_none();
+        for ids in inner.tree.values() {
+            for &id in ids.iter() {
+                if !seen_after {
+                    if Some(id) == after {
+                        seen_after = true;
+                    }
+                    continue;
+                }
+                if skip.contains(&id) {
+                    continue;
+                }
+                results.push(id);
+                if results.len() >= limit {
+                    return results;
+                }
+            }
+        }
+        results
+    }
+
     /// Get the `n` most recent memories (by timestamp, descending).
     pub fn latest(&self, n: usize) -> Vec<MemoryId> {
         let inner = self.inner.read();

--- a/crates/mentedb/src/lib.rs
+++ b/crates/mentedb/src/lib.rs
@@ -2220,6 +2220,21 @@ impl MenteDb {
         self.index.temporal.latest_filtered(limit, &skip, after)
     }
 
+    /// Oldest-first page of memory ids, excluding any carrying an `exclude_tags`
+    /// tag, beginning after `after`. The ascending mirror of
+    /// [`Self::recent_memory_ids`], served from the temporal index with no scan,
+    /// so oldest-first browse (and contextual browse, by excluding `scope:always`)
+    /// is bounded by the page.
+    pub fn oldest_memory_ids(
+        &self,
+        limit: usize,
+        exclude_tags: &[&str],
+        after: Option<MemoryId>,
+    ) -> Vec<MemoryId> {
+        let skip = self.ids_with_any_tag(exclude_tags);
+        self.index.temporal.oldest_filtered(limit, &skip, after)
+    }
+
     /// Ids of every memory carrying `tag`, straight from the bitmap index. No
     /// content is loaded and no scan runs, so a small tagged set (standing
     /// rules, the profile node, a project) is found in time proportional to the

--- a/crates/mentedb/tests/browse_index.rs
+++ b/crates/mentedb/tests/browse_index.rs
@@ -85,6 +85,41 @@ fn reindex_after_forget_keeps_the_browse_index_exact() {
 }
 
 #[test]
+fn oldest_memory_ids_is_ascending_and_paginates() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = MenteDb::open(dir.path()).expect("open");
+    let mk = |c: &str, ts: u64, tags: &[&str]| {
+        let mut n = node(1, 1, MemoryType::Semantic, c, tags);
+        n.created_at = ts;
+        n
+    };
+    let a = mk("oldest", 100, &[]);
+    let a_id = a.id;
+    let b = mk("mid", 200, &[]);
+    let b_id = b.id;
+    let turn = mk("turn", 150, &["turn"]);
+    let c = mk("newest", 300, &[]);
+    let c_id = c.id;
+    db.store(a).unwrap();
+    db.store(b).unwrap();
+    db.store(turn).unwrap();
+    db.store(c).unwrap();
+
+    // Ascending by created_at, the internal turn excluded.
+    assert_eq!(
+        db.oldest_memory_ids(10, &["turn"], None),
+        vec![a_id, b_id, c_id]
+    );
+    // Cursor: continue after the first id.
+    assert_eq!(
+        db.oldest_memory_ids(10, &["turn"], Some(a_id)),
+        vec![b_id, c_id]
+    );
+    // Limit bounds the page.
+    assert_eq!(db.oldest_memory_ids(1, &["turn"], None), vec![a_id]);
+}
+
+#[test]
 fn browse_index_survives_reopen() {
     let dir = tempfile::tempdir().unwrap();
     let id;


### PR DESCRIPTION
adds oldest_filtered/oldest_memory_ids so oldest and contextual browse serve from the temporal index instead of scanning