### PR TITLE
feat: recall_recent (recency channel separate from semantic recall)

### DIFF
--- a/crates/mentedb/src/lib.rs
+++ b/crates/mentedb/src/lib.rs
@@ -2235,6 +2235,22 @@ impl MenteDb {
         self.index.temporal.oldest_filtered(limit, &skip, after)
     }
 
+    /// The most recent `k` memories, newest first, straight from the temporal
+    /// index. Unlike browse, this includes internal turns (empty skip set): the
+    /// point is "what just happened / where did we leave off", which is the raw
+    /// activity. It is a separate recency channel, so it never touches semantic
+    /// recall or its ranking; the temporal index is per tenant and persisted, so
+    /// a fresh session sees the full history with no lag.
+    pub fn recall_recent(&self, k: usize) -> Vec<MemoryNode> {
+        let empty = std::collections::HashSet::new();
+        self.index
+            .temporal
+            .latest_filtered(k, &empty, None)
+            .into_iter()
+            .filter_map(|id| self.get_memory(id).ok())
+            .collect()
+    }
+
     /// Ids of every memory carrying `tag`, straight from the bitmap index. No
     /// content is loaded and no scan runs, so a small tagged set (standing
     /// rules, the profile node, a project) is found in time proportional to the

--- a/crates/mentedb/tests/browse_index.rs
+++ b/crates/mentedb/tests/browse_index.rs
@@ -120,6 +120,27 @@ fn oldest_memory_ids_is_ascending_and_paginates() {
 }
 
 #[test]
+fn recall_recent_is_newest_first_and_includes_hidden_turns() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = MenteDb::open(dir.path()).expect("open");
+    let mk = |c: &str, ts: u64, tags: &[&str]| {
+        let mut n = node(1, 1, MemoryType::Semantic, c, tags);
+        n.created_at = ts;
+        n
+    };
+    db.store(mk("older fact", 100, &[])).unwrap();
+    db.store(mk("a raw turn", 200, &["turn"])).unwrap(); // internal, but recency includes it
+    db.store(mk("newest action", 300, &["action"])).unwrap();
+
+    let recent: Vec<String> = db.recall_recent(2).into_iter().map(|n| n.content).collect();
+    assert_eq!(
+        recent,
+        vec!["newest action", "a raw turn"],
+        "newest first, raw turns included (recency is what just happened)"
+    );
+}
+
+#[test]
 fn browse_index_survives_reopen() {
     let dir = tempfile::tempdir().unwrap();
     let id;


### PR DESCRIPTION
adds recall_recent(k) over the temporal index (newest first, includes internal turns) so a session-start recent-activity slot can answer where-you-left-off without touching semantic ranking